### PR TITLE
Database-backed configuration element for the admin servlet.

### DIFF
--- a/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/AdminV1API.java
+++ b/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/AdminV1API.java
@@ -23,6 +23,7 @@ import net.krotscheck.kangaroo.common.exception.ExceptionFeature;
 import net.krotscheck.kangaroo.common.jackson.JacksonFeature;
 import net.krotscheck.kangaroo.common.version.VersionFeature;
 import net.krotscheck.kangaroo.database.DatabaseFeature;
+import net.krotscheck.kangaroo.servlet.admin.v1.config.AdminConfigurationFactory;
 import net.krotscheck.kangaroo.servlet.admin.v1.filter.OAuth2AuthorizationFilter;
 import net.krotscheck.kangaroo.servlet.admin.v1.resource.UserService;
 import org.glassfish.jersey.CommonProperties;
@@ -53,6 +54,9 @@ public final class AdminV1API extends ResourceConfig {
         register(ExceptionFeature.class);        // Exception Mapping.
         register(DatabaseFeature.class);         // Database Feature.
         register(VersionFeature.class);          // Version response attachment.
+
+        // Internal components
+        register(new AdminConfigurationFactory.Binder());
 
         // API Authorization
         register(new OAuth2AuthorizationFilter.Binder());

--- a/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/config/AdminConfigurationFactory.java
+++ b/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/config/AdminConfigurationFactory.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.kangaroo.servlet.admin.v1.config;
+
+import net.krotscheck.kangaroo.database.config.HibernateConfiguration;
+import org.apache.commons.configuration.Configuration;
+import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.hibernate.SessionFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * This factory instantiates a configuration element which contains all
+ * system-level configuration elements, such as root URI path, Admin API ID,
+ * and others. It should only ever be used for configuration required by this
+ * servlet.
+ *
+ * @author Michael Krotscheck
+ */
+public final class AdminConfigurationFactory
+        implements Factory<Configuration> {
+
+    /**
+     * The name of the configuration group.
+     */
+    public static final String GROUP_NAME = "kangaroo-servlet-admin";
+
+    /**
+     * The Session factory that will be provided to the hibernate
+     * configuration.
+     */
+    private final SessionFactory factory;
+
+    /**
+     * Create a new factory instance.
+     *
+     * @param factory The hibernate session factory.
+     */
+    @Inject
+    public AdminConfigurationFactory(final SessionFactory factory) {
+        this.factory = factory;
+    }
+
+    /**
+     * This method will create instances of the type of this factory.  The
+     * provide method must be annotated with the desired scope and qualifiers.
+     *
+     * @return The produces object
+     */
+    @Override
+    public Configuration provide() {
+        return new HibernateConfiguration(factory, GROUP_NAME);
+    }
+
+    /**
+     * This method will dispose of objects created with this scope.  This
+     * method should not be annotated, as it is naturally paired with the
+     * provide method.
+     *
+     * @param instance The instance to dispose of
+     */
+    @Override
+    public void dispose(final Configuration instance) {
+        // Do nothing, the config should close with the hibernate instance.
+    }
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bindFactory(AdminConfigurationFactory.class)
+                    .to(Configuration.class)
+                    .named(GROUP_NAME)
+                    .in(Singleton.class);
+        }
+    }
+}

--- a/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/config/package-info.java
+++ b/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/config/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Management of persisted configuration for the admin API.
+ */
+package net.krotscheck.kangaroo.servlet.admin.v1.config;

--- a/kangaroo-servlet-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/config/AdminConfigurationFactoryTest.java
+++ b/kangaroo-servlet-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/config/AdminConfigurationFactoryTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.krotscheck.kangaroo.servlet.admin.v1.config;
+
+import net.krotscheck.kangaroo.database.config.HibernateConfiguration;
+import net.krotscheck.kangaroo.servlet.admin.v1.config.AdminConfigurationFactory.Binder;
+import net.krotscheck.kangaroo.test.DatabaseTest;
+import net.krotscheck.kangaroo.test.IFixture;
+import org.apache.commons.configuration.Configuration;
+import org.glassfish.hk2.api.ActiveDescriptor;
+import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.api.ServiceLocatorFactory;
+import org.glassfish.hk2.utilities.BuilderHelper;
+import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+import javax.inject.Singleton;
+
+/**
+ * Test that the admin configuration factory creates a singleton instance of
+ * the HibernateConfiguration.
+ */
+public final class AdminConfigurationFactoryTest extends DatabaseTest {
+
+    /**
+     * Load data fixtures for each test.
+     *
+     * @return A list of fixtures, which will be cleared after the test.
+     * @throws Exception An exception that indicates a failed fixture load.
+     */
+    @Override
+    public List<IFixture> fixtures() throws Exception {
+        return null;
+    }
+
+    /**
+     * Assert that we can create a configuration.
+     */
+    @Test
+    public void testCreateConfiguration() {
+        // Load some data.
+        HibernateConfiguration compareConfig =
+                new HibernateConfiguration(getSessionFactory(),
+                        AdminConfigurationFactory.GROUP_NAME);
+        compareConfig.addProperty("test", "property");
+
+        // Create a new instance from the factory.
+        AdminConfigurationFactory factory =
+                new AdminConfigurationFactory(getSessionFactory());
+        Configuration created = factory.provide();
+
+        // Make sure it can access the data.
+        Assert.assertEquals("property", created.getString("test"));
+    }
+
+    /**
+     * Assert that disposing doesn't really do anything.
+     */
+    @Test
+    public void testDispose() {
+        // Create a new instance from the factory.
+        AdminConfigurationFactory factory =
+                new AdminConfigurationFactory(getSessionFactory());
+        Configuration mock = Mockito.mock(Configuration.class);
+        factory.dispose(mock);
+
+        Mockito.verifyNoMoreInteractions(mock);
+    }
+
+    /**
+     * Assert that the component is bound properly.
+     */
+    @Test
+    public void testBinder() {
+        ServiceLocatorFactory factory = ServiceLocatorFactory.getInstance();
+        ServiceLocator locator = factory.create(getClass().getCanonicalName());
+
+        Binder b = new AdminConfigurationFactory.Binder();
+        ServiceLocatorUtilities.bind(locator, b);
+
+        List<ActiveDescriptor<?>> descriptors =
+                locator.getDescriptors(
+                        BuilderHelper.createNameAndContractFilter(
+                                Configuration.class.getName(),
+                                AdminConfigurationFactory.GROUP_NAME));
+        Assert.assertEquals(1, descriptors.size());
+
+        ActiveDescriptor descriptor = descriptors.get(0);
+        Assert.assertNotNull(descriptor);
+        // Check scope...
+        Assert.assertEquals(Singleton.class.getCanonicalName(),
+                descriptor.getScope());
+
+        // ... check name.
+        Assert.assertEquals(AdminConfigurationFactory.GROUP_NAME,
+                descriptor.getName());
+    }
+
+    /**
+     * Assert that the generic interface works as expected.
+     *
+     * @throws Exception Should not be thrown.
+     * @see <a href="https://sourceforge.net/p/cobertura/bugs/92/">https://sourceforge.net/p/cobertura/bugs/92/</a>
+     */
+    @Test
+    public void testGenericInterface() throws Exception {
+        // Intentionally using the generic untyped interface here.
+        Factory factory = new AdminConfigurationFactory(getSessionFactory());
+        Object instance = factory.provide();
+        Assert.assertTrue(instance instanceof HibernateConfiguration);
+        factory.dispose(instance);
+    }
+}

--- a/kangaroo-servlet-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/config/package-info.java
+++ b/kangaroo-servlet-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/config/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Configuration tests.
+ */
+package net.krotscheck.kangaroo.servlet.admin.v1.config;


### PR DESCRIPTION
This patch adds a factory which provides a database-backed
singleton configuration instance for application-specific settings.
Here we can store the default application ID, base URI's, and
other defaults which may be handy.