### PR TITLE
Test fixtures are cleared in reverse order.

### DIFF
--- a/kangaroo-test/src/main/java/net/krotscheck/kangaroo/test/ContainerTest.java
+++ b/kangaroo-test/src/main/java/net/krotscheck/kangaroo/test/ContainerTest.java
@@ -32,6 +32,7 @@ import org.junit.BeforeClass;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
@@ -109,7 +110,9 @@ public abstract class ContainerTest
      */
     @After
     public final void clearData() {
-        fixtures.forEach(IFixture::clear);
+        List<IFixture> reversed = new ArrayList<>(fixtures);
+        Collections.reverse(reversed);
+        reversed.forEach(IFixture::clear);
         fixtures.clear();
 
         // Clean any outstanding sessions.

--- a/kangaroo-test/src/main/java/net/krotscheck/kangaroo/test/DatabaseTest.java
+++ b/kangaroo-test/src/main/java/net/krotscheck/kangaroo/test/DatabaseTest.java
@@ -25,6 +25,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -87,7 +88,9 @@ public abstract class DatabaseTest implements IDatabaseTest {
      */
     @After
     public final void clearData() throws Exception {
-        fixtures.forEach(IFixture::clear);
+        List<IFixture> reversed = new ArrayList<>(fixtures);
+        Collections.reverse(reversed);
+        reversed.forEach(IFixture::clear);
         fixtures.clear();
 
         // Clean any outstanding sessions.


### PR DESCRIPTION
Since the order of operations can create an implicitly
dependency in child records via foreign keys, this patch ensures
that the test fixtures are cleared in reversed order.