### PR TITLE
Removed Vary headers.

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/response/ListResponseBuilder.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/response/ListResponseBuilder.java
@@ -17,7 +17,6 @@
 
 package net.krotscheck.kangaroo.common.response;
 
-import java.util.ArrayList;
 import java.util.List;
 import javax.ws.rs.core.Response;
 
@@ -32,11 +31,6 @@ public final class ListResponseBuilder {
      * The wrapped builder.
      */
     private Response.ResponseBuilder builder = Response.ok();
-
-    /**
-     * The list of headers which have been added.
-     */
-    private final List<String> addedHeaders = new ArrayList<>();
 
     /**
      * Create a new personal response builder.
@@ -65,9 +59,7 @@ public final class ListResponseBuilder {
      * @return The builder.
      */
     public ListResponseBuilder limit(final Number limit) {
-        String headerName = ApiParam.LIMIT_HEADER;
-        builder.header(headerName, limit.longValue());
-        addedHeaders.add(headerName);
+        builder.header(ApiParam.LIMIT_HEADER, limit.longValue());
         return this;
     }
 
@@ -78,9 +70,7 @@ public final class ListResponseBuilder {
      * @return The builder.
      */
     public ListResponseBuilder total(final Number total) {
-        String headerName = ApiParam.TOTAL_HEADER;
-        builder.header(headerName, total.longValue());
-        addedHeaders.add(headerName);
+        builder.header(ApiParam.TOTAL_HEADER, total.longValue());
         return this;
     }
 
@@ -91,9 +81,7 @@ public final class ListResponseBuilder {
      * @return The builder.
      */
     public ListResponseBuilder total(final Object total) {
-        String headerName = ApiParam.TOTAL_HEADER;
-        builder.header(headerName, Long.valueOf(total.toString()));
-        addedHeaders.add(headerName);
+        builder.header(ApiParam.TOTAL_HEADER, Long.valueOf(total.toString()));
         return this;
     }
 
@@ -104,9 +92,7 @@ public final class ListResponseBuilder {
      * @return The builder.
      */
     public ListResponseBuilder offset(final Number offset) {
-        String headerName = ApiParam.OFFSET_HEADER;
-        builder.header(headerName, offset.longValue());
-        addedHeaders.add(headerName);
+        builder.header(ApiParam.OFFSET_HEADER, offset.longValue());
         return this;
     }
 
@@ -117,9 +103,7 @@ public final class ListResponseBuilder {
      * @return The builder.
      */
     public ListResponseBuilder sort(final String sort) {
-        String headerName = ApiParam.SORT_HEADER;
-        builder.header(headerName, sort);
-        addedHeaders.add(headerName);
+        builder.header(ApiParam.SORT_HEADER, sort);
         return this;
     }
 
@@ -130,9 +114,7 @@ public final class ListResponseBuilder {
      * @return The builder.
      */
     public ListResponseBuilder order(final SortOrder order) {
-        String headerName = ApiParam.ORDER_HEADER;
-        builder.header(headerName, order.toString());
-        addedHeaders.add(headerName);
+        builder.header(ApiParam.ORDER_HEADER, order.toString());
         return this;
     }
 
@@ -153,7 +135,6 @@ public final class ListResponseBuilder {
      */
     public Response build() {
         // Apply the vary headers
-        builder.header("Vary", String.join(",", addedHeaders));
         return builder.build();
     }
 }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/response/ListResponseBuilderTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/response/ListResponseBuilderTest.java
@@ -57,8 +57,6 @@ public final class ListResponseBuilderTest {
 
         Assert.assertEquals("10",
                 response.getHeaderString(ApiParam.OFFSET_HEADER));
-        Assert.assertEquals(ApiParam.OFFSET_HEADER,
-                response.getHeaderString("Vary"));
     }
 
     /**
@@ -74,8 +72,6 @@ public final class ListResponseBuilderTest {
 
         Assert.assertEquals("10",
                 response.getHeaderString(ApiParam.OFFSET_HEADER));
-        Assert.assertEquals(ApiParam.OFFSET_HEADER,
-                response.getHeaderString("Vary"));
     }
 
     /**
@@ -91,8 +87,6 @@ public final class ListResponseBuilderTest {
 
         Assert.assertEquals("10",
                 response.getHeaderString(ApiParam.OFFSET_HEADER));
-        Assert.assertEquals(ApiParam.OFFSET_HEADER,
-                response.getHeaderString("Vary"));
     }
 
     /**
@@ -108,8 +102,6 @@ public final class ListResponseBuilderTest {
 
         Assert.assertEquals("10",
                 response.getHeaderString(ApiParam.LIMIT_HEADER));
-        Assert.assertEquals(ApiParam.LIMIT_HEADER,
-                response.getHeaderString("Vary"));
     }
 
     /**
@@ -125,8 +117,6 @@ public final class ListResponseBuilderTest {
 
         Assert.assertEquals("10",
                 response.getHeaderString(ApiParam.LIMIT_HEADER));
-        Assert.assertEquals(ApiParam.LIMIT_HEADER,
-                response.getHeaderString("Vary"));
     }
 
     /**
@@ -142,8 +132,6 @@ public final class ListResponseBuilderTest {
 
         Assert.assertEquals("10",
                 response.getHeaderString(ApiParam.LIMIT_HEADER));
-        Assert.assertEquals(ApiParam.LIMIT_HEADER,
-                response.getHeaderString("Vary"));
     }
 
     /**
@@ -159,8 +147,6 @@ public final class ListResponseBuilderTest {
 
         Assert.assertEquals("10",
                 response.getHeaderString(ApiParam.TOTAL_HEADER));
-        Assert.assertEquals(ApiParam.TOTAL_HEADER,
-                response.getHeaderString("Vary"));
     }
 
     /**
@@ -176,8 +162,6 @@ public final class ListResponseBuilderTest {
 
         Assert.assertEquals("10",
                 response.getHeaderString(ApiParam.TOTAL_HEADER));
-        Assert.assertEquals(ApiParam.TOTAL_HEADER,
-                response.getHeaderString("Vary"));
     }
 
     /**
@@ -193,8 +177,6 @@ public final class ListResponseBuilderTest {
 
         Assert.assertEquals("10",
                 response.getHeaderString(ApiParam.TOTAL_HEADER));
-        Assert.assertEquals(ApiParam.TOTAL_HEADER,
-                response.getHeaderString("Vary"));
     }
 
     /**
@@ -210,8 +192,6 @@ public final class ListResponseBuilderTest {
 
         Assert.assertEquals("10",
                 response.getHeaderString(ApiParam.TOTAL_HEADER));
-        Assert.assertEquals(ApiParam.TOTAL_HEADER,
-                response.getHeaderString("Vary"));
     }
 
     /**
@@ -227,8 +207,6 @@ public final class ListResponseBuilderTest {
 
         Assert.assertEquals("foo",
                 response.getHeaderString(ApiParam.SORT_HEADER));
-        Assert.assertEquals(ApiParam.SORT_HEADER,
-                response.getHeaderString("Vary"));
     }
 
     /**
@@ -244,8 +222,6 @@ public final class ListResponseBuilderTest {
 
         Assert.assertEquals("DESC",
                 response.getHeaderString(ApiParam.ORDER_HEADER));
-        Assert.assertEquals(ApiParam.ORDER_HEADER,
-                response.getHeaderString("Vary"));
     }
 
     /**
@@ -261,8 +237,6 @@ public final class ListResponseBuilderTest {
 
         Assert.assertEquals("DESC",
                 response.getHeaderString(ApiParam.ORDER_HEADER));
-        Assert.assertEquals(ApiParam.ORDER_HEADER,
-                response.getHeaderString("Vary"));
     }
 
     /**


### PR DESCRIPTION
The vary headers are intended to indicate to the browser which
headers in the Request should trigger a cache refresh. Pointing out
headers in the response is useless.