### PR TITLE
Changed OAuthToken.expiresIn from long to Long.

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/OAuthToken.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/OAuthToken.java
@@ -19,6 +19,7 @@
 package net.krotscheck.kangaroo.database.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import net.krotscheck.kangaroo.database.deserializer.AbstractEntityReferenceDeserializer;
 import org.hibernate.annotations.SortNatural;
 
@@ -86,7 +87,7 @@ public final class OAuthToken extends AbstractEntity implements Principal {
      */
     @Basic(optional = false)
     @Column(name = "expiresIn", nullable = false)
-    private long expiresIn = 600;
+    private Long expiresIn = (long) 600;
 
     /**
      * Authorization Codes must keep track of the redirect they were issued
@@ -189,7 +190,7 @@ public final class OAuthToken extends AbstractEntity implements Principal {
      *
      * @return The lifetime of the token, in seconds.
      */
-    public long getExpiresIn() {
+    public Long getExpiresIn() {
         return expiresIn;
     }
 
@@ -198,6 +199,25 @@ public final class OAuthToken extends AbstractEntity implements Principal {
      *
      * @param expiresIn The time, in seconds.
      */
+    public void setExpiresIn(final Number expiresIn) {
+        this.expiresIn = expiresIn.longValue();
+    }
+
+    /**
+     * Set the expiration time, in seconds, from the creation date.
+     *
+     * @param expiresIn The time, in seconds.
+     */
+    public void setExpiresIn(final int expiresIn) {
+        this.expiresIn = (long) expiresIn;
+    }
+
+    /**
+     * Set the expiration time, in seconds, from the creation date.
+     *
+     * @param expiresIn The time, in seconds.
+     */
+    @JsonSetter
     public void setExpiresIn(final long expiresIn) {
         this.expiresIn = expiresIn;
     }
@@ -234,7 +254,7 @@ public final class OAuthToken extends AbstractEntity implements Principal {
 
         Calendar now = Calendar.getInstance();
         Calendar expireDate = (Calendar) getCreatedDate().clone();
-        expireDate.add(Calendar.SECOND, (int) getExpiresIn());
+        expireDate.add(Calendar.SECOND, getExpiresIn().intValue());
         return now.after(expireDate);
     }
 

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/OAuthTokenTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/OAuthTokenTest.java
@@ -96,9 +96,17 @@ public final class OAuthTokenTest {
         OAuthToken c = new OAuthToken();
 
         // Default
-        Assert.assertEquals(600, c.getExpiresIn());
+        Assert.assertEquals(600, c.getExpiresIn().longValue());
         c.setExpiresIn(100);
-        Assert.assertEquals(100, c.getExpiresIn());
+        Assert.assertEquals(100, c.getExpiresIn().longValue());
+        c.setExpiresIn((long) 200);
+        Assert.assertEquals(200, c.getExpiresIn().longValue());
+        c.setExpiresIn(Double.valueOf(2.222));
+        Assert.assertEquals(2, c.getExpiresIn().longValue());
+        c.setExpiresIn(Integer.valueOf(22));
+        Assert.assertEquals(22, c.getExpiresIn().longValue());
+        c.setExpiresIn(Long.valueOf(100));
+        Assert.assertEquals(100, c.getExpiresIn().longValue());
     }
 
     /**
@@ -203,20 +211,20 @@ public final class OAuthTokenTest {
 
         // Test UTC Non-Expired Token.
         token.setCreatedDate(recentUTC);
-        token.setExpiresIn(103);
+        token.setExpiresIn((long) 103);
         Assert.assertFalse(token.isExpired());
 
         // Expire the token.
-        token.setExpiresIn(99);
+        token.setExpiresIn((long) 99);
         Assert.assertTrue(token.isExpired());
 
         // Test Non-UTC Non-Expired Token.
         token.setCreatedDate(recentPDT);
-        token.setExpiresIn(103);
+        token.setExpiresIn((long) 103);
         Assert.assertFalse(token.isExpired());
 
         // Expire the token.
-        token.setExpiresIn(99);
+        token.setExpiresIn((long) 99);
         Assert.assertTrue(token.isExpired());
     }
 
@@ -265,7 +273,7 @@ public final class OAuthTokenTest {
                 token.getTokenType().toString(),
                 node.get("tokenType").asText());
         Assert.assertEquals(
-                token.getExpiresIn(),
+                token.getExpiresIn().longValue(),
                 node.get("expiresIn").asLong());
         Assert.assertEquals(
                 token.getRedirect().toString(),
@@ -320,7 +328,7 @@ public final class OAuthTokenTest {
                 c.getTokenType().toString(),
                 node.get("tokenType").asText());
         Assert.assertEquals(
-                c.getExpiresIn(),
+                c.getExpiresIn().longValue(),
                 node.get("expiresIn").asLong());
         Assert.assertEquals(
                 c.getRedirect().toString(),

--- a/kangaroo-servlet-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/TokenResponseEntityTest.java
+++ b/kangaroo-servlet-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/TokenResponseEntityTest.java
@@ -55,7 +55,7 @@ public final class TokenResponseEntityTest {
 
         TokenResponseEntity entity = TokenResponseEntity.factory(token, state);
         Assert.assertEquals(token.getId(), entity.getAccessToken());
-        Assert.assertEquals(token.getExpiresIn(),
+        Assert.assertEquals(token.getExpiresIn().longValue(),
                 (long) entity.getExpiresIn());
         Assert.assertEquals("Bearer", entity.getTokenType().toString());
         Assert.assertEquals("debug test", entity.getScope());
@@ -91,7 +91,7 @@ public final class TokenResponseEntityTest {
         TokenResponseEntity entity = TokenResponseEntity.factory(token,
                 refresh, state);
         Assert.assertEquals(token.getId(), entity.getAccessToken());
-        Assert.assertEquals(token.getExpiresIn(),
+        Assert.assertEquals(token.getExpiresIn().longValue(),
                 (long) entity.getExpiresIn());
         Assert.assertEquals("Bearer", entity.getTokenType().toString());
         Assert.assertEquals("debug test", entity.getScope());
@@ -121,7 +121,7 @@ public final class TokenResponseEntityTest {
         TokenResponseEntity entity = TokenResponseEntity.factory(token,
                 refresh, state);
         Assert.assertEquals(token.getId(), entity.getAccessToken());
-        Assert.assertEquals(token.getExpiresIn(),
+        Assert.assertEquals(token.getExpiresIn().longValue(),
                 (long) entity.getExpiresIn());
         Assert.assertEquals("Bearer", entity.getTokenType().toString());
         Assert.assertNull(entity.getScope());

--- a/kangaroo-servlet-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/grant/RefreshTokenGrantHandlerTest.java
+++ b/kangaroo-servlet-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/grant/RefreshTokenGrantHandlerTest.java
@@ -186,7 +186,7 @@ public final class RefreshTokenGrantHandlerTest
         OAuthToken newRefresh = session.get(OAuthToken.class,
                 token.getRefreshToken());
         Assert.assertEquals((long) ClientConfig.REFRESH_TOKEN_EXPIRES_DEFAULT,
-                newRefresh.getExpiresIn());
+                newRefresh.getExpiresIn().longValue());
         Assert.assertEquals(OAuthTokenType.Refresh, newRefresh.getTokenType());
         Assert.assertEquals(token.getAccessToken(),
                 newRefresh.getAuthToken().getId());
@@ -225,7 +225,7 @@ public final class RefreshTokenGrantHandlerTest
         OAuthToken newRefresh = session.get(OAuthToken.class,
                 token.getRefreshToken());
         Assert.assertEquals((long) ClientConfig.REFRESH_TOKEN_EXPIRES_DEFAULT,
-                newRefresh.getExpiresIn());
+                newRefresh.getExpiresIn().longValue());
         Assert.assertEquals(OAuthTokenType.Refresh, newRefresh.getTokenType());
         Assert.assertEquals(token.getAccessToken(),
                 newRefresh.getAuthToken().getId());
@@ -404,7 +404,7 @@ public final class RefreshTokenGrantHandlerTest
         OAuthToken newRefresh = session.get(OAuthToken.class,
                 token.getRefreshToken());
         Assert.assertEquals((long) ClientConfig.REFRESH_TOKEN_EXPIRES_DEFAULT,
-                newRefresh.getExpiresIn());
+                newRefresh.getExpiresIn().longValue());
         Assert.assertEquals(OAuthTokenType.Refresh, newRefresh.getTokenType());
         Assert.assertEquals(token.getAccessToken(),
                 newRefresh.getAuthToken().getId());
@@ -444,7 +444,7 @@ public final class RefreshTokenGrantHandlerTest
         OAuthToken newRefresh = session.get(OAuthToken.class,
                 token.getRefreshToken());
         Assert.assertEquals((long) ClientConfig.REFRESH_TOKEN_EXPIRES_DEFAULT,
-                newRefresh.getExpiresIn());
+                newRefresh.getExpiresIn().longValue());
         Assert.assertEquals(OAuthTokenType.Refresh, newRefresh.getTokenType());
         Assert.assertEquals(token.getAccessToken(),
                 newRefresh.getAuthToken().getId());


### PR DESCRIPTION
This patch changes the stored datatype to the object Long, rather
than the type long, and adds convenience setters for other non-long
values.