### PR TITLE
Ported knet utilities into kangaroo-common

### DIFF
--- a/kangaroo-common/pom.xml
+++ b/kangaroo-common/pom.xml
@@ -142,6 +142,10 @@
       <groupId>org.hibernate.javax.persistence</groupId>
       <artifactId>hibernate-jpa-2.1-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.transaction</groupId>
+      <artifactId>jta</artifactId>
+    </dependency>
 
     <!-- Hibernate Validation -->
     <dependency>
@@ -159,12 +163,6 @@
     <dependency>
       <groupId>org.glassfish.web</groupId>
       <artifactId>javax.el</artifactId>
-    </dependency>
-
-    <!-- Jersey2 Toolkit -->
-    <dependency>
-      <groupId>net.krotscheck.jersey2</groupId>
-      <artifactId>jersey2-hibernate</artifactId>
     </dependency>
 
     <!-- H2 database, used for testing. -->
@@ -197,6 +195,10 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/HibernateFeature.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/HibernateFeature.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate;
+
+
+import net.krotscheck.kangaroo.common.hibernate.factory.FulltextSearchFactoryFactory;
+import net.krotscheck.kangaroo.common.hibernate.factory.FulltextSessionFactory;
+import net.krotscheck.kangaroo.common.hibernate.factory.HibernateServiceRegistryFactory;
+import net.krotscheck.kangaroo.common.hibernate.factory.HibernateSessionFactory;
+import net.krotscheck.kangaroo.common.hibernate.factory.HibernateSessionFactoryFactory;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+/**
+ * This jersey2 feature will ensure that there is always a hibernate session
+ * available in the current request context. It is important to keep mind of
+ * scope here: Sessions are scoped by request, while the SessionFactory is
+ * scoped as a singleton. In other words, if you need a session in a context
+ * lifecycle listener, then you should construct it by injecting the
+ * SessionFactory first.
+ *
+ * @author Michael Krotscheck
+ */
+public final class HibernateFeature implements Feature {
+
+    /**
+     * Register the HibernateFeature with the current application context.
+     *
+     * @param context The application context.
+     * @return Always true.
+     */
+    @Override
+    public boolean configure(final FeatureContext context) {
+
+        // Hibernate configuration.
+        context.register(new HibernateSessionFactory.Binder());
+        context.register(new HibernateSessionFactoryFactory.Binder());
+        context.register(new HibernateServiceRegistryFactory.Binder());
+        context.register(new FulltextSearchFactoryFactory.Binder());
+        context.register(new FulltextSessionFactory.Binder());
+
+        return true;
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/context/SearchIndexContextListener.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/context/SearchIndexContextListener.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate.context;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.service.ServiceRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+/**
+ * This context listener will rebuild the hibernate search index based on the
+ * configured connector available in hibernate.cfg.xml. It is provided as a
+ * servlet context listener (rather than a container context listener), as
+ * deploying multiple containers may be deployed in the same artifact. This way,
+ * the index is only reconstructed once.
+ *
+ * @author Michael Krotscheck
+ */
+public final class SearchIndexContextListener
+        implements ServletContextListener {
+
+    /**
+     * Logger instance.
+     */
+    private static Logger logger =
+            LoggerFactory.getLogger(SearchIndexContextListener.class);
+
+    /**
+     * Create a session factory given the current configuration method.
+     *
+     * @return A constructed session factory.
+     */
+    protected SessionFactory createSessionFactory() {
+        // Set up a service registry.
+        StandardServiceRegistryBuilder b = new StandardServiceRegistryBuilder();
+
+        // configures settings from hibernate.cfg.xml
+        ServiceRegistry registry = b.configure().build();
+
+        // Build the session factory.
+        return new MetadataSources(registry)
+                .buildMetadata()
+                .buildSessionFactory();
+    }
+
+    /**
+     * Rebuild the search index during context initialization.
+     *
+     * @param servletContextEvent The context event (not really used).
+     */
+    @Override
+    public void contextInitialized(
+            final ServletContextEvent servletContextEvent) {
+        logger.info("Rebuilding Search Index...");
+
+        // Build the session factory.
+        SessionFactory factory = createSessionFactory();
+
+        // Build the hibernate session.
+        Session session = factory.openSession();
+
+        // Create the fulltext session.
+        FullTextSession fullTextSession = Search.getFullTextSession(session);
+
+        try {
+            fullTextSession
+                    .createIndexer()
+                    .startAndWait();
+        } catch (InterruptedException e) {
+            logger.warn("Search reindex interrupted. Good luck!");
+            logger.trace("Error:", e);
+        } finally {
+            // Close everything and release the lock file.
+            session.close();
+            factory.close();
+        }
+    }
+
+    @Override
+    public void contextDestroyed(
+            final ServletContextEvent servletContextEvent) {
+        // Do nothing.
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/context/package-info.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/context/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Container context listeners available for hibernate.
+ */
+package net.krotscheck.kangaroo.common.hibernate.context;

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/factory/FulltextSearchFactoryFactory.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/factory/FulltextSearchFactoryFactory.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate.factory;
+
+import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.process.internal.RequestScoped;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.SearchFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+
+/**
+ * This factory will generate a Hibernate Search SearchFactory from the current
+ * hibernate session. It is request-scoped, since it depends on a valid
+ * session.
+ *
+ * @author Michael Krotscheck
+ */
+public final class FulltextSearchFactoryFactory
+        implements Factory<SearchFactory> {
+
+    /**
+     * Logger instance.
+     */
+    private static Logger logger =
+            LoggerFactory.getLogger(FulltextSearchFactoryFactory.class);
+
+    /**
+     * The current hibernate session injected from the application container.
+     */
+    private FullTextSession session;
+
+    /**
+     * Create a new fulltext search factory.
+     *
+     * @param fullTextSession The fulltext session to use.
+     */
+    @Inject
+    public FulltextSearchFactoryFactory(final FullTextSession fullTextSession) {
+        this.session = fullTextSession;
+    }
+
+    /**
+     * Create a request-scoped SearchFactory.
+     *
+     * @return A new SearchFactory
+     */
+    @Override
+    public SearchFactory provide() {
+        logger.trace("Creating hibernate search factory.");
+        return session.getSearchFactory();
+    }
+
+    /**
+     * Dispose of the search factory.
+     *
+     * @param factory The factory to dispose of.
+     */
+    @Override
+    public void dispose(final SearchFactory factory) {
+        // Do nothing- the factory has no disposal requirements.
+    }
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bindFactory(FulltextSearchFactoryFactory.class)
+                    .to(SearchFactory.class)
+                    .in(RequestScoped.class);
+        }
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/factory/FulltextSessionFactory.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/factory/FulltextSessionFactory.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate.factory;
+
+import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.process.internal.RequestScoped;
+import org.hibernate.Session;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+
+/**
+ * This factory creates a request-scoped FulltextSession from the provided
+ * hibernate session.
+ *
+ * @author Michael Krotscheck
+ */
+public final class FulltextSessionFactory implements Factory<FullTextSession> {
+
+    /**
+     * Logger instance.
+     */
+    private static Logger logger =
+            LoggerFactory.getLogger(FulltextSessionFactory.class);
+
+    /**
+     * Our singleton session factory, injected.
+     */
+    private Session hibernateSession;
+
+    /**
+     * Create a new fulltext session factory.
+     *
+     * @param session The hibernate session from which to read our resources.
+     */
+    @Inject
+    public FulltextSessionFactory(final Session session) {
+        this.hibernateSession = session;
+    }
+
+    /**
+     * Create a new fulltext session.
+     *
+     * @return A fulltext session attached to the current hibernate session.
+     */
+    @Override
+    public FullTextSession provide() {
+        logger.trace("Creating hibernate fulltext session.");
+        return Search.getFullTextSession(hibernateSession);
+    }
+
+    /**
+     * Dispose of the fulltext session if it hasn't already been closed.
+     *
+     * @param session The fulltext session to dispose of.
+     */
+    @Override
+    public void dispose(final FullTextSession session) {
+        if (session != null && session.isOpen()) {
+            logger.trace("Disposing of hibernate fulltext session.");
+            session.close();
+        }
+    }
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bindFactory(FulltextSessionFactory.class)
+                    .to(FullTextSession.class)
+                    .in(RequestScoped.class);
+        }
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateServiceRegistryFactory.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateServiceRegistryFactory.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate.factory;
+
+import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.service.ServiceRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Singleton;
+
+/**
+ * This factory creates a singleton hibernate service registry object, using
+ * hibernate's default configuration mechanism (hibernate.properties and
+ * hibernate.cfg.xml). To ensure  all of your entities are properly registered,
+ * add both of those files to your resources directory and ensure they reflect
+ * the correct settings for your application.
+ *
+ * @author Michael Krotscheck
+ */
+public final class HibernateServiceRegistryFactory
+        implements Factory<ServiceRegistry> {
+
+    /**
+     * Logger instance.
+     */
+    private static Logger logger =
+            LoggerFactory.getLogger(HibernateServiceRegistryFactory.class);
+
+    /**
+     * Provide a Hibernate Service Registry object.
+     *
+     * @return The hibernate serfice registry.
+     */
+    @Override
+    public ServiceRegistry provide() {
+        logger.trace("Service Registry provide");
+
+        return new StandardServiceRegistryBuilder()
+                .configure() // configures settings from hibernate.cfg.xml
+                .build();
+    }
+
+    /**
+     * Dispose of the hibernate configuration.
+     *
+     * @param serviceRegistry The service registry to dispose of.
+     */
+    @Override
+    public void dispose(final ServiceRegistry serviceRegistry) {
+        StandardServiceRegistryBuilder.destroy(serviceRegistry);
+    }
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bindFactory(HibernateServiceRegistryFactory.class)
+                    .to(ServiceRegistry.class)
+                    .in(Singleton.class);
+        }
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateSessionFactory.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateSessionFactory.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate.factory;
+
+import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.process.internal.RequestScoped;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+
+/**
+ * This factory builds Hibernate Sessions on a per-request basis, disposing of
+ * them after the request has been processed. This is to ensure that sessions
+ * are disposed of and your configured threadpool is never oversaturated. To
+ * use, merely {Inject} a new {Session} into your Jersey2 component using the
+ * HK2 annotations.
+ *
+ * @author Michael Krotscheck
+ */
+public final class HibernateSessionFactory implements Factory<Session> {
+
+    /**
+     * Logger instance.
+     */
+    private static Logger logger =
+            LoggerFactory.getLogger(HibernateSessionFactory.class);
+
+    /**
+     * The session factory, provided by the injection context.
+     */
+    private SessionFactory factory;
+
+    /**
+     * Create a new instance of the hibernate session factory injector.
+     *
+     * @param sessionFactory The regular hibernate session factory to wrap.
+     */
+    @Inject
+    public HibernateSessionFactory(final SessionFactory sessionFactory) {
+        this.factory = sessionFactory;
+    }
+
+    /**
+     * Create a brand new session.
+     *
+     * @return A new, unused hibernate session.
+     */
+    @Override
+    public Session provide() {
+        logger.trace("Creating hibernate session.");
+        return factory.openSession();
+    }
+
+    /**
+     * Dispose of a hibernate session.
+     *
+     * @param session The session to dispose of.
+     */
+    @Override
+    public void dispose(final Session session) {
+        if (session != null && session.isConnected()) {
+            logger.trace("Disposing of hibernate session.");
+            session.close();
+        }
+    }
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bindFactory(HibernateSessionFactory.class)
+                    .to(Session.class)
+                    .in(RequestScoped.class);
+        }
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateSessionFactoryFactory.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateSessionFactoryFactory.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate.factory;
+
+import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.event.service.spi.EventListenerRegistry;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.event.spi.PostCommitDeleteEventListener;
+import org.hibernate.event.spi.PostCommitInsertEventListener;
+import org.hibernate.event.spi.PostCommitUpdateEventListener;
+import org.hibernate.event.spi.PostDeleteEventListener;
+import org.hibernate.event.spi.PostInsertEventListener;
+import org.hibernate.event.spi.PostUpdateEventListener;
+import org.hibernate.event.spi.PreDeleteEventListener;
+import org.hibernate.event.spi.PreInsertEventListener;
+import org.hibernate.event.spi.PreUpdateEventListener;
+import org.hibernate.internal.SessionFactoryImpl;
+import org.hibernate.service.ServiceRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.List;
+
+/**
+ * This factory provides a singleton Hibernate SessionFactory for your
+ * application context. You may use this to generate your own sessions if you
+ * are not in an explicit request context, however if you do so please make sure
+ * to clean up after yourself and call session.close().
+ *
+ * Furthermore, this injector will search through the ServiceLocator context to
+ * determine if there are any Hibernate Event Listeners injected from other
+ * features. It will gather those and automatically register them against the
+ * hibernate factory.
+ *
+ * @author Michael Krotscheck
+ */
+public final class HibernateSessionFactoryFactory
+        implements Factory<SessionFactory> {
+
+    /**
+     * Logger instance.
+     */
+    private static Logger logger = LoggerFactory
+            .getLogger(HibernateSessionFactoryFactory.class);
+
+    /**
+     * Create a new factory factory.
+     *
+     * @param registry       The Hibernate Service Registry
+     * @param serviceLocator The service locator from which to resolve event
+     *                       handlers.
+     */
+    @Inject
+    public HibernateSessionFactoryFactory(final ServiceRegistry registry,
+                                          final ServiceLocator serviceLocator) {
+        this.serviceRegistry = registry;
+        this.locator = serviceLocator;
+    }
+
+    /**
+     * Injected hibernate configuration.
+     */
+    private ServiceRegistry serviceRegistry;
+
+    /**
+     * The service locator.
+     */
+    private ServiceLocator locator;
+
+    /**
+     * Provide a singleton instance of the hibernate session factory.
+     *
+     * @return A session factory.
+     */
+    @Override
+    public SessionFactory provide() {
+        logger.trace("Creating hibernate session factory.");
+
+        // Build the service registry.
+        SessionFactory factory = new MetadataSources(serviceRegistry)
+                .buildMetadata()
+                .buildSessionFactory();
+
+        // Register our event listeners.
+        injectEventListeners(((SessionFactoryImpl) factory)
+                .getServiceRegistry());
+
+        return factory;
+    }
+
+    /**
+     * Dispose of the hibernate session.
+     *
+     * @param sessionFactory The session to dispose.
+     */
+    @Override
+    public void dispose(final SessionFactory sessionFactory) {
+        if (sessionFactory != null && !sessionFactory.isClosed()) {
+            logger.info("Disposing of hibernate session factory.");
+            sessionFactory.close();
+        }
+    }
+
+    /**
+     * This method automatically adds discovered hibernate event listeners into
+     * the hibernate service registry.
+     *
+     * @param registry The service registry.
+     */
+    private void injectEventListeners(final ServiceRegistry registry) {
+
+        EventListenerRegistry eventRegistry = registry
+                .getService(EventListenerRegistry.class);
+
+        List<PostInsertEventListener> postInsertEvents = locator
+                .getAllServices(PostInsertEventListener.class);
+        for (PostInsertEventListener piEventListener : postInsertEvents) {
+            logger.trace("Registering PostInsert: " + piEventListener
+                    .getClass().getCanonicalName());
+            eventRegistry.appendListeners(EventType.POST_INSERT,
+                    piEventListener);
+        }
+
+        List<PostUpdateEventListener> postUpdateEvents = locator
+                .getAllServices(PostUpdateEventListener.class);
+        for (PostUpdateEventListener puEventListener : postUpdateEvents) {
+            logger.trace("Registering PostUpdate: " + puEventListener
+                    .getClass().getCanonicalName());
+            eventRegistry.appendListeners(EventType.POST_UPDATE,
+                    puEventListener);
+        }
+
+        List<PostDeleteEventListener> postDeleteEvents = locator
+                .getAllServices(PostDeleteEventListener.class);
+        for (PostDeleteEventListener pdEventListener : postDeleteEvents) {
+            logger.trace("Registering PostDelete: " + pdEventListener
+                    .getClass().getCanonicalName());
+            eventRegistry.appendListeners(EventType.POST_DELETE,
+                    pdEventListener);
+        }
+
+        List<PreInsertEventListener> preInsertEvents = locator
+                .getAllServices(PreInsertEventListener.class);
+        for (PreInsertEventListener piEventListener : preInsertEvents) {
+            logger.trace("Registering PreInsert: " + piEventListener
+                    .getClass().getCanonicalName());
+            eventRegistry.appendListeners(EventType.PRE_INSERT,
+                    piEventListener);
+        }
+
+        List<PreUpdateEventListener> preUpdateEvents = locator
+                .getAllServices(PreUpdateEventListener.class);
+        for (PreUpdateEventListener puEventListener : preUpdateEvents) {
+            logger.trace("Registering PreUpdate: " + puEventListener
+                    .getClass().getCanonicalName());
+            eventRegistry.appendListeners(EventType.PRE_UPDATE,
+                    puEventListener);
+        }
+
+        List<PreDeleteEventListener> preDeleteEvents = locator
+                .getAllServices(PreDeleteEventListener.class);
+        for (PreDeleteEventListener pdEventListener : preDeleteEvents) {
+            logger.trace("Registering PreDelete: " + pdEventListener
+                    .getClass().getCanonicalName());
+            eventRegistry.appendListeners(EventType.PRE_DELETE,
+                    pdEventListener);
+        }
+
+        List<PostCommitInsertEventListener> pciEvents = locator
+                .getAllServices(PostCommitInsertEventListener.class);
+        for (PostCommitInsertEventListener cpiEventListener : pciEvents) {
+            logger.trace("Registering PostCommitInsert: " + cpiEventListener
+                    .getClass().getCanonicalName());
+            eventRegistry.appendListeners(EventType.POST_COMMIT_INSERT,
+                    cpiEventListener);
+        }
+
+        List<PostCommitUpdateEventListener> pcuEvents = locator
+                .getAllServices(PostCommitUpdateEventListener.class);
+        for (PostCommitUpdateEventListener cpuEventListener : pcuEvents) {
+            logger.trace("Registering PostCommitUpdate: " + cpuEventListener
+                    .getClass().getCanonicalName());
+            eventRegistry.appendListeners(EventType.POST_COMMIT_UPDATE,
+                    cpuEventListener);
+        }
+
+        List<PostCommitDeleteEventListener> pcdEvents = locator
+                .getAllServices(PostCommitDeleteEventListener.class);
+        for (PostCommitDeleteEventListener cpdEventListener : pcdEvents) {
+            logger.trace("Registering PostCommitDelete: " + cpdEventListener
+                    .getClass().getCanonicalName());
+            eventRegistry.appendListeners(EventType.POST_COMMIT_DELETE,
+                    cpdEventListener);
+        }
+    }
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bindFactory(HibernateSessionFactoryFactory.class)
+                    .to(SessionFactory.class)
+                    .in(Singleton.class);
+        }
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/factory/package-info.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/factory/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Hibernate Component Factories and Injectors.
+ *
+ * @author Michael Krotscheck
+ */
+package net.krotscheck.kangaroo.common.hibernate.factory;

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/package-info.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Hibernate configuration and session injection.
+ *
+ * @author Michael Krotscheck
+ */
+package net.krotscheck.kangaroo.common.hibernate;

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/DatabaseFeature.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/DatabaseFeature.java
@@ -17,13 +17,13 @@
 
 package net.krotscheck.kangaroo.database;
 
-import net.krotscheck.jersey2.hibernate.HibernateFeature;
 import net.krotscheck.kangaroo.database.listener.CreatedUpdatedListener;
 import net.krotscheck.kangaroo.database.mapper.ConstraintViolationExceptionMapper;
 import net.krotscheck.kangaroo.database.mapper.HibernateExceptionMapper;
 import net.krotscheck.kangaroo.database.mapper.PropertyValueExceptionMapper;
 import net.krotscheck.kangaroo.database.mapper.QueryExceptionMapper;
 import net.krotscheck.kangaroo.database.mapper.SearchExceptionMapper;
+import net.krotscheck.kangaroo.common.hibernate.HibernateFeature;
 
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;

--- a/kangaroo-common/src/main/resources/logback.xml
+++ b/kangaroo-common/src/main/resources/logback.xml
@@ -42,7 +42,6 @@
   <logger name="ContextClassLoaderXsdStreamResolver" level="WARN"/>
   <logger name="jndi" level="WARN"/>
   <logger name="org.eclipse.jetty" level="WARN"/>
-  <logger name="net.krotscheck.jersey2" level="WARN"/>
   <logger name="ch.qos" level="WARN"/>
   <logger name="org.glassfish.jersey.test" level="INFO"/>
   <logger name="org.glassfish.jersey.internal" level="ERROR"/>

--- a/kangaroo-common/src/main/webapp/WEB-INF/web.xml
+++ b/kangaroo-common/src/main/webapp/WEB-INF/web.xml
@@ -63,7 +63,7 @@
   <!-- Hibernate Search Lucene Index Rebuild -->
   <listener>
     <listener-class>
-      net.krotscheck.jersey2.hibernate.context.SearchIndexContextListener
+      net.krotscheck.kangaroo.common.hibernate.context.SearchIndexContextListener
     </listener-class>
   </listener>
 

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/HibernateFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/HibernateFeatureTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate;
+
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.SearchFactory;
+import org.hibernate.service.ServiceRegistry;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * Test that all expected classes are in the hibernate feature.
+ *
+ * @author Michael Krotscheck
+ */
+public final class HibernateFeatureTest extends JerseyTest {
+
+    /**
+     * Run a service request.
+     */
+    @Test
+    public void testService() {
+        target("/test")
+                .request(MediaType.APPLICATION_JSON)
+                .get();
+    }
+
+    /**
+     * Configure the application.
+     *
+     * @return A properly configured application.
+     */
+    @Override
+    protected Application configure() {
+        ResourceConfig config = new ResourceConfig();
+        config.register(HibernateFeature.class);
+        config.register(TestService.class);
+
+        return config;
+    }
+
+    /**
+     * A test service that asserts our injection scopes.
+     */
+    @Path("/test")
+    public static final class TestService {
+
+        /**
+         * Hibernate service registry.
+         */
+        private ServiceRegistry serviceRegistry;
+
+        /**
+         * Session factory.
+         */
+        private SessionFactory factory;
+
+        /**
+         * Search factory injection.
+         */
+        private SearchFactory searchFactory;
+
+        /**
+         * FullText session injector.
+         */
+        private FullTextSession ftSession;
+
+        /**
+         * Session injector.
+         */
+        private Session session;
+
+        /**
+         * Create a new instance of our test service.
+         *
+         * @param sr  ServiceRegistry
+         * @param f   Session Factory
+         * @param s   Hibernate Session
+         * @param sF  Search Factory
+         * @param ftS Full text session
+         */
+        @Inject
+        public TestService(final ServiceRegistry sr,
+                           final SessionFactory f,
+                           final SearchFactory sF,
+                           final Session s,
+                           final FullTextSession ftS) {
+            serviceRegistry = sr;
+            factory = f;
+            session = s;
+            searchFactory = sF;
+            ftSession = ftS;
+        }
+
+        /**
+         * Run the test service.
+         *
+         * @return An OK response.
+         */
+        @GET
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response testService() {
+            Assert.assertNotNull(serviceRegistry);
+            Assert.assertNotNull(searchFactory);
+            Assert.assertNotNull(factory);
+            Assert.assertNotNull(ftSession);
+            Assert.assertNotNull(session);
+
+            return Response.ok().build();
+        }
+    }
+
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/context/SearchIndexContextListenerITest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/context/SearchIndexContextListenerITest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate.context;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.MassIndexer;
+import org.hibernate.search.Search;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import javax.servlet.ServletContextEvent;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+
+/**
+ * Unit test for our lucene indexer.
+ *
+ * @author Michael Krotscheck
+ */
+@RunWith(PowerMockRunner.class)
+public final class SearchIndexContextListenerITest {
+
+    /**
+     * Assert that the index is created on startup.
+     *
+     * @throws Exception Any unexpected exceptions.
+     */
+    @Test
+    @PrepareForTest({Search.class, SearchIndexContextListener.class})
+    public void testOnStartup() throws Exception {
+        // Set up a fake session factory
+        SessionFactory mockFactory = mock(SessionFactory.class);
+        Session mockSession = mock(Session.class);
+        when(mockFactory.openSession()).thenReturn(mockSession);
+
+        // Set up a fake indexer
+        MassIndexer mockIndexer = mock(MassIndexer.class);
+
+        // Set up our fulltext session.
+        FullTextSession mockFtSession = mock(FullTextSession.class);
+        when(mockFtSession.createIndexer())
+                .thenReturn(mockIndexer);
+
+        // This is the way to tell PowerMock to mock all static methods of a
+        // given class
+        mockStatic(Search.class);
+        when(Search.getFullTextSession(mockSession))
+                .thenReturn(mockFtSession);
+
+        SearchIndexContextListener listener =
+                mock(SearchIndexContextListener.class);
+
+        doReturn(mockFactory).when(listener).createSessionFactory();
+        doCallRealMethod().when(listener).contextInitialized(any());
+
+        // Run the test
+        listener.contextInitialized(mock(ServletContextEvent.class));
+
+        verify(mockIndexer).startAndWait();
+
+        // Verify that the session was closed.
+        verify(mockSession).close();
+    }
+
+    /**
+     * Assert that an interrupted exception exits cleanly.
+     *
+     * @throws Exception An exception that might be thrown.
+     */
+    @Test
+    @PrepareForTest({Search.class, SearchIndexContextListener.class})
+    public void testInterruptedIndex() throws Exception {
+        // Set up a fake session factory
+        SessionFactory mockFactory = mock(SessionFactory.class);
+        Session mockSession = mock(Session.class);
+        when(mockFactory.openSession()).thenReturn(mockSession);
+
+        // Set up a fake indexer
+        MassIndexer mockIndexer = mock(MassIndexer.class);
+
+        // Set up our fulltext session.
+        FullTextSession mockFtSession = mock(FullTextSession.class);
+        when(mockFtSession.createIndexer())
+                .thenReturn(mockIndexer);
+        doThrow(new InterruptedException())
+                .when(mockIndexer)
+                .startAndWait();
+
+        // This is the way to tell PowerMock to mock all static methods of a
+        // given class
+        mockStatic(Search.class);
+        when(Search.getFullTextSession(mockSession))
+                .thenReturn(mockFtSession);
+
+        SearchIndexContextListener listener =
+                mock(SearchIndexContextListener.class);
+        doReturn(mockFactory).when(listener).createSessionFactory();
+        doCallRealMethod().when(listener).contextInitialized(any());
+
+        // Run the test
+        listener.contextInitialized(mock(ServletContextEvent.class));
+
+        // Verify that the session was closed.
+        verify(mockSession).close();
+        verify(mockFactory).close();
+    }
+
+    /**
+     * Assert that the disposal method does nothing.
+     *
+     * @throws Exception An exception that might be thrown.
+     */
+    @Test
+    public void testDisposal() throws Exception {
+        ServletContextEvent e = mock(ServletContextEvent.class);
+        SearchIndexContextListener listener = new SearchIndexContextListener();
+        listener.contextDestroyed(e);
+
+        verifyZeroInteractions(e);
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/context/SearchIndexContextListenerTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/context/SearchIndexContextListenerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate.context;
+
+import net.krotscheck.kangaroo.test.DatabaseTest;
+import net.krotscheck.kangaroo.test.EnvironmentBuilder;
+import org.hibernate.SessionFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+
+/**
+ * Unit test for our lucene indexer.
+ *
+ * @author Michael Krotscheck
+ */
+public final class SearchIndexContextListenerTest extends DatabaseTest {
+
+    /**
+     * Load data fixtures for each test.
+     *
+     * @return A list of fixtures, which will be cleared after the test.
+     * @throws Exception An exception that indicates a failed fixture load.
+     */
+    @Override
+    public List<EnvironmentBuilder> fixtures() throws Exception {
+        return null;
+    }
+
+    /**
+     * Assert that the session factory is properly created.
+     */
+    @Test
+    public void createSessionFactory() {
+        SearchIndexContextListener listener = new SearchIndexContextListener();
+        SessionFactory factory = listener.createSessionFactory();
+        // It's not easy to introspect into what's being loaded, but we need
+        // this for coverage.
+        Assert.assertNotNull(factory);
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/context/package-info.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/context/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Unit tests for Lucene Indexing.
+ *
+ * @author Michael Krotscheck
+ */
+package net.krotscheck.kangaroo.common.hibernate.context;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/entity/TestEntity.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/entity/TestEntity.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate.entity;
+
+
+import org.hibernate.search.annotations.Indexed;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * A test hibernate persistence entity.
+ *
+ * @author Michael Krotscheck
+ */
+@Entity
+@Indexed
+@Table(name = "test")
+public final class TestEntity {
+
+    /**
+     * Identifier.
+     */
+    @Id
+    private Long id;
+
+    /**
+     * Get the ID.
+     *
+     * @return the ID.
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Set the ID.
+     *
+     * @param entityId The ID.
+     */
+    public void setId(final Long entityId) {
+        this.id = entityId;
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/entity/package-info.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/entity/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Test entities for our hibernate feature.
+ *
+ * @author Michael Krotscheck
+ */
+package net.krotscheck.kangaroo.common.hibernate.entity;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/FulltextSearchFactoryFactoryTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/FulltextSearchFactoryFactoryTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate.factory;
+
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.jersey.server.ApplicationHandler;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.SearchFactory;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+/**
+ * Unit test for the fulltext search factory factory.
+ *
+ * @author Michael Krotscheck
+ */
+public final class FulltextSearchFactoryFactoryTest {
+
+    /**
+     * The jersey application handler.
+     */
+    private ApplicationHandler handler;
+
+    /**
+     * The jersey application service locator.
+     */
+    private ServiceLocator locator;
+
+    /**
+     * Setup the application handler for this test.
+     */
+    @Before
+    public void setup() {
+        ResourceConfig config = new ResourceConfig();
+        config.register(TestFeature.class);
+        handler = new ApplicationHandler(config);
+        locator = handler.getServiceLocator();
+    }
+
+    /**
+     * Teardown the application handler.
+     */
+    @After
+    public void teardown() {
+        locator.shutdown();
+        locator = null;
+        handler = null;
+    }
+
+    /**
+     * Test provide and dispose.
+     */
+    @Test
+    public void testProvideDispose() {
+        SessionFactory sessionFactory =
+                locator.getService(SessionFactory.class);
+        Session hibernateSession = sessionFactory.openSession();
+        FullTextSession ftSession = Search.getFullTextSession(hibernateSession);
+
+
+        FulltextSearchFactoryFactory factory =
+                new FulltextSearchFactoryFactory(ftSession);
+
+        // Make sure that we can create a search factory.
+        SearchFactory searchFactory = factory.provide();
+        Assert.assertNotNull(searchFactory);
+
+        // Make sure we can dispose of the factory (does nothing, sadly).
+        factory.dispose(searchFactory);
+
+        if (hibernateSession.isOpen()) {
+            hibernateSession.close();
+        }
+    }
+
+    /**
+     * A private class to test our feature injection.
+     */
+    private static class TestFeature implements Feature {
+
+        @Override
+        public boolean configure(final FeatureContext context) {
+            context.register(new HibernateServiceRegistryFactory.Binder());
+            context.register(new HibernateSessionFactoryFactory.Binder());
+            context.register(new HibernateSessionFactory.Binder());
+            context.register(new FulltextSessionFactory.Binder());
+            context.register(new FulltextSearchFactoryFactory.Binder());
+            return true;
+        }
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/FulltextSessionFactoryTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/FulltextSessionFactoryTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate.factory;
+
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.jersey.server.ApplicationHandler;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.search.FullTextSession;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+/**
+ * Unit test for our fulltext search factory.
+ *
+ * @author Michael Krotscheck
+ */
+public final class FulltextSessionFactoryTest {
+
+    /**
+     * The jersey application handler.
+     */
+    private ApplicationHandler handler;
+
+    /**
+     * The jersey application service locator.
+     */
+    private ServiceLocator locator;
+
+    /**
+     * Setup the application handler for this test.
+     */
+    @Before
+    public void setup() {
+        ResourceConfig config = new ResourceConfig();
+        config.register(TestFeature.class);
+        handler = new ApplicationHandler(config);
+        locator = handler.getServiceLocator();
+    }
+
+    /**
+     * Teardown the application handler.
+     */
+    @After
+    public void teardown() {
+        locator.shutdown();
+        locator = null;
+        handler = null;
+    }
+
+    /**
+     * Test provide and dispose.
+     */
+    @Test
+    public void testProvideDispose() {
+        SessionFactory sessionFactory =
+                locator.getService(SessionFactory.class);
+        Session hibernateSession = sessionFactory.openSession();
+
+        FulltextSessionFactory factory =
+                new FulltextSessionFactory(hibernateSession);
+
+        // Make sure that we can create a session.
+        FullTextSession session = factory.provide();
+        Assert.assertNotNull(session);
+        Assert.assertTrue(session.isOpen());
+
+        // Make sure we can dispose of the session.
+        factory.dispose(session);
+        Assert.assertFalse(session.isOpen());
+
+        // Make sure we can dispose of the session again.
+        factory.dispose(session);
+        Assert.assertFalse(session.isOpen());
+
+        // Make sure accidentally passing null doesn't blow up.
+        factory.dispose(null);
+
+        if (hibernateSession.isOpen()) {
+            hibernateSession.close();
+        }
+    }
+
+    /**
+     * A private class to test our feature injection.
+     */
+    private static class TestFeature implements Feature {
+
+        @Override
+        public boolean configure(final FeatureContext context) {
+            context.register(new HibernateServiceRegistryFactory.Binder());
+            context.register(new HibernateSessionFactoryFactory.Binder());
+            context.register(new HibernateSessionFactory.Binder());
+            context.register(new FulltextSessionFactory.Binder());
+            return true;
+        }
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateServiceRegistryFactoryTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateServiceRegistryFactoryTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate.factory;
+
+
+import org.glassfish.jersey.server.ApplicationHandler;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.H2Dialect;
+import org.hibernate.service.ServiceRegistry;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+/**
+ * Unit test for the hibernate configuration and its binder.
+ *
+ * @author Michael Krotscheck
+ */
+public final class HibernateServiceRegistryFactoryTest {
+
+    /**
+     * Test provide and dispose.
+     */
+    @Test
+    public void testProvideDispose() {
+        HibernateServiceRegistryFactory factory = new
+                HibernateServiceRegistryFactory();
+
+        ServiceRegistry serviceRegistry = factory.provide();
+
+        Dialect d = new MetadataSources(serviceRegistry)
+                .buildMetadata().getDatabase().getDialect();
+        Assert.assertTrue(d instanceof H2Dialect);
+
+        // This shouldn't actually do anything, but is included here for
+        // coverage.
+        factory.dispose(serviceRegistry);
+    }
+
+    /**
+     * Test the application binder.
+     */
+    @Test
+    public void testBinder() {
+
+        ResourceConfig config = new ResourceConfig();
+        config.register(TestFeature.class);
+
+        // Make sure it's registered
+        Assert.assertTrue(config.isRegistered(TestFeature.class));
+
+        // Create a fake application.
+        ApplicationHandler handler = new ApplicationHandler(config);
+        ServiceRegistry serviceRegistry = handler
+                .getServiceLocator().getService(ServiceRegistry.class);
+        Assert.assertNotNull(serviceRegistry);
+
+        // Make sure it's reading from the same place.
+        Dialect d = new MetadataSources(serviceRegistry)
+                .buildMetadata().getDatabase().getDialect();
+        Assert.assertTrue(d instanceof H2Dialect);
+
+        // Make sure it's a singleton...
+        ServiceRegistry serviceRegistry2 = handler
+                .getServiceLocator().getService(ServiceRegistry.class);
+        Assert.assertSame(serviceRegistry, serviceRegistry2);
+    }
+
+    /**
+     * A private class to test our feature injection.
+     */
+    private static class TestFeature implements Feature {
+
+        @Override
+        public boolean configure(final FeatureContext context) {
+            context.register(new HibernateServiceRegistryFactory.Binder());
+            return true;
+        }
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateSessionFactoryFactoryTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateSessionFactoryFactoryTest.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate.factory;
+
+import org.glassfish.hk2.api.PerThread;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.server.ApplicationHandler;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.event.service.spi.EventListenerGroup;
+import org.hibernate.event.service.spi.EventListenerRegistry;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.event.spi.PostCommitDeleteEventListener;
+import org.hibernate.event.spi.PostCommitInsertEventListener;
+import org.hibernate.event.spi.PostCommitUpdateEventListener;
+import org.hibernate.event.spi.PostDeleteEvent;
+import org.hibernate.event.spi.PostDeleteEventListener;
+import org.hibernate.event.spi.PostInsertEvent;
+import org.hibernate.event.spi.PostInsertEventListener;
+import org.hibernate.event.spi.PostUpdateEvent;
+import org.hibernate.event.spi.PostUpdateEventListener;
+import org.hibernate.event.spi.PreDeleteEvent;
+import org.hibernate.event.spi.PreDeleteEventListener;
+import org.hibernate.event.spi.PreInsertEvent;
+import org.hibernate.event.spi.PreInsertEventListener;
+import org.hibernate.event.spi.PreUpdateEvent;
+import org.hibernate.event.spi.PreUpdateEventListener;
+import org.hibernate.internal.SessionFactoryImpl;
+import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.service.ServiceRegistry;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+/**
+ * Unit test for our hibernate session factory factory.
+ *
+ * @author Michael Krotscheck
+ */
+public final class HibernateSessionFactoryFactoryTest {
+
+    /**
+     * The jersey application handler.
+     */
+    private ApplicationHandler handler;
+
+    /**
+     * The jersey application service locator.
+     */
+    private ServiceLocator locator;
+
+    /**
+     * Setup the application handler for this test.
+     */
+    @Before
+    public void setup() {
+        ResourceConfig config = new ResourceConfig();
+        config.register(TestFeature.class);
+        handler = new ApplicationHandler(config);
+        locator = handler.getServiceLocator();
+    }
+
+    /**
+     * Teardown the application handler.
+     */
+    @After
+    public void teardown() {
+        locator.shutdown();
+        locator = null;
+        handler = null;
+    }
+
+    /**
+     * Test provide and dispose.
+     */
+    @Test
+    public void testProvideDispose() {
+        ServiceRegistry serviceRegistry =
+                locator.getService(ServiceRegistry.class);
+        HibernateSessionFactoryFactory factoryFactory =
+                new HibernateSessionFactoryFactory(serviceRegistry, locator);
+        SessionFactory factory = locator.getService(SessionFactory.class);
+
+        // Assert that the factory is open.
+        Assert.assertFalse(factory.isClosed());
+
+        // Make sure that we can create a session.
+        Session session = factory.openSession();
+        Assert.assertNotNull(session);
+        Assert.assertTrue(session.isOpen());
+
+        // Make sure we can dispose of the factory.
+        factoryFactory.dispose(factory);
+        Assert.assertTrue(factory.isClosed());
+        Assert.assertFalse(session.isOpen());
+
+        // Make sure doing it twice won't fail.
+        factoryFactory.dispose(factory);
+
+        // Make sure passing null doesn't fail
+        factoryFactory.dispose(null);
+    }
+
+    /**
+     * Test the application binder.
+     */
+    @Test
+    public void testBinder() {
+
+        // Create a fake application.
+        SessionFactory factoryFactory = locator
+                .getService(SessionFactory.class);
+        Assert.assertNotNull(factoryFactory);
+
+        // Make sure it's reading from the same place.
+        Assert.assertFalse(factoryFactory.isClosed());
+
+        // Make sure it's a singleton...
+        SessionFactory factoryFactory2 = handler
+                .getServiceLocator().getService(SessionFactory.class);
+        Assert.assertSame(factoryFactory, factoryFactory2);
+    }
+
+    /**
+     * Test the application event injectors.
+     */
+    @Test
+    public void testEventInjection() {
+
+        // Create a fake application.
+        SessionFactory factoryFactory = locator
+                .getService(SessionFactory.class);
+        Assert.assertNotNull(factoryFactory);
+
+
+        ServiceRegistry serviceRegistry = ((SessionFactoryImpl) factoryFactory)
+                .getServiceRegistry();
+        EventListenerRegistry eventRegistry = serviceRegistry
+                .getService(EventListenerRegistry.class);
+
+        EventListenerGroup<PreInsertEventListener> priGroup = eventRegistry
+                .getEventListenerGroup(EventType.PRE_INSERT);
+        assertContainsListener(priGroup);
+
+        EventListenerGroup<PostInsertEventListener> poiGroup = eventRegistry
+                .getEventListenerGroup(EventType.POST_INSERT);
+        assertContainsListener(poiGroup);
+
+        EventListenerGroup<PreUpdateEventListener> pruGroup = eventRegistry
+                .getEventListenerGroup(EventType.PRE_UPDATE);
+        assertContainsListener(pruGroup);
+
+        EventListenerGroup<PostUpdateEventListener> pouGroup = eventRegistry
+                .getEventListenerGroup(EventType.POST_UPDATE);
+        assertContainsListener(pouGroup);
+
+        EventListenerGroup<PreDeleteEventListener> prdGroup = eventRegistry
+                .getEventListenerGroup(EventType.PRE_DELETE);
+        assertContainsListener(prdGroup);
+
+        EventListenerGroup<PostDeleteEventListener> podGroup = eventRegistry
+                .getEventListenerGroup(EventType.POST_DELETE);
+        assertContainsListener(podGroup);
+
+        EventListenerGroup<PostInsertEventListener> pciGroup = eventRegistry
+                .getEventListenerGroup(EventType.POST_COMMIT_INSERT);
+        assertContainsListener(pciGroup);
+
+        EventListenerGroup<PostUpdateEventListener> pcuGroup = eventRegistry
+                .getEventListenerGroup(EventType.POST_COMMIT_UPDATE);
+        assertContainsListener(pcuGroup);
+
+        EventListenerGroup<PostDeleteEventListener> pcdGroup = eventRegistry
+                .getEventListenerGroup(EventType.POST_COMMIT_DELETE);
+        assertContainsListener(pcdGroup);
+    }
+
+    /**
+     * Helper method that asserts that our event listener is in the passed
+     * group.
+     *
+     * @param group The event listener group in question.
+     */
+    private void assertContainsListener(final EventListenerGroup group) {
+
+        for (Object listener : group.listeners()) {
+            if (listener instanceof TestEventListener) {
+                return;
+            }
+        }
+
+        Assert.assertFalse(true);
+    }
+
+    /**
+     * A private class to test our feature injection.
+     */
+    private static class TestFeature implements Feature {
+
+        @Override
+        public boolean configure(final FeatureContext context) {
+            context.register(new HibernateServiceRegistryFactory.Binder());
+            context.register(new HibernateSessionFactoryFactory.Binder());
+            context.register(new TestEventListener.Binder());
+            return true;
+        }
+    }
+
+    /**
+     * A test event listener to ensure that the session factory can read them
+     * from the injection context.
+     */
+    public static final class TestEventListener
+            implements PreInsertEventListener, PostInsertEventListener,
+            PreUpdateEventListener, PostUpdateEventListener,
+            PreDeleteEventListener, PostDeleteEventListener,
+            PostCommitInsertEventListener, PostCommitUpdateEventListener,
+            PostCommitDeleteEventListener {
+
+        @Override
+        public void onPostDelete(final PostDeleteEvent event) {
+
+        }
+
+        @Override
+        public void onPostInsert(final PostInsertEvent event) {
+
+        }
+
+        @Override
+        public void onPostUpdate(final PostUpdateEvent event) {
+
+        }
+
+        @Override
+        public boolean requiresPostCommitHanding(
+                final EntityPersister persister) {
+            return false;
+        }
+
+        @Override
+        public boolean onPreDelete(final PreDeleteEvent event) {
+            return false;
+        }
+
+        @Override
+        public boolean onPreInsert(final PreInsertEvent event) {
+            return false;
+        }
+
+        @Override
+        public boolean onPreUpdate(final PreUpdateEvent event) {
+            return false;
+        }
+
+        @Override
+        public void onPostDeleteCommitFailed(final PostDeleteEvent event) {
+
+        }
+
+        @Override
+        public void onPostInsertCommitFailed(final PostInsertEvent event) {
+
+        }
+
+        @Override
+        public void onPostUpdateCommitFailed(final PostUpdateEvent event) {
+
+        }
+
+        /**
+         * HK2 Binder for our injector context.
+         */
+        public static final class Binder extends AbstractBinder {
+
+            @Override
+            protected void configure() {
+                bind(TestEventListener.class)
+                        .to(PostDeleteEventListener.class)
+                        .to(PreDeleteEventListener.class)
+                        .to(PreInsertEventListener.class)
+                        .to(PostInsertEventListener.class)
+                        .to(PreUpdateEventListener.class)
+                        .to(PostUpdateEventListener.class)
+                        .to(PostCommitInsertEventListener.class)
+                        .to(PostCommitUpdateEventListener.class)
+                        .to(PostCommitDeleteEventListener.class)
+                        .in(PerThread.class);
+            }
+        }
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateSessionFactoryTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateSessionFactoryTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate.factory;
+
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.jersey.server.ApplicationHandler;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+/**
+ * The hibernate session factory test.
+ *
+ * @author Michael Krotscheck
+ */
+public final class HibernateSessionFactoryTest {
+
+    /**
+     * The jersey application handler.
+     */
+    private ApplicationHandler handler;
+
+    /**
+     * The jersey application service locator.
+     */
+    private ServiceLocator locator;
+
+    /**
+     * Setup the application handler for this test.
+     */
+    @Before
+    public void setup() {
+        ResourceConfig config = new ResourceConfig();
+        config.register(TestFeature.class);
+        handler = new ApplicationHandler(config);
+        locator = handler.getServiceLocator();
+    }
+
+    /**
+     * Teardown the application handler.
+     */
+    @After
+    public void teardown() {
+        locator.shutdown();
+        locator = null;
+        handler = null;
+    }
+
+    /**
+     * Test provide and dispose.
+     */
+    @Test
+    public void testProvideDispose() {
+        SessionFactory sessionFactory =
+                locator.getService(SessionFactory.class);
+
+        HibernateSessionFactory factory =
+                new HibernateSessionFactory(sessionFactory);
+
+        // Make sure that we can create a session.
+        Session session = factory.provide();
+        Assert.assertNotNull(session);
+        Assert.assertTrue(session.isOpen());
+
+        // Make sure we can dispose of the session.
+        factory.dispose(session);
+        Assert.assertFalse(session.isOpen());
+
+        // Make sure that disposing an already closed session doesn't blow up.
+        factory.dispose(session);
+        Assert.assertFalse(session.isOpen());
+
+        // Make sure accidentally passing null doesn't blow up.
+        factory.dispose(null);
+    }
+
+    /**
+     * A private class to test our feature injection.
+     */
+    private static class TestFeature implements Feature {
+
+        @Override
+        public boolean configure(final FeatureContext context) {
+            context.register(new HibernateServiceRegistryFactory.Binder());
+            context.register(new HibernateSessionFactoryFactory.Binder());
+            context.register(new HibernateSessionFactory.Binder());
+            return true;
+        }
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/package-info.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Unit tests for our factories.
+ *
+ * @author Michael Krotscheck
+ */
+package net.krotscheck.kangaroo.common.hibernate.factory;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/package-info.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Unit tests for the hibernate feature.
+ *
+ * @author Michael Krotscheck
+ */
+package net.krotscheck.kangaroo.common.hibernate;

--- a/kangaroo-common/src/test/resources/logback/default/logback-test.xml
+++ b/kangaroo-common/src/test/resources/logback/default/logback-test.xml
@@ -43,7 +43,6 @@
   <logger name="ContextClassLoaderXsdStreamResolver" level="WARN"/>
   <logger name="jndi" level="WARN"/>
   <logger name="org.eclipse.jetty" level="WARN"/>
-  <logger name="net.krotscheck.jersey2" level="WARN"/>
   <logger name="ch.qos" level="WARN"/>
   <logger name="org.glassfish.jersey.test.jetty" level="ERROR"/>
   <logger name="org.glassfish.jersey.test" level="INFO"/>

--- a/kangaroo-server-admin/src/main/webapp/WEB-INF/web.xml
+++ b/kangaroo-server-admin/src/main/webapp/WEB-INF/web.xml
@@ -74,7 +74,7 @@
   <!-- Hibernate Search Lucene Index Rebuild -->
   <listener>
     <listener-class>
-      net.krotscheck.jersey2.hibernate.context.SearchIndexContextListener
+      net.krotscheck.kangaroo.common.hibernate.context.SearchIndexContextListener
     </listener-class>
   </listener>
 </web-app>

--- a/kangaroo-server-oauth2/pom.xml
+++ b/kangaroo-server-oauth2/pom.xml
@@ -117,16 +117,6 @@
       <artifactId>httpcore</artifactId>
     </dependency>
 
-    <!-- Jersey2 Toolkit -->
-    <dependency>
-      <groupId>net.krotscheck.jersey2</groupId>
-      <artifactId>jersey2-configuration</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>net.krotscheck.jersey2</groupId>
-      <artifactId>jersey2-hibernate</artifactId>
-    </dependency>
-
     <!-- Hibernate -->
     <dependency>
       <groupId>org.hibernate</groupId>

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/filter/ClientAuthorizationFilterTest.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/filter/ClientAuthorizationFilterTest.java
@@ -17,10 +17,10 @@
 
 package net.krotscheck.kangaroo.servlet.oauth2.filter;
 
-import net.krotscheck.jersey2.hibernate.HibernateFeature;
 import net.krotscheck.kangaroo.common.config.ConfigurationFeature;
 import net.krotscheck.kangaroo.common.exception.rfc6749.Rfc6749Exception.AccessDeniedException;
 import net.krotscheck.kangaroo.common.exception.rfc6749.Rfc6749Exception.InvalidClientException;
+import net.krotscheck.kangaroo.common.hibernate.HibernateFeature;
 import net.krotscheck.kangaroo.database.entity.Application;
 import net.krotscheck.kangaroo.database.entity.Client;
 import net.krotscheck.kangaroo.database.entity.ClientType;

--- a/pom.xml
+++ b/pom.xml
@@ -584,12 +584,6 @@
       <!--<artifactId>jersey-container-servlet</artifactId>-->
     <!--</dependency>-->
 
-    <!--&lt;!&ndash; Jersey2 Toolkit &ndash;&gt;-->
-    <!--<dependency>-->
-      <!--<groupId>net.krotscheck.jersey2</groupId>-->
-      <!--<artifactId>jersey2-hibernate</artifactId>-->
-    <!--</dependency>-->
-
     <!-- H2 database, used for testing. -->
     <dependency>
       <groupId>com.h2database</groupId>
@@ -662,18 +656,6 @@
         <version>2.4</version>
       </dependency>
 
-      <!-- Jersey2 Toolkit -->
-      <dependency>
-        <groupId>net.krotscheck.jersey2</groupId>
-        <artifactId>jersey2-configuration</artifactId>
-        <version>${jersey2-toolkit.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>net.krotscheck.jersey2</groupId>
-        <artifactId>jersey2-hibernate</artifactId>
-        <version>${jersey2-toolkit.version}</version>
-      </dependency>
-
       <!-- Hibernate -->
       <dependency>
         <groupId>org.hibernate</groupId>
@@ -704,6 +686,11 @@
         <groupId>org.hibernate.javax.persistence</groupId>
         <artifactId>hibernate-jpa-2.1-api</artifactId>
         <version>1.0.0.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.transaction</groupId>
+        <artifactId>jta</artifactId>
+        <version>1.1</version>
       </dependency>
 
       <!-- Hibernate validation annotations -->


### PR DESCRIPTION
It's a bit easier to manage this code inside of the lifecycle of this
application, rather than having to rerelease the separate version
whenever a new use case arises or the old ones change. In this case,
it was prompted by the load order of the search index listener vs.
the FirstRunContainer; As the search indexes cannot be built without
an existing schema.