### PR TITLE
Created Hibernate-backed Apache Commons Configuration

### DIFF
--- a/kangaroo-database/src/main/java/net/krotscheck/kangaroo/database/config/HibernateConfiguration.java
+++ b/kangaroo-database/src/main/java/net/krotscheck/kangaroo/database/config/HibernateConfiguration.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.kangaroo.database.config;
+
+import net.krotscheck.kangaroo.database.entity.ConfigurationEntry;
+import org.apache.commons.configuration.AbstractConfiguration;
+import org.apache.commons.configuration.Configuration;
+import org.hibernate.Criteria;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.criterion.Restrictions;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * An apache-commons configuration implementation backed by hibernate entities.
+ *
+ * This implementation is not thread safe.
+ *
+ * @author Michael Krotscheck
+ */
+public final class HibernateConfiguration
+        extends AbstractConfiguration
+        implements Configuration {
+
+    /**
+     * The session factory.
+     */
+    private final SessionFactory factory;
+
+    /**
+     * The name of the configuration section.
+     */
+    private final String section;
+
+    /**
+     * Cache of last-loaded configuration values.
+     */
+    private SortedMap<String, Object> configurationCache;
+
+    /**
+     * Create a new instance of this configuration implementation, for a
+     * specific group of configuration values.
+     *
+     * @param factory The session factory used to access sessions.
+     * @param section The name of the section. Corresponds to the 'section'
+     *                column in the configuration table.
+     */
+    public HibernateConfiguration(final SessionFactory factory,
+                                  final String section) {
+        this.factory = factory;
+        this.section = section;
+    }
+
+    /**
+     * Adds a key/value pair to the Configuration. Override this method to
+     * provide write access to underlying Configuration store.
+     *
+     * @param key   key to use for mapping
+     * @param value object to store
+     */
+    @Override
+    protected void addPropertyDirect(final String key,
+                                     final Object value) {
+        ConfigurationEntry e = new ConfigurationEntry();
+        e.setSection(section);
+        e.setKey(key);
+        e.setValue(String.valueOf(value));
+
+        // Open a new session, save the data, and close the session.
+        Session s = factory.openSession();
+        Transaction t = s.beginTransaction();
+        s.save(e);
+        t.commit();
+        s.close();
+
+        // Clear the existing configuration
+        configurationCache = null;
+    }
+
+    /**
+     * Check if the configuration is empty.
+     *
+     * @return {@code true} if the configuration contains no property,
+     * {@code false} otherwise.
+     */
+    @Override
+    public boolean isEmpty() {
+        return getConfiguration().isEmpty();
+    }
+
+    /**
+     * Check if the configuration contains the specified key.
+     *
+     * @param key the key whose presence in this configuration is to be tested
+     * @return {@code true} if the configuration contains a value for this
+     * key, {@code false} otherwise
+     */
+    @Override
+    public boolean containsKey(final String key) {
+        return getConfiguration().containsKey(key);
+    }
+
+    /**
+     * Gets a property from the configuration. This is the most basic get
+     * method for retrieving values of properties. In a typical implementation
+     * of the {@code Configuration} interface the other get methods (that
+     * return specific data types) will internally make use of this method. On
+     * this level variable substitution is not yet performed. The returned
+     * object is an internal representation of the property value for the
+     * passed
+     * in key. It is owned by the {@code Configuration} object. So a caller
+     * should not modify this object. It cannot be guaranteed that this object
+     * will stay constant over time (i.e. further update operations on the
+     * configuration may change its internal state).
+     *
+     * @param key property to retrieve
+     * @return the value to which this configuration maps the specified key, or
+     * null if the configuration contains no mapping for this key.
+     */
+    @Override
+    public Object getProperty(final String key) {
+        return getConfiguration().get(key);
+    }
+
+    /**
+     * Removes the specified property from this configuration. This method is
+     * called by {@code clearProperty()} after it has done some
+     * preparations. It should be overridden in sub classes. This base
+     * implementation is just left empty.
+     *
+     * @param key the key to be removed
+     */
+    @Override
+    protected void clearPropertyDirect(final String key) {
+
+        // Open a session.
+        Session s = factory.openSession();
+
+        // Search for all configuration entries.
+        Criteria c = s.createCriteria(ConfigurationEntry.class);
+        c.add(Restrictions.eq("section", section));
+        c.add(Restrictions.eq("key", key));
+
+        Transaction t = s.beginTransaction();
+        for (ConfigurationEntry entry : (List<ConfigurationEntry>) c.list()) {
+            s.delete(entry);
+        }
+        t.commit();
+
+        // Close the session.
+        s.close();
+
+        // Clear the existing configuration
+        configurationCache = null;
+    }
+
+    /**
+     * Clear all configuration entries for this particular group.
+     */
+    @Override
+    public void clear() {
+        fireEvent(EVENT_CLEAR, null, null, true);
+
+        // Open a session.
+        Session s = factory.openSession();
+
+        // Search for all configuration entries.
+        Criteria c = s.createCriteria(ConfigurationEntry.class);
+        c.add(Restrictions.eq("section", section));
+
+        Transaction t = s.beginTransaction();
+        for (ConfigurationEntry entry : (List<ConfigurationEntry>) c.list()) {
+            s.delete(entry);
+        }
+        t.commit();
+
+        // Close the session.
+        s.close();
+
+        // Clear the existing configuration
+        configurationCache = null;
+
+        // Fire the completion event.
+        fireEvent(EVENT_CLEAR, null, null, false);
+    }
+
+    /**
+     * Get the list of the keys contained in the configuration. The returned
+     * iterator can be used to obtain all defined keys. Note that the exact
+     * behavior of the iterator's {@code remove()} method is specific to
+     * a concrete implementation. It <em>may</em> remove the corresponding
+     * property from the configuration, but this is not guaranteed. In any case
+     * it is no replacement for calling
+     * {@link #clearProperty(String)} for this property. So it is
+     * highly recommended to avoid using the iterator's {@code remove()}
+     * method.
+     *
+     * @return An Iterator.
+     */
+    @Override
+    public Iterator<String> getKeys() {
+        return getConfiguration().keySet().iterator();
+    }
+
+    /**
+     * Retrieve the most recent configuration elements for this group.
+     *
+     * @return The configuration, could be cached.
+     */
+    private SortedMap<String, Object> getConfiguration() {
+        if (configurationCache == null) {
+            // Open a session.
+            Session s = factory.openSession();
+
+            // Search for all configuration entries.
+            Criteria c = s.createCriteria(ConfigurationEntry.class);
+            c.add(Restrictions.eq("section", section));
+            List<ConfigurationEntry> entries = c.list();
+
+            /**
+             * Map those entries into a tree.
+             */
+            TreeMap<String, Object> values = new TreeMap<>();
+            for (ConfigurationEntry entry : entries) {
+                values.put(entry.getKey(), entry.getValue());
+            }
+
+            // Close the session.
+            s.close();
+
+            // Store the cache as an unmodifiable map.
+            configurationCache = Collections.unmodifiableSortedMap(values);
+        }
+        return configurationCache;
+    }
+}

--- a/kangaroo-database/src/main/java/net/krotscheck/kangaroo/database/config/package-info.java
+++ b/kangaroo-database/src/main/java/net/krotscheck/kangaroo/database/config/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * An apache-commons-config compliant configuration implementation backed by
+ * hibernate.
+ */
+package net.krotscheck.kangaroo.database.config;

--- a/kangaroo-database/src/main/java/net/krotscheck/kangaroo/database/entity/ConfigurationEntry.java
+++ b/kangaroo-database/src/main/java/net/krotscheck/kangaroo/database/entity/ConfigurationEntry.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.kangaroo.database.entity;
+
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+/**
+ * A configuration entity, containing key/value pairs sorted by group.
+ *
+ * @author Michael Krotscheck
+ */
+@Entity
+@Table(name = "configuration")
+public final class ConfigurationEntry extends AbstractEntity {
+
+    /**
+     * The section for this entry.
+     */
+    @Basic(optional = false)
+    @Column(name = "section", nullable = false)
+    private String section;
+
+    /**
+     * The key name.
+     */
+    @Basic(optional = false)
+    @Column(name = "key", nullable = false)
+    private String key;
+
+    /**
+     * The stored value.
+     */
+    @Basic(optional = false)
+    @Column(name = "value", nullable = false)
+    private String value;
+
+    /**
+     * Get the configuration section.
+     *
+     * @return The configuration section.
+     */
+    public String getSection() {
+        return section;
+    }
+
+    /**
+     * Set the configuration section.
+     *
+     * @param section The configuration section.
+     */
+    public void setSection(final String section) {
+        this.section = section;
+    }
+
+    /**
+     * The key for this configuration entry.
+     *
+     * @return The entry key.
+     */
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * Set the key for this configuration entry.
+     *
+     * @param key The key.
+     */
+    public void setKey(final String key) {
+        this.key = key;
+    }
+
+    /**
+     * Get the value for this configuration entry.
+     *
+     * @return The value.
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Set the value for this configuration entry.
+     *
+     * @param value The new value.
+     */
+    public void setValue(final String value) {
+        this.value = value;
+    }
+
+}

--- a/kangaroo-database/src/main/resources/hibernate.cfg.xml
+++ b/kangaroo-database/src/main/resources/hibernate.cfg.xml
@@ -22,7 +22,8 @@
 <hibernate-configuration>
   <session-factory>
     <!-- Connection properties -->
-    <property name="connection.datasource">java:comp/env/jdbc/OIDServerDB
+    <property name="connection.datasource">
+      java:comp/env/jdbc/OIDServerDB
     </property>
 
     <!-- Generic hibernate configuration -->
@@ -52,6 +53,7 @@
     <mapping class="net.krotscheck.kangaroo.database.entity.Authenticator"/>
     <mapping class="net.krotscheck.kangaroo.database.entity.AuthenticatorState"/>
     <mapping class="net.krotscheck.kangaroo.database.entity.Client"/>
+    <mapping class="net.krotscheck.kangaroo.database.entity.ConfigurationEntry"/>
     <mapping class="net.krotscheck.kangaroo.database.entity.OAuthToken"/>
     <mapping class="net.krotscheck.kangaroo.database.entity.Role"/>
     <mapping class="net.krotscheck.kangaroo.database.entity.User"/>

--- a/kangaroo-database/src/main/resources/liquibase/db.changelog-1.0.0.yaml
+++ b/kangaroo-database/src/main/resources/liquibase/db.changelog-1.0.0.yaml
@@ -4,6 +4,57 @@ databaseChangeLog:
       author: krotscheck
       changes:
 
+      # The Configuration table.
+      - createTable:
+          tableName: configuration
+          columns:
+            - column:
+                name: id
+                type: BINARY(16)
+                constraints:
+                  primaryKey: true
+                  nullable: false
+                  primaryKeyName: pk_configuration_id
+            - column:
+                name: createdDate
+                type: datetime
+            - column:
+                name: modifiedDate
+                type: datetime
+            - column:
+                name: section
+                type: varchar(255)
+                constraints:
+                  nullable: false
+            - column:
+                name: key
+                type: varchar(255)
+                constraints:
+                  nullable: false
+            - column:
+                name: value
+                type: varchar(255)
+                constraints:
+                  nullable: false
+      - createIndex:
+          columns:
+          - column:
+              name: section
+              type: varchar(255)
+          indexName: idx_configuration_section
+          tableName: configuration
+      - createIndex:
+          columns:
+          - column:
+              name: key
+              type: varchar(255)
+          indexName: idx_configuration_key
+          tableName: configuration
+      - addUniqueConstraint:
+          columnNames: section, key
+          constraintName: uq_configuration_section_key
+          tableName: configuration
+
       # The Application table, the root resource from which everything else
       # is derived.
       - createTable:
@@ -875,3 +926,5 @@ databaseChangeLog:
             tableName: application_scopes
         - dropTable:
             tableName: applications
+        - dropTable:
+            tableName: configuration

--- a/kangaroo-database/src/test/java/net/krotscheck/kangaroo/database/config/HibernateConfigurationTest.java
+++ b/kangaroo-database/src/test/java/net/krotscheck/kangaroo/database/config/HibernateConfigurationTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.kangaroo.database.config;
+
+import net.krotscheck.kangaroo.test.DatabaseTest;
+import net.krotscheck.kangaroo.test.IFixture;
+import org.apache.commons.configuration.Configuration;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Unit tests for the Hibernate-backed configuration implementation.
+ *
+ * @author Michael Krotscheck
+ */
+public final class HibernateConfigurationTest extends DatabaseTest {
+
+    /**
+     * The configuration instance under test.
+     */
+    private Configuration configOne;
+
+    /**
+     * A second instance under test.
+     */
+    private Configuration configTwo;
+
+    /**
+     * Setup the test.
+     */
+    @Before
+    public void setup() {
+        configOne = new HibernateConfiguration(
+                getSessionFactory(),
+                "one");
+        configTwo = new HibernateConfiguration(
+                getSessionFactory(),
+                "two");
+    }
+
+    /**
+     * Teardown the test.
+     */
+    @After
+    public void teardown() {
+        configOne.clear();
+        configTwo.clear();
+    }
+
+    /**
+     * Load data fixtures for each test.
+     *
+     * @return A list of fixtures, which will be cleared after the test.
+     * @throws Exception An exception that indicates a failed fixture load.
+     */
+    @Override
+    public List<IFixture> fixtures() throws Exception {
+        return null; // No fixtures.
+    }
+
+    /**
+     * Test isEmpty().
+     */
+    @Test
+    public void testIsEmpty() {
+        Assert.assertTrue(configOne.isEmpty());
+        configOne.addProperty("key", "value");
+        Assert.assertFalse(configOne.isEmpty());
+    }
+
+    /**
+     * Test keys.
+     */
+    @Test
+    public void testKeys() {
+        configOne.addProperty("key", "value");
+        configOne.addProperty("lol", "cat");
+
+        List<String> keys = new ArrayList<>();
+        configOne.getKeys().forEachRemaining(keys::add);
+
+        Assert.assertTrue(keys.contains("key"));
+        Assert.assertTrue(keys.contains("lol"));
+        Assert.assertEquals(2, keys.size());
+    }
+
+    /**
+     * Assert that we can store and retrieve data.
+     */
+    @Test
+    public void testStoreAndRetrieve() {
+        configOne.addProperty("key", "value");
+        Assert.assertTrue(configOne.containsKey("key"));
+        Assert.assertEquals("value", configOne.getString("key"));
+        configOne.clearProperty("key");
+        Assert.assertFalse(configOne.containsKey("key"));
+    }
+
+    /**
+     * Assert that multiple instances read from the same source.
+     */
+    @Test
+    public void testMultipleInstances() {
+        configOne.addProperty("key", "value");
+        Assert.assertTrue(configOne.containsKey("key"));
+
+        Configuration configuration = new HibernateConfiguration(
+                getSessionFactory(),
+                "one");
+        Assert.assertTrue(configuration.containsKey("key"));
+    }
+
+    /**
+     * Assert that separate instances do not conflict.
+     */
+    @Test
+    public void testNoGroupConflict() {
+        configOne.addProperty("key", "value");
+        Assert.assertTrue(configOne.containsKey("key"));
+        Assert.assertFalse(configTwo.containsKey("key"));
+
+        configTwo.addProperty("foo", "bar");
+        Assert.assertFalse(configOne.containsKey("foo"));
+        Assert.assertTrue(configTwo.containsKey("foo"));
+    }
+}

--- a/kangaroo-database/src/test/java/net/krotscheck/kangaroo/database/config/package-info.java
+++ b/kangaroo-database/src/test/java/net/krotscheck/kangaroo/database/config/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unit tests for the hibernate-backed configuration.
+ */
+package net.krotscheck.kangaroo.database.config;

--- a/kangaroo-database/src/test/java/net/krotscheck/kangaroo/database/entity/ConfigurationEntryTest.java
+++ b/kangaroo-database/src/test/java/net/krotscheck/kangaroo/database/entity/ConfigurationEntryTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.kangaroo.database.entity;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test the configuration entry entity.
+ *
+ * @author Michael Krotscheck
+ */
+public final class ConfigurationEntryTest {
+
+    /**
+     * Test getting/setting the section.
+     */
+    @Test
+    public void testGetSetSection() {
+        ConfigurationEntry entry = new ConfigurationEntry();
+
+        Assert.assertNull(entry.getSection());
+        entry.setSection("section");
+        Assert.assertEquals("section", entry.getSection());
+    }
+
+    /**
+     * Test getting/setting the key.
+     */
+    @Test
+    public void testGetSetKey() {
+        ConfigurationEntry entry = new ConfigurationEntry();
+
+        Assert.assertNull(entry.getKey());
+        entry.setKey("key");
+        Assert.assertEquals("key", entry.getKey());
+    }
+
+    /**
+     * Test getting/setting the value.
+     */
+    @Test
+    public void testGetSetValue() {
+        ConfigurationEntry entry = new ConfigurationEntry();
+
+        Assert.assertNull(entry.getValue());
+        entry.setValue("value");
+        Assert.assertEquals("value", entry.getValue());
+    }
+}

--- a/kangaroo-database/src/test/java/net/krotscheck/kangaroo/database/listener/CreatedUpdatedListenerTest.java
+++ b/kangaroo-database/src/test/java/net/krotscheck/kangaroo/database/listener/CreatedUpdatedListenerTest.java
@@ -33,7 +33,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.File;
 import java.util.Calendar;
 import java.util.List;
 


### PR DESCRIPTION
This patch creates an implementation of the apache commons
configuration interface, backed by hibernate. We'll be using it
to store servlet-specific configuration elements - such as the
admin servlet's OAuth Application ID - in an easily accessible
location.