### PR TITLE
OAuth2 Post-Matching filter

### DIFF
--- a/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/AdminV1API.java
+++ b/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/AdminV1API.java
@@ -23,9 +23,11 @@ import net.krotscheck.kangaroo.common.exception.ExceptionFeature;
 import net.krotscheck.kangaroo.common.jackson.JacksonFeature;
 import net.krotscheck.kangaroo.common.version.VersionFeature;
 import net.krotscheck.kangaroo.database.DatabaseFeature;
+import net.krotscheck.kangaroo.servlet.admin.v1.filter.OAuth2AuthorizationFilter;
 import net.krotscheck.kangaroo.servlet.admin.v1.resource.UserService;
 import org.glassfish.jersey.CommonProperties;
 import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
 
 /**
  * The OID Servlet application, including all configured resources and
@@ -42,12 +44,18 @@ public final class AdminV1API extends ResourceConfig {
         // No autodiscovery, we load everything explicitly.
         property(CommonProperties.FEATURE_AUTO_DISCOVERY_DISABLE, true);
 
+        // Ensure that role annotations are respected.
+        register(RolesAllowedDynamicFeature.class);
+
         // Common features.
         register(ConfigurationFeature.class);    // Configuration loader
         register(JacksonFeature.class);          // Data Type de/serialization.
         register(ExceptionFeature.class);        // Exception Mapping.
         register(DatabaseFeature.class);         // Database Feature.
         register(VersionFeature.class);          // Version response attachment.
+
+        // API Authorization
+        register(new OAuth2AuthorizationFilter.Binder());
 
         // API Services
         register(UserService.class);

--- a/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/filter/OAuth2.java
+++ b/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/filter/OAuth2.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.kangaroo.servlet.admin.v1.filter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.ws.rs.NameBinding;
+
+/**
+ * This annotation should be used to indicate that a resource is
+ * authorized/authenticated via OAuth2 Tokens.
+ *
+ * @author Michael Krotscheck
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(value = RetentionPolicy.RUNTIME)
+@NameBinding
+public @interface OAuth2 {
+
+}

--- a/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/filter/OAuth2AuthorizationFilter.java
+++ b/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/filter/OAuth2AuthorizationFilter.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.kangaroo.servlet.admin.v1.filter;
+
+import net.krotscheck.kangaroo.database.entity.ApplicationScope;
+import net.krotscheck.kangaroo.database.entity.OAuthToken;
+import net.krotscheck.kangaroo.database.entity.OAuthTokenType;
+import net.krotscheck.kangaroo.database.entity.UserIdentity;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHeaders;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.hibernate.Session;
+
+import java.io.IOException;
+import java.security.Principal;
+import java.util.SortedMap;
+import java.util.UUID;
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.SecurityContext;
+
+/**
+ * A request filter that validates a bearer token before permitting the
+ * request to continue. It will replace the user principal with one that is
+ * aware of the token's granted scopes.
+ *
+ * @author Michael Krotscheck
+ */
+@Priority(Priorities.AUTHORIZATION)
+@OAuth2
+public final class OAuth2AuthorizationFilter implements ContainerRequestFilter {
+
+    /**
+     * The request's session provider.
+     */
+    private final Provider<Session> sessionProvider;
+
+    /**
+     * Create a new instance of this authorization filter.
+     *
+     * @param sessionProvider The context-relevant session provider.
+     */
+    @Inject
+    public OAuth2AuthorizationFilter(final Provider<Session> sessionProvider) {
+        this.sessionProvider = sessionProvider;
+    }
+
+    /**
+     * This filter attempts to resolve an OAuth authorization token from the
+     * request, and validate it. If successful, it will replace the
+     * security context, otherwise it will leave it blank.
+     *
+     * @param requestContext request context.
+     * @throws IOException if an I/O exception occurs.
+     */
+    @Override
+    public void filter(final ContainerRequestContext requestContext)
+            throws IOException {
+        String header =
+                requestContext.getHeaderString(HttpHeaders.AUTHORIZATION);
+        OAuthToken token = getTokenFromHeader(header);
+
+        // Blank token, and/or expired tokens, throw an exception.
+        if (token == null || token.isExpired()) {
+            return;
+        }
+
+        Boolean isSecure = requestContext.getSecurityContext().isSecure();
+        SecurityContext context = new OAuthTokenContext(token, isSecure);
+        requestContext.setSecurityContext(context);
+    }
+
+    /**
+     * Extracts an OAuthToken from the authorization header string.
+     *
+     * @param header The header string.
+     * @return An OAuth token, or null.
+     */
+    private OAuthToken getTokenFromHeader(final String header) {
+
+        if (StringUtils.isEmpty(header)) {
+            return null;
+        }
+
+        String[] token = header.split(" ");
+        if (token.length != 2) {
+            return null;
+        }
+
+        if (!token[0].equals("Bearer")) {
+            return null;
+        }
+
+        UUID tokenId;
+        try {
+            tokenId = UUID.fromString(token[1]);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            return null;
+        }
+
+        Session session = sessionProvider.get();
+        OAuthToken oauthToken = session.get(OAuthToken.class, tokenId);
+
+        if (oauthToken == null) {
+            return null;
+        }
+
+        if (!oauthToken.getTokenType().equals(OAuthTokenType.Bearer)) {
+            return null;
+        }
+
+        return oauthToken;
+    }
+
+    /**
+     * Private security context implementation that validates against our
+     * database of tokens.
+     */
+    public static final class OAuthTokenContext implements SecurityContext {
+
+        /**
+         * Is this secure?
+         */
+        private final boolean secure;
+
+        /**
+         * The principal.
+         */
+        private final UserIdentity principal;
+
+        /**
+         * The principal.
+         */
+        private final SortedMap<String, ApplicationScope> scopes;
+
+        /**
+         * Construct an authentication context from an OAuth token and a secure
+         * flag.
+         *
+         * @param token    The OAuth token for this principal.
+         * @param isSecure Whether to secure the context.
+         */
+        public OAuthTokenContext(final OAuthToken token,
+                                 final Boolean isSecure) {
+            // Materialize the scopes and the user identity.
+            principal = token.getIdentity();
+            scopes = token.getScopes();
+            secure = isSecure;
+        }
+
+        /**
+         * Return the current user identity.
+         */
+        @Override
+        public Principal getUserPrincipal() {
+            return principal;
+        }
+
+        /**
+         * WARNING: OVERLOADED TERMS
+         *
+         * In order to simplify the declaration of scope permissions, this
+         * method will check to see if the current user has been granted the
+         * provied "scope" rather than "role".
+         */
+        @Override
+        public boolean isUserInRole(final String roleName) {
+            return scopes.containsKey(roleName);
+        }
+
+        /**
+         * Was this request done via a secure request method?
+         */
+        @Override
+        public boolean isSecure() {
+            return secure;
+        }
+
+        /**
+         * Get the authentication scheme.
+         */
+        @Override
+        public String getAuthenticationScheme() {
+            return "OAuth2";
+        }
+    }
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bind(OAuth2AuthorizationFilter.class)
+                    .to(ContainerRequestFilter.class)
+                    .in(Singleton.class);
+        }
+    }
+}

--- a/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/filter/package-info.java
+++ b/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/filter/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Request filters for the admin server.
+ */
+package net.krotscheck.kangaroo.servlet.admin.v1.filter;

--- a/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/UserService.java
+++ b/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/UserService.java
@@ -23,6 +23,7 @@ import net.krotscheck.kangaroo.common.response.ListResponseBuilder;
 import net.krotscheck.kangaroo.common.response.SortOrder;
 import net.krotscheck.kangaroo.database.entity.User;
 import net.krotscheck.kangaroo.database.util.SortUtil;
+import net.krotscheck.kangaroo.servlet.admin.v1.filter.OAuth2;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.criterion.Projections;
@@ -33,7 +34,7 @@ import org.hibernate.search.query.dsl.QueryBuilder;
 
 import java.util.List;
 import java.util.UUID;
-import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -50,7 +51,8 @@ import javax.ws.rs.core.Response;
  * @author Michael Krotscheck
  */
 @Path("/user")
-@PermitAll
+@RolesAllowed("user")
+@OAuth2
 public final class UserService extends AbstractService {
 
     /**
@@ -170,7 +172,6 @@ public final class UserService extends AbstractService {
     @GET
     @Path("/{id: [a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}}")
     @Produces(MediaType.APPLICATION_JSON)
-    @PermitAll
     public Response getUser(@PathParam("id") final UUID id) {
         User user = getSession().get(User.class, id);
         if (user == null) {

--- a/kangaroo-servlet-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/filter/OAuth2AuthorizationFilterTest.java
+++ b/kangaroo-servlet-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/filter/OAuth2AuthorizationFilterTest.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.kangaroo.servlet.admin.v1.filter;
+
+import net.krotscheck.kangaroo.database.entity.ClientType;
+import net.krotscheck.kangaroo.database.entity.OAuthToken;
+import net.krotscheck.kangaroo.database.entity.OAuthTokenType;
+import net.krotscheck.kangaroo.servlet.admin.v1.AdminV1API;
+import net.krotscheck.kangaroo.servlet.admin.v1.filter.OAuth2AuthorizationFilter.Binder;
+import net.krotscheck.kangaroo.servlet.admin.v1.filter.OAuth2AuthorizationFilter.OAuthTokenContext;
+import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.EnvironmentBuilder;
+import net.krotscheck.kangaroo.test.IFixture;
+import org.apache.http.HttpStatus;
+import org.glassfish.hk2.api.ActiveDescriptor;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.api.ServiceLocatorFactory;
+import org.glassfish.hk2.utilities.BuilderHelper;
+import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import javax.inject.Singleton;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+
+/**
+ * Tests for our authorization filter.
+ *
+ * @author Michael Krotscheck
+ */
+public final class OAuth2AuthorizationFilterTest extends ContainerTest {
+
+    /**
+     * A valid, non-expired, bearer token.
+     */
+    private OAuthToken validBearerToken;
+
+    /**
+     * A valid, non-expired, bearer token with no appropriate scope.
+     */
+    private OAuthToken noScopeBearerToken;
+
+    /**
+     * An expired bearer token.
+     */
+    private OAuthToken expiredBearerToken;
+
+    /**
+     * A non-bearer token.
+     */
+    private OAuthToken authToken;
+
+    /**
+     * The application under test.
+     *
+     * @return An instance of the Admin servlet.
+     */
+    @Override
+    protected Application configure() {
+        return new AdminV1API();
+    }
+
+    /**
+     * Load data fixtures for each test.
+     *
+     * @return A list of fixtures, which will be cleared after the test.
+     * @throws Exception An exception that indicates a failed fixture load.
+     */
+    @Override
+    public List<IFixture> fixtures() throws Exception {
+        EnvironmentBuilder context = new EnvironmentBuilder(getSession())
+                .client(ClientType.Implicit)
+                .scope("user")
+                .redirect("http://example.com/redirect")
+                .referrer("http://example.com/redirect")
+                .authenticator("test")
+                .user()
+                .identity("remote_identity");
+
+        // Valid token
+        context.token(OAuthTokenType.Bearer, false, "user", null, null);
+        validBearerToken = context.getToken();
+
+        // Valid token
+        context.token(OAuthTokenType.Bearer, true, null, null, null);
+        noScopeBearerToken = context.getToken();
+
+        // Expired token.
+        context.token(OAuthTokenType.Bearer, true, "user", null, null);
+        expiredBearerToken = context.getToken();
+
+        // Auth token
+        context.authToken();
+        authToken = context.getToken();
+
+        List<IFixture> fixtures = new ArrayList<>();
+        fixtures.add(context);
+        return fixtures;
+    }
+
+    /**
+     * Test a valid bearer token.
+     */
+    @Test
+    public void testValidBearerToken() {
+        Response r = target("/user")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION,
+                        String.format("Bearer %s", validBearerToken.getId()))
+                .get();
+        Assert.assertEquals(HttpStatus.SC_OK, r.getStatus());
+    }
+
+    /**
+     * Test a valid bearer token.
+     */
+    @Test
+    public void testNoAuthHeader() {
+        Response r = target("/user")
+                .request()
+                .get();
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, r.getStatus());
+    }
+
+    /**
+     * Test a valid bearer token with no scope.
+     */
+    @Test
+    public void testValidBearerTokenWithoutScope() {
+        Response r = target("/user")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION,
+                        String.format("Bearer %s", noScopeBearerToken.getId()))
+                .get();
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, r.getStatus());
+    }
+
+    /**
+     * Test an expired bearer token.
+     */
+    @Test
+    public void testExpiredBearerToken() {
+        Response r = target("/user")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION,
+                        String.format("Bearer %s", expiredBearerToken.getId()))
+                .get();
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, r.getStatus());
+    }
+
+    /**
+     * Test a bearer token that doesn't exist.
+     */
+    @Test
+    public void testNonexistentBearerToken() {
+        Response r = target("/user")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION,
+                        String.format("Bearer %s", UUID.randomUUID()))
+                .get();
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, r.getStatus());
+    }
+
+    /**
+     * Test a bearer token that isn't formatted correctly (invalid UUID).
+     */
+    @Test
+    public void testMalformedBearerToken() {
+        Response r = target("/user")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer YUIIUYIY")
+                .get();
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, r.getStatus());
+    }
+
+    /**
+     * Test a token that isn't actually a bearer token, such as an
+     * authorization token.
+     */
+    @Test
+    public void testAuthorizationToken() {
+        Response r = target("/user")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION,
+                        String.format("Bearer %s", authToken.getId()))
+                .get();
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, r.getStatus());
+    }
+
+    /**
+     * Test a token with the wrong prefix type.
+     */
+    @Test
+    public void testWrongPrefixTokenToken() {
+        Response r = target("/user")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION,
+                        String.format("HMAC %s", authToken.getId()))
+                .get();
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, r.getStatus());
+    }
+
+    /**
+     * Test a token with no bearer prefix.
+     */
+    @Test
+    public void testMalformedToken() {
+        Response r = target("/user")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, "OMGOMGOMG")
+                .get();
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, r.getStatus());
+    }
+
+    /**
+     * Assert that we can invoke the binder.
+     *
+     * @throws Exception An authenticator exception.
+     */
+    @Test
+    public void testBinder() throws Exception {
+        ServiceLocatorFactory factory = ServiceLocatorFactory.getInstance();
+        ServiceLocator locator = factory.create(getClass().getCanonicalName());
+
+        Binder b = new OAuth2AuthorizationFilter.Binder();
+        ServiceLocatorUtilities.bind(locator, b);
+
+        List<ActiveDescriptor<?>> descriptors =
+                locator.getDescriptors(
+                        BuilderHelper.createContractFilter(
+                                ContainerRequestFilter.class.getName()));
+        Assert.assertEquals(1, descriptors.size());
+
+        ActiveDescriptor descriptor = descriptors.get(0);
+        Assert.assertNotNull(descriptor);
+        // Check scope...
+        Assert.assertEquals(Singleton.class.getCanonicalName(),
+                descriptor.getScope());
+
+        // ... check name.
+        Assert.assertNull(descriptor.getName());
+    }
+
+    /**
+     * Assert that we can invoke the binder.
+     *
+     * @throws Exception An authenticator exception.
+     */
+    @Test
+    public void testContextMethods() throws Exception {
+        OAuthTokenContext context =
+                new OAuthTokenContext(new OAuthToken(), false);
+
+        Assert.assertFalse(context.isSecure());
+        Assert.assertEquals("OAuth2", context.getAuthenticationScheme());
+    }
+}

--- a/kangaroo-servlet-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/filter/package-info.java
+++ b/kangaroo-servlet-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/filter/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unit tests for our filters.
+ */
+package net.krotscheck.kangaroo.servlet.admin.v1.filter;


### PR DESCRIPTION
This patch adds the @OAuth annotation, which adds token
validation logic to the selected resource path, as well as
the postmatching filter which enables this logic. The user
resource has been updated to require a token with the "user"
scope.

This implementation still depends on access to the database.
Eventually, it should be replaced with a caching implementation
that validates the token independently.