### PR TITLE
Added owner management to EnvironmentBuilder

### DIFF
--- a/kangaroo-test-database/src/main/java/net/krotscheck/kangaroo/test/EnvironmentBuilder.java
+++ b/kangaroo-test-database/src/main/java/net/krotscheck/kangaroo/test/EnvironmentBuilder.java
@@ -439,9 +439,10 @@ public final class EnvironmentBuilder implements IFixture {
         session.saveOrUpdate(e);
         t.commit();
 
+        // Evict the entity, so that it's freshly loaded later.
+        session.evict(e);
+
         if (!trackedEntities.contains(e)) {
-            // Evict the entity, so that it's freshly loaded later.
-            session.evict(e);
             trackedEntities.add(e);
         }
 
@@ -585,6 +586,29 @@ public final class EnvironmentBuilder implements IFixture {
         userIdentity.getClaims().putIfAbsent(name, value);
         persist(userIdentity);
         return this;
+    }
+
+    /**
+     * Set the owner for the current application.
+     *
+     * @param user The new owner.
+     * @return This builder.
+     */
+    public EnvironmentBuilder owner(final User user) {
+        // Reload the owner from the current session.
+        User sessionUser = session.get(User.class, user.getId());
+        application.setOwner(sessionUser);
+        persist(application);
+        return this;
+    }
+
+    /**
+     * Get the owner of this app.
+     *
+     * @return The application owner.
+     */
+    public User getOwner() {
+        return application.getOwner();
     }
 
     /**

--- a/kangaroo-test-database/src/test/java/net/krotscheck/kangaroo/test/EnvironmentBuilderTest.java
+++ b/kangaroo-test-database/src/test/java/net/krotscheck/kangaroo/test/EnvironmentBuilderTest.java
@@ -94,6 +94,11 @@ public final class EnvironmentBuilderTest extends DatabaseTest {
         // Make sure we have an application.
         Assert.assertNotNull(b.getApplication());
 
+        // Set the owner
+        Assert.assertNull(b.getOwner());
+        b.owner(context.getUser());
+        Assert.assertEquals(context.getUser(), b.getOwner());
+
         // Create a role.
         Assert.assertNull(b.getRole());
         b.role("testRole");
@@ -303,8 +308,12 @@ public final class EnvironmentBuilderTest extends DatabaseTest {
         SessionFactory f = getSessionFactory();
         Session builderSession = f.openSession();
 
+        // Create a dummy owner...
+        context.user();
+
         // Create a new application with some basic data.
         EnvironmentBuilder b = new EnvironmentBuilder(builderSession)
+                .owner(context.getUser())
                 .client(ClientType.OwnerCredentials)
                 .authenticator("password")
                 .scope("test")


### PR DESCRIPTION
When creating an application, you can now explicitly assign an
owner. This patch also fixes a bug in the entity eviction, where
updated entities were not subsequently evicted from the session.