### PR TITLE
PasswordUtil no longer throws exceptions.

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/util/PasswordUtil.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/util/PasswordUtil.java
@@ -58,23 +58,23 @@ public final class PasswordUtil {
      * @param password The password.
      * @param salt     The salt.
      * @return The hash.
-     * @throws NoSuchAlgorithmException Thrown if the encryption algorithm is
-     *                                  not available.
-     * @throws InvalidKeySpecException  Thrown if the key spec is not
-     *                                  available.
      */
     public static String hash(final String password,
-                              final String salt)
-            throws NoSuchAlgorithmException, InvalidKeySpecException {
+                              final String salt) {
         char[] chars = password.toCharArray();
         byte[] saltBytes = Base64.decodeBase64(salt);
         int iterations = 1000;
         PBEKeySpec spec = new PBEKeySpec(chars, saltBytes, iterations, 64 * 8);
 
-        SecretKeyFactory skf =
-                SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1");
-        byte[] encodedPassword = skf.generateSecret(spec).getEncoded();
-        return Base64.encodeBase64String(encodedPassword);
+        try {
+            SecretKeyFactory skf =
+                    SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1");
+            byte[] encodedPassword = skf.generateSecret(spec).getEncoded();
+            return Base64.encodeBase64String(encodedPassword);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            // If you don't have encryption, you don't get to play.
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/util/PasswordUtilTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/util/PasswordUtilTest.java
@@ -30,6 +30,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.security.NoSuchAlgorithmException;
+import javax.crypto.SecretKeyFactory;
 
 import static org.mockito.Mockito.when;
 
@@ -83,6 +84,25 @@ public final class PasswordUtilTest {
 
         Assert.assertTrue(PasswordUtil.isValid(password, salt1, hash1));
         Assert.assertFalse(PasswordUtil.isValid(password, salt2, hash1));
+    }
+
+    /**
+     * Test a nonexistent algorithm cannot validate a hash.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test(expected = RuntimeException.class)
+    @PrepareForTest(SecretKeyFactory.class)
+    public void testCannotFindAlgoritm() throws Exception {
+        PowerMockito.mockStatic(SecretKeyFactory.class);
+
+        when(SecretKeyFactory.getInstance(Matchers.anyString()))
+                .thenThrow(NoSuchAlgorithmException.class);
+
+        String password = RandomStringUtils.random(40);
+        String salt1 = PasswordUtil.createSalt();
+
+        PasswordUtil.hash(password, salt1);
     }
 
     /**

--- a/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/servlet/FirstRunContainerLifecycleListener.java
+++ b/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/servlet/FirstRunContainerLifecycleListener.java
@@ -37,8 +37,6 @@ import org.hibernate.Transaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.security.NoSuchAlgorithmException;
-import java.security.spec.InvalidKeySpecException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
@@ -96,83 +94,78 @@ public final class FirstRunContainerLifecycleListener
         logger.info("Bootstrapping Application");
 
         Session s = sessionFactory.openSession();
-        try {
-            // Create the application.
-            Application servletApp = new Application();
-            servletApp.setName("Kangaroo");
 
-            // Create the application's client.
-            Client servletClient = new Client();
-            servletClient.setApplication(servletApp);
-            servletClient.setName("Kangaroo Web UI");
-            servletClient.setType(ClientType.OwnerCredentials);
+        // Create the application.
+        Application servletApp = new Application();
+        servletApp.setName("Kangaroo");
 
-            // Create the password authenticator
-            Authenticator passwordAuth = new Authenticator();
-            passwordAuth.setType("password");
-            passwordAuth.setClient(servletClient);
+        // Create the application's client.
+        Client servletClient = new Client();
+        servletClient.setApplication(servletApp);
+        servletClient.setName("Kangaroo Web UI");
+        servletClient.setType(ClientType.OwnerCredentials);
 
-            // Create the scopes
-            List<ApplicationScope> scopes = new ArrayList<>();
-            for (String scope : Scope.allScopes()) {
-                ApplicationScope newScope = new ApplicationScope();
-                newScope.setApplication(servletApp);
-                newScope.setName(scope);
-                scopes.add(newScope);
-            }
+        // Create the password authenticator
+        Authenticator passwordAuth = new Authenticator();
+        passwordAuth.setType("password");
+        passwordAuth.setClient(servletClient);
 
-            // Create the roles.
-            Role adminRole = new Role();
-            adminRole.setName("admin");
-            adminRole.setApplication(servletApp);
-            adminRole.setScopes(scopes);
-
-            Role memberRole = new Role();
-            memberRole.setName("member");
-            memberRole.setApplication(servletApp);
-            memberRole.setScopes(scopes);
-
-            // Create the first admin
-            User adminUser = new User();
-            adminUser.setApplication(servletApp);
-            adminUser.setRole(adminRole);
-
-            // Create the admin's login identity.
-            UserIdentity adminIdentity = new UserIdentity();
-            adminIdentity.setAuthenticator(passwordAuth);
-            adminIdentity.setRemoteId("admin");
-            adminIdentity.setUser(adminUser);
-            adminIdentity.setSalt(PasswordUtil.createSalt());
-            adminIdentity.setPassword(
-                    PasswordUtil.hash("admin", adminIdentity.getSalt()));
-
-            Transaction t = s.beginTransaction();
-            s.save(servletApp);
-            s.save(servletClient);
-            s.save(passwordAuth);
-            scopes.forEach(s::save);
-            s.save(adminRole);
-            s.save(memberRole);
-            s.save(adminUser);
-            s.save(adminIdentity);
-            t.commit();
-
-            logger.info(String.format("Application ID: %s",
-                    servletApp.getId()));
-            logger.info(String.format("Admin User ID: %s",
-                    adminUser.getId()));
-            logger.info("Application created. Let's rock!");
-
-            // Refresh the servlet app, populating all persisted references.
-            s.refresh(servletApp);
-
-            return servletApp;
-        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
-            throw new RuntimeException("Unable to persist kangaroo admin "
-                    + "application.", e);
-        } finally {
-            s.close();
+        // Create the scopes
+        List<ApplicationScope> scopes = new ArrayList<>();
+        for (String scope : Scope.allScopes()) {
+            ApplicationScope newScope = new ApplicationScope();
+            newScope.setApplication(servletApp);
+            newScope.setName(scope);
+            scopes.add(newScope);
         }
+
+        // Create the roles.
+        Role adminRole = new Role();
+        adminRole.setName("admin");
+        adminRole.setApplication(servletApp);
+        adminRole.setScopes(scopes);
+
+        Role memberRole = new Role();
+        memberRole.setName("member");
+        memberRole.setApplication(servletApp);
+        memberRole.setScopes(scopes);
+
+        // Create the first admin
+        User adminUser = new User();
+        adminUser.setApplication(servletApp);
+        adminUser.setRole(adminRole);
+
+        // Create the admin's login identity.
+        UserIdentity adminIdentity = new UserIdentity();
+        adminIdentity.setAuthenticator(passwordAuth);
+        adminIdentity.setRemoteId("admin");
+        adminIdentity.setUser(adminUser);
+        adminIdentity.setSalt(PasswordUtil.createSalt());
+        adminIdentity.setPassword(
+                PasswordUtil.hash("admin", adminIdentity.getSalt()));
+
+        Transaction t = s.beginTransaction();
+        s.save(servletApp);
+        s.save(servletClient);
+        s.save(passwordAuth);
+        scopes.forEach(s::save);
+        s.save(adminRole);
+        s.save(memberRole);
+        s.save(adminUser);
+        s.save(adminIdentity);
+        t.commit();
+
+        logger.info(String.format("Application ID: %s",
+                servletApp.getId()));
+        logger.info(String.format("Admin User ID: %s",
+                adminUser.getId()));
+        logger.info("Application created. Let's rock!");
+
+        // Refresh the servlet app, populating all persisted references.
+        s.refresh(servletApp);
+        s.close();
+
+        return servletApp;
     }
 
     /**

--- a/kangaroo-servlet-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/servlet/FirstRunContainerLifecycleListenerTest.java
+++ b/kangaroo-servlet-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/servlet/FirstRunContainerLifecycleListenerTest.java
@@ -22,7 +22,6 @@ import net.krotscheck.kangaroo.database.entity.Application;
 import net.krotscheck.kangaroo.servlet.admin.v1.servlet.FirstRunContainerLifecycleListener.Binder;
 import net.krotscheck.kangaroo.test.DatabaseTest;
 import net.krotscheck.kangaroo.test.IFixture;
-import net.krotscheck.kangaroo.util.PasswordUtil;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.MapConfiguration;
 import org.glassfish.hk2.api.ActiveDescriptor;
@@ -36,16 +35,8 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Matchers;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.security.NoSuchAlgorithmException;
-import java.security.spec.InvalidKeySpecException;
 import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
@@ -56,9 +47,6 @@ import javax.inject.Singleton;
  *
  * @author Michael Krotscheck
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(PasswordUtil.class)
-@PowerMockIgnore({"javax.*", "com.sun.*", "org.xml.*"})
 public final class FirstRunContainerLifecycleListenerTest
         extends DatabaseTest {
 
@@ -120,55 +108,6 @@ public final class FirstRunContainerLifecycleListenerTest
 
         // Cleanup
         testConfig.clear();
-    }
-
-    /**
-     * Assert that a fatal exception is thrown when the password util blows up.
-     *
-     * @throws Exception Runtime exception thrown to stop servlet
-     *                   initialization.
-     */
-    @Test(expected = RuntimeException.class)
-    public void assertBootstrapException() throws Exception {
-        Configuration testConfig = new HibernateConfiguration(
-                getSessionFactory(), ServletConfigFactory.GROUP_NAME);
-        SessionFactory mockFactory = Mockito.mock(SessionFactory.class);
-        Container mockContainer = Mockito.mock(Container.class);
-
-        PowerMockito.mockStatic(PasswordUtil.class);
-        Mockito.when(
-                PasswordUtil.hash(Matchers.anyString(), Matchers.anyString()))
-                .thenThrow(NoSuchAlgorithmException.class);
-
-        ContainerLifecycleListener l =
-                new FirstRunContainerLifecycleListener(
-                        mockFactory, testConfig);
-        l.onStartup(mockContainer);
-    }
-
-    /**
-     * Assert that a fatal exception is thrown when the password util blows
-     * up with yet another error.
-     *
-     * @throws Exception Runtime exception thrown to stop servlet
-     *                   initialization.
-     */
-    @Test(expected = RuntimeException.class)
-    public void assertBootstrapInvalidKeyException() throws Exception {
-        Configuration testConfig = new HibernateConfiguration(
-                getSessionFactory(), ServletConfigFactory.GROUP_NAME);
-        SessionFactory mockFactory = Mockito.mock(SessionFactory.class);
-        Container mockContainer = Mockito.mock(Container.class);
-
-        PowerMockito.mockStatic(PasswordUtil.class);
-        Mockito.when(
-                PasswordUtil.hash(Matchers.anyString(), Matchers.anyString()))
-                .thenThrow(InvalidKeySpecException.class);
-
-        ContainerLifecycleListener l =
-                new FirstRunContainerLifecycleListener(
-                        mockFactory, testConfig);
-        l.onStartup(mockContainer);
     }
 
     /**


### PR DESCRIPTION
Or rather, PasswordUtil now throws runtime exceptions. Handling
coverage for a nonexistent hash algorithm was problematic. Since
proper password hashing is a requirement for effective authentication,
we've now made it a requirement.