### PR TITLE
Reduced logging output.

### DIFF
--- a/kangaroo-test/src/main/java/net/krotscheck/kangaroo/test/ContainerTest.java
+++ b/kangaroo-test/src/main/java/net/krotscheck/kangaroo/test/ContainerTest.java
@@ -25,7 +25,6 @@ import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
-import org.glassfish.jersey.test.TestProperties;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.junit.After;
@@ -92,10 +91,6 @@ public abstract class ContainerTest
      */
     @Override
     protected final Application configure() {
-        // General configuration.
-        enable(TestProperties.LOG_TRAFFIC);
-        enable(TestProperties.DUMP_ENTITY);
-
         ResourceConfig config = createApplication();
         config.register(this);
 

--- a/pom.xml
+++ b/pom.xml
@@ -480,6 +480,12 @@
       <version>${slf4j.version}</version>
     </dependency>
 
+    <!-- special dependency to fix liquibase's logging fetish -->
+    <dependency>
+      <groupId>com.mattbertolini</groupId>
+      <artifactId>liquibase-slf4j</artifactId>
+      <version>1.2.1</version>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>


### PR DESCRIPTION
Liquibase is now piped into slf4j, and ContainerTest no longer makes
assumptions about how we'd like to log things.