### PR TITLE
Removed Query Parameter from HTTP response.

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/response/ApiParam.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/response/ApiParam.java
@@ -96,11 +96,6 @@ public final class ApiParam {
     public static final String TOTAL_HEADER = "Total";
 
     /**
-     * Header Name: Query String.
-     */
-    public static final String QUERY_HEADER = "Query";
-
-    /**
      * Query variable: Query String.
      */
     public static final String QUERY_QUERY = "q";

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/response/ListResponseBuilder.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/response/ListResponseBuilder.java
@@ -147,19 +147,6 @@ public final class ListResponseBuilder {
     }
 
     /**
-     * Add a search query to the response.
-     *
-     * @param query The search query to add.
-     * @return This builder.
-     */
-    public ListResponseBuilder query(final String query) {
-        String headerName = ApiParam.QUERY_HEADER;
-        builder.header(headerName, query);
-        addedHeaders.add(headerName);
-        return this;
-    }
-
-    /**
      * Build the response.
      *
      * @return The response.

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/response/ApiParamTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/response/ApiParamTest.java
@@ -62,7 +62,6 @@ public final class ApiParamTest {
 
         Assert.assertEquals("Total", ApiParam.TOTAL_HEADER);
 
-        Assert.assertEquals("Query", ApiParam.QUERY_HEADER);
         Assert.assertEquals("q", ApiParam.QUERY_QUERY);
         Assert.assertEquals("", ApiParam.QUERY_DEFAULT);
 

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/response/ListResponseBuilderTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/response/ListResponseBuilderTest.java
@@ -266,23 +266,6 @@ public final class ListResponseBuilderTest {
     }
 
     /**
-     * Assert that you can apply a search query.
-     *
-     * @throws Exception Should not be thrown.
-     */
-    @Test
-    public void testQuery() throws Exception {
-        ListResponseBuilder b = ListResponseBuilder.builder();
-        b.query("foo");
-        Response response = b.build();
-
-        Assert.assertEquals("foo",
-                response.getHeaderString(ApiParam.QUERY_HEADER));
-        Assert.assertEquals(ApiParam.QUERY_HEADER,
-                response.getHeaderString("Vary"));
-    }
-
-    /**
      * Assert that SortOrder.fromString always works.
      *
      * @throws Exception Should not be thrown.

--- a/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/UserService.java
+++ b/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/UserService.java
@@ -112,7 +112,6 @@ public final class UserService extends AbstractService {
 
         return ListResponseBuilder
                 .builder()
-                .query(queryString)
                 .offset(offset)
                 .limit(limit)
                 .addResult(results)

--- a/kangaroo-servlet-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/UserServiceSearchTest.java
+++ b/kangaroo-servlet-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/UserServiceSearchTest.java
@@ -145,7 +145,6 @@ public final class UserServiceSearchTest extends AbstractResourceTest {
         Assert.assertEquals("1", response.getHeaderString("Total"));
         Assert.assertEquals("0", response.getHeaderString("Offset"));
         Assert.assertEquals("10", response.getHeaderString("Limit"));
-        Assert.assertEquals("Single", response.getHeaderString("Query"));
         Assert.assertEquals(1, results.size());
         Assert.assertEquals(users.get(3).getId(), results.get(0).getId());
     }
@@ -168,7 +167,6 @@ public final class UserServiceSearchTest extends AbstractResourceTest {
         Assert.assertEquals("4", response.getHeaderString("Total"));
         Assert.assertEquals("2", response.getHeaderString("Offset"));
         Assert.assertEquals("10", response.getHeaderString("Limit"));
-        Assert.assertEquals("User", response.getHeaderString("Query"));
         Assert.assertEquals(2, users.size());
     }
 
@@ -190,7 +188,6 @@ public final class UserServiceSearchTest extends AbstractResourceTest {
         Assert.assertEquals("4", response.getHeaderString("Total"));
         Assert.assertEquals("0", response.getHeaderString("Offset"));
         Assert.assertEquals("2", response.getHeaderString("Limit"));
-        Assert.assertEquals("User", response.getHeaderString("Query"));
         Assert.assertEquals(2, users.size());
     }
 
@@ -211,7 +208,6 @@ public final class UserServiceSearchTest extends AbstractResourceTest {
         Assert.assertEquals("2", response.getHeaderString("Total"));
         Assert.assertEquals("0", response.getHeaderString("Offset"));
         Assert.assertEquals("10", response.getHeaderString("Limit"));
-        Assert.assertEquals("Search", response.getHeaderString("Query"));
         Assert.assertEquals(2, results.size());
         Assert.assertEquals(users.get(2).getId(), results.get(0).getId());
         Assert.assertEquals(users.get(3).getId(), results.get(1).getId());
@@ -234,7 +230,6 @@ public final class UserServiceSearchTest extends AbstractResourceTest {
         Assert.assertEquals("0", response.getHeaderString("Total"));
         Assert.assertEquals("0", response.getHeaderString("Offset"));
         Assert.assertEquals("10", response.getHeaderString("Limit"));
-        Assert.assertEquals("FooBar", response.getHeaderString("Query"));
         Assert.assertEquals(0, users.size());
     }
 


### PR DESCRIPTION
There's no real good reason to return this. Additionally, in
some cases there'll be multiple different dimensional parameters
which could influence the query response, which would make
this header inaccurate and misleading.