### PR TITLE
Data model corrections

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/AbstractEntity.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/AbstractEntity.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.lucene.analysis.charfilter.HTMLStripCharFilterFactory;
+import org.apache.lucene.analysis.charfilter.MappingCharFilterFactory;
 import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
 import org.apache.lucene.analysis.core.StopFilterFactory;
 import org.apache.lucene.analysis.miscellaneous.RemoveDuplicatesTokenFilterFactory;
@@ -57,7 +58,12 @@ import java.util.UUID;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @AnalyzerDef(name = "entity_analyzer",
         charFilters = {
-                @CharFilterDef(factory = HTMLStripCharFilterFactory.class)
+                @CharFilterDef(factory = HTMLStripCharFilterFactory.class),
+                @CharFilterDef(factory = MappingCharFilterFactory.class,
+                        params = {@Parameter(
+                                name = "mapping",
+                                value = "kangaroo-char-mapping.properties")}
+                )
         },
         tokenizer = @TokenizerDef(factory = StandardTokenizerFactory.class),
         filters = {
@@ -71,7 +77,7 @@ import java.util.UUID;
                 @TokenFilterDef(
                         factory = RemoveDuplicatesTokenFilterFactory.class)
         })
-public abstract class AbstractEntity {
+public abstract class AbstractEntity implements Cloneable {
 
     /**
      * The DB ID.
@@ -203,5 +209,15 @@ public abstract class AbstractEntity {
     public final String toString() {
         return String.format("%s [id=%s]", this.getClass().getCanonicalName(),
                 getId());
+    }
+
+    /**
+     * Clone this instance.
+     *
+     * @return A clone of this entity.
+     */
+    @Override
+    public final Object clone() throws CloneNotSupportedException {
+        return super.clone();
     }
 }

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/Authenticator.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/Authenticator.java
@@ -22,10 +22,21 @@ import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import net.krotscheck.kangaroo.database.deserializer.AbstractEntityReferenceDeserializer;
-import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.CascadeType;
+import net.krotscheck.kangaroo.database.filters.UUIDFilter;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.FilterCacheModeType;
+import org.hibernate.search.annotations.FullTextFilterDef;
+import org.hibernate.search.annotations.FullTextFilterDefs;
+import org.hibernate.search.annotations.Index;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.IndexedEmbedded;
+import org.hibernate.search.annotations.Store;
 
 import javax.persistence.Basic;
+import javax.persistence.CascadeType;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
@@ -36,7 +47,9 @@ import javax.persistence.ManyToOne;
 import javax.persistence.MapKeyColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -48,6 +61,15 @@ import java.util.Map;
  */
 @Entity
 @Table(name = "authenticators")
+@Indexed(index = "authenticators")
+@FullTextFilterDefs({
+        @FullTextFilterDef(name = "uuid_authenticator_owner",
+                impl = UUIDFilter.class,
+                cache = FilterCacheModeType.INSTANCE_ONLY),
+        @FullTextFilterDef(name = "uuid_authenticator_client",
+                impl = UUIDFilter.class,
+                cache = FilterCacheModeType.INSTANCE_ONLY)
+})
 public final class Authenticator extends AbstractEntity {
 
     /**
@@ -57,22 +79,32 @@ public final class Authenticator extends AbstractEntity {
     @JoinColumn(name = "client", nullable = false, updatable = false)
     @JsonIdentityReference(alwaysAsId = true)
     @JsonDeserialize(using = Client.Deserializer.class)
+    @IndexedEmbedded(includePaths = {"id", "application.owner.id"})
     private Client client;
 
     /**
      * List of all identities assigned to this authenticator.
      */
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "authenticator")
-    @Cascade(CascadeType.ALL)
+    @OneToMany(
+            fetch = FetchType.LAZY,
+            mappedBy = "authenticator",
+            cascade = {CascadeType.REMOVE, CascadeType.MERGE},
+            orphanRemoval = true
+    )
     @JsonIgnore
     private List<UserIdentity> identities;
 
     /**
      * List of all authenticator states currently active.
      */
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "authenticator")
-    @Cascade(CascadeType.ALL)
+    @OneToMany(
+            fetch = FetchType.LAZY,
+            mappedBy = "authenticator",
+            cascade = {CascadeType.REMOVE},
+            orphanRemoval = true
+    )
     @JsonIgnore
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private List<AuthenticatorState> states;
 
     /**
@@ -80,6 +112,8 @@ public final class Authenticator extends AbstractEntity {
      */
     @Basic(optional = false)
     @Column(name = "type", nullable = false, updatable = false)
+    @Field(index = Index.YES, analyze = Analyze.YES, store = Store.NO)
+    @NotNull
     private String type;
 
     /**
@@ -90,7 +124,7 @@ public final class Authenticator extends AbstractEntity {
             joinColumns = @JoinColumn(name = "authenticator"))
     @MapKeyColumn(name = "name")
     @Column(name = "value")
-    private Map<String, String> configuration;
+    private Map<String, String> configuration = new HashMap<>();
 
     /**
      * Get the client for this authenticator.

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/AuthenticatorState.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/AuthenticatorState.java
@@ -19,6 +19,7 @@
 package net.krotscheck.kangaroo.database.entity;
 
 import org.hibernate.annotations.SortNatural;
+import org.hibernate.annotations.Type;
 
 import javax.persistence.Basic;
 import javax.persistence.Column;
@@ -71,6 +72,7 @@ public final class AuthenticatorState extends AbstractEntity {
      */
     @Basic(optional = false)
     @Column(name = "clientRedirect", unique = false)
+    @Type(type = "net.krotscheck.kangaroo.database.type.URIType")
     private URI clientRedirect;
 
     /**

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/ClientType.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/ClientType.java
@@ -64,5 +64,23 @@ public enum ClientType {
      *
      * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.4">https://tools.ietf.org/html/rfc6749#section-4.4</a>
      */
-    ClientCredentials
+    ClientCredentials;
+
+    /**
+     * Is the client type one of the passed in list of types?
+     *
+     * @param types An array of types to check against.
+     * @return True if the type matches, otherwise false.
+     */
+    public Boolean in(final ClientType... types) {
+        if (types == null) {
+            return false;
+        }
+        for (ClientType type : types) {
+            if (this.equals(type)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/ConfigurationEntry.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/ConfigurationEntry.java
@@ -42,14 +42,14 @@ public final class ConfigurationEntry extends AbstractEntity {
      * The key name.
      */
     @Basic(optional = false)
-    @Column(name = "key", nullable = false)
+    @Column(name = "configKey", nullable = false)
     private String key;
 
     /**
      * The stored value.
      */
     @Basic(optional = false)
-    @Column(name = "value", nullable = false)
+    @Column(name = "configValue", nullable = false)
     private String value;
 
     /**

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/jackson/Views.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/jackson/Views.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.database.jackson;
+
+/**
+ * These views describe classes used in Jackson's view annotations.
+ *
+ * @author Michael Krotscheck
+ */
+public final class Views {
+
+    /**
+     * A view used for attributes that are considered secure - such as salts,
+     * passwords, etc.
+     */
+    public static final class Secure {
+    }
+
+    /**
+     * A view used for attributes that are considered public.
+     */
+    public static final class Public {
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/jackson/package-info.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/jackson/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Jackson components for our data models and entities.
+ */
+package net.krotscheck.kangaroo.database.jackson;

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/type/URITypeDescriptor.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/type/URITypeDescriptor.java
@@ -62,7 +62,7 @@ public final class URITypeDescriptor extends AbstractTypeDescriptor<URI> {
      */
     public URI fromString(final String string) {
         try {
-            return UriBuilder.fromPath(string).build();
+            return UriBuilder.fromUri(string).build();
         } catch (Exception e) {
             throw new HibernateException(
                     "Unable to convert string [" + string + "] to URI : " + e);

--- a/kangaroo-common/src/main/resources/hibernate.cfg.xml
+++ b/kangaroo-common/src/main/resources/hibernate.cfg.xml
@@ -38,8 +38,7 @@
     <property name="default_batch_fetch_size">8</property>
 
     <!-- Hibernate Search Configuration -->
-    <property name="search.default.directory_provider">filesystem</property>
-    <property name="hibernate.search.default.indexBase">/tmp/oid_lucene</property>
+    <property name="search.default.directory_provider">ram</property>
     <property name="search.default.optimizer.operation_limit">1000</property>
     <property name="search.default.optimizer.transaction_limit">100</property>
     <property name="search.lucene_version">LUCENE_CURRENT</property>

--- a/kangaroo-common/src/main/resources/kangaroo-char-mapping.properties
+++ b/kangaroo-common/src/main/resources/kangaroo-char-mapping.properties
@@ -1,0 +1,11 @@
+# This file is a series of character replacement rules, to assist in building
+# a solid search index for our entities.
+
+# Convert various punctuation to spaces
+":" => " "
+"-" => " "
+"_" => " "
+"/" => " "
+"?" => " "
+"#" => " "
+"." => " "

--- a/kangaroo-common/src/main/resources/liquibase/db.changelog-1.0.0.yaml
+++ b/kangaroo-common/src/main/resources/liquibase/db.changelog-1.0.0.yaml
@@ -27,12 +27,12 @@ databaseChangeLog:
                 constraints:
                   nullable: false
             - column:
-                name: key
+                name: configKey
                 type: varchar(255)
                 constraints:
                   nullable: false
             - column:
-                name: value
+                name: configValue
                 type: varchar(255)
                 constraints:
                   nullable: false
@@ -46,13 +46,13 @@ databaseChangeLog:
       - createIndex:
           columns:
           - column:
-              name: key
+              name: configKey
               type: varchar(255)
-          indexName: idx_configuration_key
+          indexName: idx_configuration_configKey
           tableName: configuration
       - addUniqueConstraint:
-          columnNames: section, key
-          constraintName: uq_configuration_section_key
+          columnNames: section, configKey
+          constraintName: uq_configuration_section_configKey
           tableName: configuration
 
       # The Application table, the root resource from which everything else
@@ -266,7 +266,7 @@ databaseChangeLog:
           baseColumnNames: role
           baseTableName: users
           constraintName: fk_users_roles
-          onDelete: CASCADE
+          onDelete: SET NULL
           onUpdate: CASCADE
           referencedColumnNames: id
           referencedTableName: roles
@@ -411,12 +411,12 @@ databaseChangeLog:
                 constraints:
                   nullable: false
             - column:
-                name: key
+                name: configKey
                 type: varchar(255)
                 constraints:
                   nullable: false
             - column:
-                name: value
+                name: configValue
                 type: varchar(255)
                 constraints:
                   nullable: true
@@ -430,12 +430,12 @@ databaseChangeLog:
       - createIndex:
           columns:
           - column:
-              name: key
+              name: configKey
               type: varchar(255)
           indexName: idx_client_configs_name
           tableName: client_configs
       - addUniqueConstraint:
-          columnNames: client, key
+          columnNames: client, configKey
           constraintName: uq_client_configs_client_key
           tableName: client_configs
       - addForeignKeyConstraint:
@@ -732,12 +732,12 @@ databaseChangeLog:
                 constraints:
                   nullable: false
             - column:
-                name: key
+                name: claimKey
                 type: varchar(255)
                 constraints:
                   nullable: false
             - column:
-                name: value
+                name: claimValue
                 type: varchar(255)
                 constraints:
                   nullable: true
@@ -751,12 +751,12 @@ databaseChangeLog:
       - createIndex:
           columns:
           - column:
-              name: key
+              name: claimKey
               type: varchar(255)
           indexName: idx_user_identity_claims_name
           tableName: user_identity_claims
       - addUniqueConstraint:
-          columnNames: user_identity, key
+          columnNames: user_identity, claimKey
           constraintName: uq_user_identity_claims_user_identity_name
           tableName: user_identity_claims
       - addForeignKeyConstraint:
@@ -916,6 +916,9 @@ databaseChangeLog:
             tableName: client_referrers
         - dropTable:
             tableName: clients
+        - dropForeignKeyConstraint:
+            constraintName: fk_applications_owner
+            baseTableName: applications
         - dropTable:
             tableName: users
         - dropTable:

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/AbstractEntityTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/AbstractEntityTest.java
@@ -145,6 +145,20 @@ public final class AbstractEntityTest {
     }
 
     /**
+     * Test cloneable.
+     *
+     * @throws CloneNotSupportedException Should not be thrown.
+     */
+    @Test
+    public void testCloneable() throws CloneNotSupportedException {
+        AbstractEntity a = new TestEntity();
+        a.setId(UUID.randomUUID());
+        AbstractEntity b = (AbstractEntity) a.clone();
+
+        Assert.assertEquals(a.getId(), b.getId());
+    }
+
+    /**
      * Test entity, used for testing!
      */
     private static class TestEntity extends AbstractEntity {

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/ApplicationScopeTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/ApplicationScopeTest.java
@@ -80,7 +80,7 @@ public final class ApplicationScopeTest {
         List<Role> roles = new ArrayList<>();
         roles.add(new Role());
 
-        Assert.assertNull(scope.getRoles());
+        Assert.assertTrue(scope.getRoles().size() == 0);
         scope.setRoles(roles);
         Assert.assertEquals(roles, scope.getRoles());
         Assert.assertNotSame(roles, scope.getRoles());
@@ -95,7 +95,7 @@ public final class ApplicationScopeTest {
         List<OAuthToken> tokens = new ArrayList<>();
         tokens.add(new OAuthToken());
 
-        Assert.assertNull(scope.getTokens());
+        Assert.assertTrue(scope.getTokens().size() == 0);
         scope.setTokens(tokens);
         Assert.assertEquals(tokens, scope.getTokens());
         Assert.assertNotSame(tokens, scope.getTokens());

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/AuthenticatorTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/AuthenticatorTest.java
@@ -81,7 +81,7 @@ public final class AuthenticatorTest {
         Authenticator auth = new Authenticator();
         Map<String, String> config = new HashMap<>();
 
-        Assert.assertNull(auth.getConfiguration());
+        Assert.assertEquals(0, auth.getConfiguration().size());
         auth.setConfiguration(config);
         Assert.assertEquals(config, auth.getConfiguration());
     }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/ClientTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/ClientTest.java
@@ -99,7 +99,7 @@ public final class ClientTest {
     public void testGetSetType() {
         Client c = new Client();
 
-        Assert.assertEquals(ClientType.AuthorizationGrant, c.getType());
+        Assert.assertNull(c.getType());
         c.setType(ClientType.Implicit);
         Assert.assertEquals(ClientType.Implicit, c.getType());
     }
@@ -117,7 +117,7 @@ public final class ClientTest {
         URI referrer = new URI("https://example.com/oauth/foo?lol=cat#omg");
         referrers.add(referrer);
 
-        Assert.assertNull(c.getReferrers());
+        Assert.assertEquals(0, c.getReferrers().size());
         c.setReferrers(referrers);
         Assert.assertEquals(referrers, c.getReferrers());
         Assert.assertTrue(c.getReferrers().contains(referrer));
@@ -136,7 +136,7 @@ public final class ClientTest {
         URI redirect = new URI("https://example.com/oauth/foo?lol=cat#omg");
         redirects.add(redirect);
 
-        Assert.assertNull(c.getRedirects());
+        Assert.assertEquals(0, c.getRedirects().size());
         c.setRedirects(redirects);
         Assert.assertEquals(redirects, c.getRedirects());
         Assert.assertTrue(c.getRedirects().contains(redirect));
@@ -195,7 +195,7 @@ public final class ClientTest {
         Client client = new Client();
         Map<String, String> configuration = new HashMap<>();
 
-        Assert.assertNull(client.getConfiguration());
+        Assert.assertEquals(0, client.getConfiguration().size());
         client.setConfiguration(configuration);
         Assert.assertEquals(configuration, client.getConfiguration());
         Assert.assertNotSame(configuration, client.getConfiguration());

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/ClientTypeTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/ClientTypeTest.java
@@ -77,4 +77,32 @@ public final class ClientTypeTest {
                 m.readValue("\"ClientCredentials\"", ClientType.class);
         Assert.assertSame(client, ClientType.ClientCredentials);
     }
+
+    /**
+     * Assert that the in() method works with various input types.
+     */
+    @Test
+    public void testInWithValues() {
+        Assert.assertFalse(ClientType.AuthorizationGrant.in());
+        Assert.assertFalse(ClientType.AuthorizationGrant.in(null));
+        Assert.assertTrue(ClientType.AuthorizationGrant.in(
+                ClientType.ClientCredentials,
+                ClientType.AuthorizationGrant
+        ));
+        Assert.assertTrue(ClientType.AuthorizationGrant.in(
+                ClientType.AuthorizationGrant
+        ));
+        Assert.assertTrue(ClientType.AuthorizationGrant.in(
+                ClientType.AuthorizationGrant,
+                ClientType.AuthorizationGrant,
+                ClientType.AuthorizationGrant
+        ));
+        Assert.assertFalse(ClientType.AuthorizationGrant.in(
+                ClientType.Implicit,
+                ClientType.ClientCredentials,
+                ClientType.OwnerCredentials
+        ));
+    }
+
+
 }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/OAuthTokenTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/OAuthTokenTest.java
@@ -83,7 +83,7 @@ public final class OAuthTokenTest {
         OAuthToken c = new OAuthToken();
 
         // Default
-        Assert.assertEquals(OAuthTokenType.Bearer, c.getTokenType());
+        Assert.assertNull(c.getTokenType());
         c.setTokenType(OAuthTokenType.Authorization);
         Assert.assertEquals(OAuthTokenType.Authorization, c.getTokenType());
     }
@@ -96,7 +96,7 @@ public final class OAuthTokenTest {
         OAuthToken c = new OAuthToken();
 
         // Default
-        Assert.assertEquals(600, c.getExpiresIn().longValue());
+        Assert.assertNull(c.getExpiresIn());
         c.setExpiresIn(100);
         Assert.assertEquals(100, c.getExpiresIn().longValue());
         c.setExpiresIn((long) 200);
@@ -107,6 +107,8 @@ public final class OAuthTokenTest {
         Assert.assertEquals(22, c.getExpiresIn().longValue());
         c.setExpiresIn(Long.valueOf(100));
         Assert.assertEquals(100, c.getExpiresIn().longValue());
+        c.setExpiresIn((Long) null);
+        Assert.assertNull(c.getExpiresIn());
     }
 
     /**
@@ -185,7 +187,7 @@ public final class OAuthTokenTest {
         SortedMap<String, ApplicationScope> scopes = new TreeMap<>();
         scopes.put("test", new ApplicationScope());
 
-        Assert.assertNull(token.getScopes());
+        Assert.assertEquals(0, token.getScopes().size());
         token.setScopes(scopes);
         Assert.assertEquals(scopes, token.getScopes());
         Assert.assertNotSame(scopes, token.getScopes());
@@ -241,6 +243,7 @@ public final class OAuthTokenTest {
         identity.setId(UUID.randomUUID());
 
         Client client = new Client();
+        client.setType(ClientType.ClientCredentials);
         client.setId(UUID.randomUUID());
 
         OAuthToken token = new OAuthToken();
@@ -278,9 +281,12 @@ public final class OAuthTokenTest {
         Assert.assertEquals(
                 token.getRedirect().toString(),
                 node.get("redirect").asText());
-
-        Assert.assertFalse(node.has("client"));
-        Assert.assertFalse(node.has("identity"));
+        Assert.assertEquals(
+                token.getClient().getId().toString(),
+                node.get("client").asText());
+        Assert.assertEquals(
+                token.getIdentity().getId().toString(),
+                node.get("identity").asText());
 
         // Enforce a given number of items.
         List<String> names = new ArrayList<>();
@@ -288,7 +294,7 @@ public final class OAuthTokenTest {
         while (nameIterator.hasNext()) {
             names.add(nameIterator.next());
         }
-        Assert.assertEquals(6, names.size());
+        Assert.assertEquals(8, names.size());
     }
 
     /**

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/RoleTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/RoleTest.java
@@ -35,6 +35,8 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Iterator;
 import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.UUID;
 
 import static org.mockito.Mockito.mock;
@@ -94,10 +96,10 @@ public final class RoleTest {
     @Test
     public void testGetSetScopes() {
         Role role = new Role();
-        List<ApplicationScope> scopes = new ArrayList<>();
-        scopes.add(new ApplicationScope());
+        SortedMap<String, ApplicationScope> scopes = new TreeMap<>();
+        scopes.put("foo", new ApplicationScope());
 
-        Assert.assertNull(role.getScopes());
+        Assert.assertEquals(0, role.getScopes().size());
         role.setScopes(scopes);
         Assert.assertEquals(scopes, role.getScopes());
         Assert.assertNotSame(scopes, role.getScopes());

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/UserIdentityTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/UserIdentityTest.java
@@ -108,7 +108,7 @@ public final class UserIdentityTest {
         UserIdentity identity = new UserIdentity();
         Map<String, String> claims = new HashMap<>();
 
-        Assert.assertNull(identity.getClaims());
+        Assert.assertEquals(0, identity.getClaims().size());
         identity.setClaims(claims);
         Assert.assertEquals(claims, identity.getClaims());
         Assert.assertNotSame(claims, identity.getClaims());
@@ -211,8 +211,10 @@ public final class UserIdentityTest {
                 claimsNode.get("two").asText());
 
         Assert.assertFalse(node.has("tokens"));
-        Assert.assertFalse(node.has("password"));
-        Assert.assertFalse(node.has("salt"));
+        // We are not testing for password/salt, as those are
+        // handled by view inclusion
+//        Assert.assertFalse(node.has("password"));
+//        Assert.assertFalse(node.has("salt"));
 
         // Enforce a given number of items.
         List<String> names = new ArrayList<>();
@@ -220,7 +222,7 @@ public final class UserIdentityTest {
         while (nameIterator.hasNext()) {
             names.add(nameIterator.next());
         }
-        Assert.assertEquals(7, names.size());
+        Assert.assertEquals(9, names.size());
     }
 
     /**

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/UserTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/UserTest.java
@@ -61,6 +61,22 @@ public final class UserTest {
     }
 
     /**
+     * Assert that we can get and set the applications which this user owns
+     */
+    @Test
+    public void testGetSetApplications() {
+        User u = new User();
+        List<Application> applications = new ArrayList<>();
+        applications.add(new Application());
+        applications.add(new Application());
+
+        Assert.assertNull(u.getApplications());
+        u.setApplications(applications);
+        Assert.assertEquals(applications, u.getApplications());
+        Assert.assertNotSame(applications, u.getApplications());
+    }
+
+    /**
      * Assert that we can get and set the user's role.
      */
     @Test

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/jackson/ViewsTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/jackson/ViewsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.database.jackson;
+
+import net.krotscheck.kangaroo.database.jackson.Views.Public;
+import net.krotscheck.kangaroo.database.jackson.Views.Secure;
+import org.junit.Test;
+
+/**
+ * Smoke test for the jackson view annotation classes.
+ *
+ * @author Michael Krotscheck
+ */
+public final class ViewsTest {
+
+    /**
+     * Test that all three classes exist.
+     */
+    @Test
+    public void assertAllClasses() {
+        Views views = new Views();
+        Public pub = new Views.Public();
+        Secure secure = new Views.Secure();
+    }
+
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/EnvironmentBuilderTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/EnvironmentBuilderTest.java
@@ -149,7 +149,7 @@ public final class EnvironmentBuilderTest extends DatabaseTest {
         Assert.assertEquals(b.getClient(), b.getAuthenticator().getClient());
 
         // Add a redirect for this client.
-        Assert.assertNull(b.getClient().getRedirects());
+        Assert.assertEquals(0, b.getClient().getRedirects().size());
         b.redirect("http://example.com");
         Assert.assertNotNull(b.getClient().getRedirects());
         Assert.assertTrue(b.getClient().getRedirects()
@@ -161,7 +161,7 @@ public final class EnvironmentBuilderTest extends DatabaseTest {
         Assert.assertEquals(2, b.getClient().getRedirects().size());
 
         // Add a referrer for this client.
-        Assert.assertNull(b.getClient().getReferrers());
+        Assert.assertEquals(0, b.getClient().getReferrers().size());
         b.referrer("http://example.com");
         Assert.assertNotNull(b.getClient().getReferrers());
         Assert.assertTrue(b.getClient().getReferrers()
@@ -194,7 +194,7 @@ public final class EnvironmentBuilderTest extends DatabaseTest {
                 b.getUserIdentity().getAuthenticator());
 
         // Add some claims to the user identity
-        Assert.assertNull(b.getUserIdentity().getClaims());
+        Assert.assertEquals(0, b.getUserIdentity().getClaims().size());
         b.claim("foo", "bar");
         b.claim("lol", "cat");
         Assert.assertEquals("bar", b.getUserIdentity().getClaims().get("foo"));

--- a/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/UserService.java
+++ b/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/UserService.java
@@ -97,7 +97,7 @@ public final class UserService extends AbstractService {
         org.apache.lucene.search.Query luceneQuery = builder
                 .keyword()
                 .fuzzy()
-                .onFields("identities.claims")
+                .onFields("identities.claims", "identities.remoteId")
                 .matching(queryString)
                 .createQuery();
 

--- a/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/servlet/FirstRunContainerLifecycleListener.java
+++ b/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/servlet/FirstRunContainerLifecycleListener.java
@@ -37,8 +37,8 @@ import org.hibernate.Transaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -111,12 +111,12 @@ public final class FirstRunContainerLifecycleListener
         passwordAuth.setClient(servletClient);
 
         // Create the scopes
-        List<ApplicationScope> scopes = new ArrayList<>();
-        for (String scope : Scope.allScopes()) {
+        SortedMap<String, ApplicationScope> scopes = new TreeMap<>();
+        for (String scopeName : Scope.allScopes()) {
             ApplicationScope newScope = new ApplicationScope();
             newScope.setApplication(servletApp);
-            newScope.setName(scope);
-            scopes.add(newScope);
+            newScope.setName(scopeName);
+            scopes.put(scopeName, newScope);
         }
 
         // Create the roles.


### PR DESCRIPTION
The following corrections were made to the data model:

- Cascade types have been explicitly declared. This assists in building
  the search indexes.
- Search indexes are constructed for all primary entities.
- Foreign index dropped manually in rollback.
- MySQL Reserved words have been changed (key, value).
- hibernate.cfg.xml files removed in favor of global one.
- Owned applications are accessible via the user.
- URITypes have been applied where appropriate.
- Bug in URIType has been fixed.
- UserIdentity's remoteId has been added to User Search Index.
- Default Lucene index is now kept in Ram (build speed improvement).
- Roles now use the same scope data structure as tokens, etc.
- Validation Rule annotations have been added.
- View classes for non-jsonignore based entity filtering.
- Some special characters are converted into whitespace.