### PR TITLE
Added convenience test method to create Bearer Headers

### DIFF
--- a/kangaroo-test/src/main/java/net/krotscheck/kangaroo/test/HttpUtil.java
+++ b/kangaroo-test/src/main/java/net/krotscheck/kangaroo/test/HttpUtil.java
@@ -86,6 +86,26 @@ public final class HttpUtil {
     }
 
     /**
+     * Create a bearer authorization header.
+     *
+     * @param token The bearer token ID.
+     * @return 'Bearer (token)'
+     */
+    public static String authHeaderBearer(final UUID token) {
+        return authHeaderBearer(token.toString());
+    }
+
+    /**
+     * Create a bearer authorization header.
+     *
+     * @param token The bearer token ID.
+     * @return 'Bearer (token)'
+     */
+    public static String authHeaderBearer(final String token) {
+        return String.format("Bearer %s", token);
+    }
+
+    /**
      * Helper method, which extracts the query string from a URI.
      *
      * @param uri The URI from which we're pulling the query response.

--- a/kangaroo-test/src/test/java/net/krotscheck/kangaroo/test/HttpUtilTest.java
+++ b/kangaroo-test/src/test/java/net/krotscheck/kangaroo/test/HttpUtilTest.java
@@ -74,6 +74,22 @@ public final class HttpUtilTest {
         c.newInstance();
     }
 
+    /**
+     * Test the bearer auth header.
+     */
+    @Test
+    public void testAuthHeaderBearer() {
+        UUID token = UUID.randomUUID();
+        String expected = String.format("Bearer %s", token.toString());
+
+        // Test via string.
+        String header = HttpUtil.authHeaderBearer(token.toString());
+        Assert.assertEquals(expected, header);
+
+        // Test via uuid
+        String uuidHeader = HttpUtil.authHeaderBearer(token);
+        Assert.assertEquals(expected, uuidHeader);
+    }
 
     /**
      * Test the basic auth header with strings.


### PR DESCRIPTION
HttpUtil can now construct bearer headers.