### PR TITLE
Corrected test execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
   - mvn checkstyle:check -Ptravis
   - mvn pmd:check -Ptravis
   - mvn pmd:cpd-check -Ptravis
+  - mvn install -Ptravis
   - mvn cobertura:check -Ptravis
-  - mvn install -DskipTests -Ptravis
 after_success:
   - mvn cobertura:cobertura coveralls:report -DskipTests -Ptravis


### PR DESCRIPTION
The cobertura:check directive will only fail if coverage metrics are
not met: not if a unit test fails. This fixes this, even though it
means the tests run twice.