### PR TITLE
EnvironmentBuilder now flushes all entities

### DIFF
--- a/kangaroo-test-database/src/main/java/net/krotscheck/kangaroo/test/EnvironmentBuilder.java
+++ b/kangaroo-test-database/src/main/java/net/krotscheck/kangaroo/test/EnvironmentBuilder.java
@@ -242,10 +242,15 @@ public final class EnvironmentBuilder implements IFixture {
 
         // Load this entity from the provided session.
         this.application = session.get(Application.class, app.getId());
-        this.scopes = this.application.getScopes();
+        this.scopes.putAll(this.application.getScopes());
         this.client = this.application.getClients().get(0);
         this.authenticator = this.client.getAuthenticators().get(0);
         this.user = this.application.getUsers().get(0);
+        if (this.application.getRoles().size() > 0) {
+            this.role = this.application.getRoles().get(0);
+        }
+
+        session.clear();
     }
 
     /**
@@ -445,7 +450,11 @@ public final class EnvironmentBuilder implements IFixture {
             trackedEntities.add(e);
         }
 
+        // Persist all changes.
         session.flush();
+
+        // Make sure everything's evicted, so we can load it cleanly later.
+        session.clear();
     }
 
     /**

--- a/kangaroo-test-database/src/test/java/net/krotscheck/kangaroo/test/EnvironmentBuilderTest.java
+++ b/kangaroo-test-database/src/test/java/net/krotscheck/kangaroo/test/EnvironmentBuilderTest.java
@@ -59,8 +59,6 @@ public final class EnvironmentBuilderTest extends DatabaseTest {
                 .client(ClientType.OwnerCredentials)
                 .authenticator("password")
                 .scopes(Arrays.asList("one", "two", "three"))
-                .role("admin")
-                .role("member")
                 .user()
                 .identity("admin");
 
@@ -292,6 +290,24 @@ public final class EnvironmentBuilderTest extends DatabaseTest {
 
         adminApp = session.get(Application.class, adminApp.getId());
         Assert.assertNotNull(adminApp);
+    }
+
+    /**
+     * Assert that we can wrap the builder around an application.
+     */
+    @Test
+    public void testApplicationWrapperWithRoles() {
+        // Add some roles...
+        context.role("admin");
+        context.role("member");
+
+        // A mock, self-owned admin application.
+        Application adminApp = context.getApplication();
+
+        Session session = getSession();
+        EnvironmentBuilder b =
+                new EnvironmentBuilder(session, context.getApplication());
+        Assert.assertEquals(adminApp, b.getApplication());
     }
 
     /**


### PR DESCRIPTION
Rather than try to flush all entities from the session as they are
saved, we instead just clear everything. This guarantees that any
entities that are children and/or persisted due to relationships and
non-lazy keys are properly detached.