### PR TITLE
Add kangaroo namespace to scope.

### DIFF
--- a/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/Scope.java
+++ b/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/Scope.java
@@ -38,32 +38,32 @@ public final class Scope {
     /**
      * Authorization scope for the user resource.
      */
-    public static final String USER = "user";
+    public static final String USER = "kangaroo:user";
 
     /**
      * Authorization scope for the application resource.
      */
-    public static final String APPLICATION = "application";
+    public static final String APPLICATION = "kangaroo:application";
 
     /**
      * Authorization scope for the authenticator resource.
      */
-    public static final String AUTHENTICATOR = "authenticator";
+    public static final String AUTHENTICATOR = "kangaroo:authenticator";
 
     /**
      * Authorization scope for the client resource.
      */
-    public static final String CLIENT = "client";
+    public static final String CLIENT = "kangaroo:client";
 
     /**
      * Authorization scope for the identity resource.
      */
-    public static final String IDENTITY = "identity";
+    public static final String IDENTITY = "kangaroo:identity";
 
     /**
      * Authorization scope for the roles resource.
      */
-    public static final String ROLE = "role";
+    public static final String ROLE = "kangaroo:role";
 
     /**
      * Get a list of all the scopes.

--- a/kangaroo-servlet-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/ScopeTest.java
+++ b/kangaroo-servlet-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/ScopeTest.java
@@ -51,12 +51,12 @@ public final class ScopeTest {
      */
     @Test
     public void testExpectedConstants() {
-        Assert.assertEquals("application", Scope.APPLICATION);
-        Assert.assertEquals("authenticator", Scope.AUTHENTICATOR);
-        Assert.assertEquals("client", Scope.CLIENT);
-        Assert.assertEquals("user", Scope.USER);
-        Assert.assertEquals("role", Scope.ROLE);
-        Assert.assertEquals("identity", Scope.IDENTITY);
+        Assert.assertEquals("kangaroo:application", Scope.APPLICATION);
+        Assert.assertEquals("kangaroo:authenticator", Scope.AUTHENTICATOR);
+        Assert.assertEquals("kangaroo:client", Scope.CLIENT);
+        Assert.assertEquals("kangaroo:user", Scope.USER);
+        Assert.assertEquals("kangaroo:role", Scope.ROLE);
+        Assert.assertEquals("kangaroo:identity", Scope.IDENTITY);
     }
 
     /**

--- a/kangaroo-servlet-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/filter/OAuth2AuthorizationFilterTest.java
+++ b/kangaroo-servlet-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/filter/OAuth2AuthorizationFilterTest.java
@@ -21,6 +21,7 @@ import net.krotscheck.kangaroo.database.entity.ClientType;
 import net.krotscheck.kangaroo.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.database.entity.OAuthTokenType;
 import net.krotscheck.kangaroo.servlet.admin.v1.AdminV1API;
+import net.krotscheck.kangaroo.servlet.admin.v1.Scope;
 import net.krotscheck.kangaroo.servlet.admin.v1.filter.OAuth2AuthorizationFilter.Binder;
 import net.krotscheck.kangaroo.servlet.admin.v1.filter.OAuth2AuthorizationFilter.OAuthTokenContext;
 import net.krotscheck.kangaroo.test.ContainerTest;
@@ -91,7 +92,7 @@ public final class OAuth2AuthorizationFilterTest extends ContainerTest {
     public List<IFixture> fixtures() throws Exception {
         EnvironmentBuilder context = new EnvironmentBuilder(getSession())
                 .client(ClientType.Implicit)
-                .scope("user")
+                .scope(Scope.USER)
                 .redirect("http://example.com/redirect")
                 .referrer("http://example.com/redirect")
                 .authenticator("test")
@@ -99,7 +100,7 @@ public final class OAuth2AuthorizationFilterTest extends ContainerTest {
                 .identity("remote_identity");
 
         // Valid token
-        context.token(OAuthTokenType.Bearer, false, "user", null, null);
+        context.token(OAuthTokenType.Bearer, false, Scope.USER, null, null);
         validBearerToken = context.getToken();
 
         // Valid token
@@ -107,7 +108,7 @@ public final class OAuth2AuthorizationFilterTest extends ContainerTest {
         noScopeBearerToken = context.getToken();
 
         // Expired token.
-        context.token(OAuthTokenType.Bearer, true, "user", null, null);
+        context.token(OAuthTokenType.Bearer, true, Scope.USER, null, null);
         expiredBearerToken = context.getToken();
 
         // Auth token


### PR DESCRIPTION
When creating a new application on a kangaroo server, we would
like to be able to grant the users of that application limited
access to the kangaroo API. In order to accomplish this, we will
make the kangaroo:scopes available directly to each created application;
and to avoid namespace collisions, prefix it with "kangaroo:". Note
that any user, not a member of the admin application, who attempts to
access data on the kangaroo API, should only be able to read data
related to themselves, and should only be able to modify their own
identities.