### PR TITLE
Added convenience configuration for MySQL

### DIFF
--- a/kangaroo-test/src/main/java/net/krotscheck/kangaroo/test/DatabaseManager.java
+++ b/kangaroo-test/src/main/java/net/krotscheck/kangaroo/test/DatabaseManager.java
@@ -52,12 +52,15 @@ public final class DatabaseManager {
     /**
      * JDBC Connection string.
      */
+//    public static final String JDBC =
+//            "jdbc:mysql://localhost:3306/oid?useUnicode=yes";
     public static final String JDBC =
             "jdbc:h2:mem:target/test/db/h2/hibernate";
 
     /**
      * JDBC Connection string.
      */
+//    public static final String DRIVER = "com.mysql.jdbc.Driver";
     public static final String DRIVER = "org.h2.Driver";
 
     /**


### PR DESCRIPTION
For development purposes, running our tests against mysql can be useful.
This adds the appropriate configuration parameters so we can enable
it during development.