### PR TITLE
Changed Principal to OAuthToken

### DIFF
--- a/kangaroo-database/src/main/java/net/krotscheck/kangaroo/database/entity/OAuthToken.java
+++ b/kangaroo-database/src/main/java/net/krotscheck/kangaroo/database/entity/OAuthToken.java
@@ -22,6 +22,7 @@ import net.krotscheck.kangaroo.database.deserializer.AbstractEntityReferenceDese
 import org.hibernate.annotations.SortNatural;
 
 import java.net.URI;
+import java.security.Principal;
 import java.util.Calendar;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -46,7 +47,7 @@ import javax.persistence.Table;
  */
 @Entity
 @Table(name = "oauth_tokens")
-public final class OAuthToken extends AbstractEntity {
+public final class OAuthToken extends AbstractEntity implements Principal {
 
     /**
      * The authenticated user identity.
@@ -252,6 +253,22 @@ public final class OAuthToken extends AbstractEntity {
      */
     public void setRedirect(final URI redirect) {
         this.redirect = redirect;
+    }
+
+    /**
+     * Returns the name of this principal. In our case, this will either be
+     * the remote ID of the user identity, or the human readable name of the
+     * OAuth Client application (in the case of a ClientCredentials Client).
+     *
+     * @return the name of this principal.
+     */
+    @Override
+    public String getName() {
+        if (getClient().getType().equals(ClientType.ClientCredentials)) {
+            return getClient().getName();
+        } else {
+            return getIdentity().getRemoteId();
+        }
     }
 
     /**

--- a/kangaroo-database/src/main/java/net/krotscheck/kangaroo/database/entity/UserIdentity.java
+++ b/kangaroo-database/src/main/java/net/krotscheck/kangaroo/database/entity/UserIdentity.java
@@ -31,7 +31,6 @@ import org.hibernate.search.annotations.Index;
 import org.hibernate.search.annotations.IndexedEmbedded;
 import org.hibernate.search.annotations.Store;
 
-import java.security.Principal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -58,7 +57,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "user_identities")
 @Analyzer(definition = "entity_analyzer")
-public final class UserIdentity extends AbstractEntity implements Principal {
+public final class UserIdentity extends AbstractEntity {
 
     /**
      * The user to whom this identity record belongs.
@@ -196,17 +195,6 @@ public final class UserIdentity extends AbstractEntity implements Principal {
      */
     public void setClaims(final Map<String, String> claims) {
         this.claims = new HashMap<>(claims);
-    }
-
-    /**
-     * Returns the name of this principal, in our case the remote ID.
-     *
-     * @return the name of this principal.
-     */
-    @Override
-    @JsonIgnore
-    public String getName() {
-        return getRemoteId();
     }
 
     /**

--- a/kangaroo-database/src/test/java/net/krotscheck/kangaroo/database/entity/OAuthTokenTest.java
+++ b/kangaroo-database/src/test/java/net/krotscheck/kangaroo/database/entity/OAuthTokenTest.java
@@ -132,6 +132,43 @@ public final class OAuthTokenTest {
     }
 
     /**
+     * Test getting the principal name for a regular user.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testGetNameUserIdentity() throws Exception {
+        OAuthToken token = new OAuthToken();
+        UserIdentity u = new UserIdentity();
+        u.setRemoteId("RemoteId");
+
+        Client c = new Client();
+        c.setType(ClientType.Implicit);
+        c.setName("foo");
+
+        token.setClient(c);
+        token.setIdentity(u);
+
+        Assert.assertEquals(u.getRemoteId(), token.getName());
+    }
+
+    /**
+     * Test getting the principal name for a credentials client.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testGetNameClient() throws Exception {
+        OAuthToken token = new OAuthToken();
+        Client c = new Client();
+        c.setType(ClientType.ClientCredentials);
+        c.setName("foo");
+
+        token.setClient(c);
+        Assert.assertEquals(c.getName(), token.getName());
+    }
+
+    /**
      * Test get/set scope list.
      */
     @Test

--- a/kangaroo-database/src/test/java/net/krotscheck/kangaroo/database/entity/UserIdentityTest.java
+++ b/kangaroo-database/src/test/java/net/krotscheck/kangaroo/database/entity/UserIdentityTest.java
@@ -101,18 +101,6 @@ public final class UserIdentityTest {
     }
 
     /**
-     * Test the name.
-     */
-    @Test
-    public void testGetName() {
-        UserIdentity identity = new UserIdentity();
-
-        Assert.assertNull(identity.getName());
-        identity.setRemoteId("foo");
-        Assert.assertEquals("foo", identity.getName());
-    }
-
-    /**
      * Test getting/setting the claims.
      */
     @Test

--- a/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/filter/OAuth2AuthorizationFilter.java
+++ b/kangaroo-servlet-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/filter/OAuth2AuthorizationFilter.java
@@ -20,7 +20,6 @@ package net.krotscheck.kangaroo.servlet.admin.v1.filter;
 import net.krotscheck.kangaroo.database.entity.ApplicationScope;
 import net.krotscheck.kangaroo.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.database.entity.OAuthTokenType;
-import net.krotscheck.kangaroo.database.entity.UserIdentity;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
@@ -146,7 +145,7 @@ public final class OAuth2AuthorizationFilter implements ContainerRequestFilter {
         /**
          * The principal.
          */
-        private final UserIdentity principal;
+        private final OAuthToken principal;
 
         /**
          * The principal.
@@ -163,7 +162,7 @@ public final class OAuth2AuthorizationFilter implements ContainerRequestFilter {
         public OAuthTokenContext(final OAuthToken token,
                                  final Boolean isSecure) {
             // Materialize the scopes and the user identity.
-            principal = token.getIdentity();
+            principal = token;
             scopes = token.getScopes();
             secure = isSecure;
         }


### PR DESCRIPTION
The Client Credentials client type is able to issue oauth tokens
without an assigned User Identity. To properly support this, we
need to switch the user principal from being the UserIdentity,
to being the OAuthToken itself.