### PR TITLE
Permitted token scopes are now restricted by role.

### DIFF
--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/TestAuthenticator.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/TestAuthenticator.java
@@ -19,7 +19,9 @@
 package net.krotscheck.kangaroo.test;
 
 import net.krotscheck.kangaroo.authenticator.IAuthenticator;
+import net.krotscheck.kangaroo.database.entity.Application;
 import net.krotscheck.kangaroo.database.entity.Authenticator;
+import net.krotscheck.kangaroo.database.entity.Role;
 import net.krotscheck.kangaroo.database.entity.User;
 import net.krotscheck.kangaroo.database.entity.UserIdentity;
 import org.apache.http.HttpStatus;
@@ -96,7 +98,6 @@ public final class TestAuthenticator
     public UserIdentity authenticate(final Authenticator authenticator,
                                      final MultivaluedMap<String, String>
                                              parameters) {
-
         Criteria searchCriteria = session.createCriteria(UserIdentity.class);
 
         searchCriteria.add(Restrictions.eq("authenticator", authenticator));
@@ -108,8 +109,12 @@ public final class TestAuthenticator
 
         // Do we need to create a new user?
         if (results.size() == 0) {
+            Role testRole = getTestAuthenticatorRole(
+                    authenticator.getClient().getApplication());
+
             User devUser = new User();
             devUser.setApplication(authenticator.getClient().getApplication());
+            devUser.setRole(testRole);
 
             UserIdentity identity = new UserIdentity();
             identity.setAuthenticator(authenticator);
@@ -125,6 +130,22 @@ public final class TestAuthenticator
         }
 
         return results.get(0);
+    }
+
+    /**
+     * Get the "test" role from the passed application, assuming it exists.
+     * If it does not exist, it will not be created.
+     *
+     * @param application The passed application.
+     * @return A role, or null.
+     */
+    private Role getTestAuthenticatorRole(final Application application) {
+        for (Role r : application.getRoles()) {
+            if (r.getName().equals("test")) {
+                return r;
+            }
+        }
+        return null;
     }
 
     /**

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/util/ValidationUtilTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/util/ValidationUtilTest.java
@@ -25,6 +25,7 @@ import net.krotscheck.kangaroo.database.entity.ApplicationScope;
 import net.krotscheck.kangaroo.database.entity.Authenticator;
 import net.krotscheck.kangaroo.database.entity.Client;
 import net.krotscheck.kangaroo.database.entity.ClientType;
+import net.krotscheck.kangaroo.database.entity.Role;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -448,6 +449,167 @@ public final class ValidationUtilTest {
     }
 
     /**
+     * Assert that null role fails.
+     *
+     * @throws Exception Should be thrown when the validation fails.
+     */
+    @Test(expected = InvalidScopeException.class)
+    public void testValidateScopeStringNullRole() throws Exception {
+        ValidationUtil.validateScope("debug1", (Role) null);
+    }
+
+    /**
+     * Assert that a role with no scopes passes.
+     *
+     * @throws Exception Should be thrown when the validation fails.
+     */
+    @Test
+    public void testValidateScopeStringNoScopeRole() throws Exception {
+        SortedMap<String, ApplicationScope> roleScopes = new TreeMap<>();
+
+        Role r = new Role();
+        r.setScopes(roleScopes);
+
+        SortedMap<String, ApplicationScope> scopes =
+                ValidationUtil.validateScope("", r);
+        Assert.assertEquals(0, scopes.size());
+    }
+
+    /**
+     * Assert that a role with valid scopes passes.
+     *
+     * @throws Exception Should be thrown when the validation fails.
+     */
+    @Test
+    public void testValidateScopeStringValidScopesInRole() throws Exception {
+        SortedMap<String, ApplicationScope> roleScopes = new TreeMap<>();
+
+        ApplicationScope debug1Scope = new ApplicationScope();
+        debug1Scope.setName("debug1");
+        roleScopes.put(debug1Scope.getName(), debug1Scope);
+
+        ApplicationScope debug2Scope = new ApplicationScope();
+        debug2Scope.setName("debug2");
+        roleScopes.put(debug2Scope.getName(), debug2Scope);
+
+        Role r = new Role();
+        r.setScopes(roleScopes);
+
+        SortedMap<String, ApplicationScope> scopes =
+                ValidationUtil.validateScope("debug2", r);
+        Assert.assertEquals(1, scopes.size());
+    }
+
+    /**
+     * Assert that a role with mismatching scopes fails.
+     *
+     * @throws Exception Should be thrown when the validation fails.
+     */
+    @Test(expected = InvalidScopeException.class)
+    public void testValidateScopeStringMismatchScopesInRole() throws Exception {
+        SortedMap<String, ApplicationScope> roleScopes = new TreeMap<>();
+
+        ApplicationScope debug1Scope = new ApplicationScope();
+        debug1Scope.setName("debug1");
+        roleScopes.put(debug1Scope.getName(), debug1Scope);
+
+        ApplicationScope debug2Scope = new ApplicationScope();
+        debug2Scope.setName("debug2");
+        roleScopes.put(debug2Scope.getName(), debug2Scope);
+
+        Role r = new Role();
+        r.setScopes(roleScopes);
+
+        ValidationUtil.validateScope("debug1 debug3", r);
+    }
+
+    /**
+     * Assert that null role fails.
+     *
+     * @throws Exception Should be thrown when the validation fails.
+     */
+    @Test(expected = InvalidScopeException.class)
+    public void testValidateScopeMapNullRole() throws Exception {
+        ValidationUtil.validateScope(new TreeMap<>(),
+                (Role) null);
+    }
+
+    /**
+     * Assert that a role with no scopes passes.
+     *
+     * @throws Exception Should be thrown when the validation fails.
+     */
+    @Test
+    public void testValidateScopeMapNoScopeRole() throws Exception {
+        SortedMap<String, ApplicationScope> roleScopes = new TreeMap<>();
+
+        Role r = new Role();
+        r.setScopes(roleScopes);
+
+        SortedMap<String, ApplicationScope> scopes =
+                ValidationUtil.validateScope(new TreeMap<>(), r);
+        Assert.assertEquals(0, scopes.size());
+    }
+
+    /**
+     * Assert that a role with valid scopes passes.
+     *
+     * @throws Exception Should be thrown when the validation fails.
+     */
+    @Test
+    public void testValidateScopeMapValidScopesInRole() throws Exception {
+        SortedMap<String, ApplicationScope> roleScopes = new TreeMap<>();
+
+        ApplicationScope debug1Scope = new ApplicationScope();
+        debug1Scope.setName("debug1");
+        roleScopes.put(debug1Scope.getName(), debug1Scope);
+
+        ApplicationScope debug2Scope = new ApplicationScope();
+        debug2Scope.setName("debug2");
+        roleScopes.put(debug2Scope.getName(), debug2Scope);
+
+        SortedMap<String, ApplicationScope> requestedScopes = new TreeMap<>();
+        requestedScopes.put(debug2Scope.getName(), debug2Scope);
+
+        Role r = new Role();
+        r.setScopes(roleScopes);
+
+        SortedMap<String, ApplicationScope> scopes =
+                ValidationUtil.validateScope(requestedScopes, r);
+        Assert.assertEquals(1, scopes.size());
+    }
+
+    /**
+     * Assert that a role with mismatching scopes fails.
+     *
+     * @throws Exception Should be thrown when the validation fails.
+     */
+    @Test(expected = InvalidScopeException.class)
+    public void testValidateScopeMapMismatchScopesInRole() throws Exception {
+        SortedMap<String, ApplicationScope> roleScopes = new TreeMap<>();
+
+        ApplicationScope debug1Scope = new ApplicationScope();
+        debug1Scope.setName("debug1");
+        roleScopes.put(debug1Scope.getName(), debug1Scope);
+
+        ApplicationScope debug2Scope = new ApplicationScope();
+        debug2Scope.setName("debug2");
+        roleScopes.put(debug2Scope.getName(), debug2Scope);
+
+        ApplicationScope debug3Scope = new ApplicationScope();
+        debug3Scope.setName("debug3");
+
+        SortedMap<String, ApplicationScope> requestedScopes = new TreeMap<>();
+        requestedScopes.put(debug2Scope.getName(), debug2Scope);
+        requestedScopes.put(debug3Scope.getName(), debug3Scope);
+
+        Role r = new Role();
+        r.setScopes(roleScopes);
+
+        ValidationUtil.validateScope(requestedScopes, r);
+    }
+
+    /**
      * Assert that a basic test passes using a request array.
      *
      * @throws Exception Should only be thrown when the validation fails.
@@ -471,6 +633,32 @@ public final class ValidationUtilTest {
                 ValidationUtil.revalidateScope(
                         "debug1", validScopes, validScopes);
         Assert.assertEquals(1, scopes.size());
+    }
+
+    /**
+     * Assert that a basic test passes using a request role.
+     *
+     * @throws Exception Should only be thrown when the validation fails.
+     */
+    @Test
+    public void testRevalidateRequestRole() throws Exception {
+        Role r = new Role();
+        r.setScopes(validScopes);
+
+        SortedMap<String, ApplicationScope> scopes =
+                ValidationUtil.revalidateScope(
+                        "debug1", validScopes, r);
+        Assert.assertEquals(1, scopes.size());
+    }
+
+    /**
+     * Assert that passing a null role fails.
+     *
+     * @throws Exception Should only be thrown when the validation fails.
+     */
+    @Test(expected = InvalidScopeException.class)
+    public void testRevalidateNullRole() throws Exception {
+        ValidationUtil.revalidateScope("debug1", validScopes, (Role) null);
     }
 
     /**

--- a/kangaroo-server-oauth2/src/main/java/net/krotscheck/kangaroo/servlet/oauth2/resource/AuthorizationService.java
+++ b/kangaroo-server-oauth2/src/main/java/net/krotscheck/kangaroo/servlet/oauth2/resource/AuthorizationService.java
@@ -251,7 +251,8 @@ public final class AuthorizationService {
         OAuthToken t = new OAuthToken();
         t.setClient(s.getClient());
         t.setIdentity(i);
-        t.setScopes(s.getClientScopes());
+        t.setScopes(ValidationUtil
+                .validateScope(s.getClientScopes(), i.getUser().getRole()));
         t.setTokenType(OAuthTokenType.Bearer);
         t.setExpiresIn(s.getClient().getAccessTokenExpireIn());
 
@@ -302,7 +303,8 @@ public final class AuthorizationService {
         OAuthToken t = new OAuthToken();
         t.setClient(s.getClient());
         t.setIdentity(i);
-        t.setScopes(s.getClientScopes());
+        t.setScopes(ValidationUtil
+                .validateScope(s.getClientScopes(), i.getUser().getRole()));
         t.setTokenType(OAuthTokenType.Authorization);
         t.setExpiresIn(s.getClient().getAuthorizationCodeExpiresIn());
         t.setRedirect(s.getClientRedirect());

--- a/kangaroo-server-oauth2/src/main/java/net/krotscheck/kangaroo/servlet/oauth2/resource/grant/ClientCredentialsGrantHandler.java
+++ b/kangaroo-server-oauth2/src/main/java/net/krotscheck/kangaroo/servlet/oauth2/resource/grant/ClientCredentialsGrantHandler.java
@@ -84,7 +84,8 @@ public final class ClientCredentialsGrantHandler implements IGrantTypeHandler {
             throw new UnauthorizedClientException();
         }
 
-        // Make sure all requested scopes are in the map.
+        // This flow permits requesting any of the available scopes from the
+        // application, without filtering by Roles.
         SortedMap<String, ApplicationScope> requestedScopes =
                 ValidationUtil.validateScope(formData.getFirst("scope"),
                         client.getApplication().getScopes());

--- a/kangaroo-server-oauth2/src/main/java/net/krotscheck/kangaroo/servlet/oauth2/resource/grant/OwnerCredentialsGrantHandler.java
+++ b/kangaroo-server-oauth2/src/main/java/net/krotscheck/kangaroo/servlet/oauth2/resource/grant/OwnerCredentialsGrantHandler.java
@@ -104,10 +104,10 @@ public final class OwnerCredentialsGrantHandler implements IGrantTypeHandler {
             throw new HttpStatusException(HttpStatus.SC_UNAUTHORIZED);
         }
 
-        // Make sure all requested scopes are in the map.
+        // Make sure all requested scopes are permitted for this user.
         SortedMap<String, ApplicationScope> requestedScopes =
                 ValidationUtil.validateScope(formData.getFirst("scope"),
-                        client.getApplication().getScopes());
+                        identity.getUser().getRole());
 
         // Ensure that we retrieve a state, if it exists.
         String state = formData.getFirst("state");

--- a/kangaroo-server-oauth2/src/main/java/net/krotscheck/kangaroo/servlet/oauth2/resource/grant/RefreshTokenGrantHandler.java
+++ b/kangaroo-server-oauth2/src/main/java/net/krotscheck/kangaroo/servlet/oauth2/resource/grant/RefreshTokenGrantHandler.java
@@ -102,7 +102,7 @@ public final class RefreshTokenGrantHandler implements IGrantTypeHandler {
                 ValidationUtil.revalidateScope(
                         formData.getFirst("scope"),
                         refreshToken.getScopes(),
-                        refreshToken.getClient().getApplication().getScopes()
+                        refreshToken.getIdentity().getUser().getRole()
                 );
 
         // Ensure that we retrieve a state, if it exists.

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/grant/RefreshTokenGrantHandlerTest.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/grant/RefreshTokenGrantHandlerTest.java
@@ -103,8 +103,12 @@ public final class RefreshTokenGrantHandlerTest
 
         authGrantContext = new EnvironmentBuilder(getSession())
                 .client(ClientType.AuthorizationGrant, true)
+                .authenticator("test")
                 .scope("debug")
                 .scope("debug1")
+                .role("test", new String[]{"debug", "debug1"})
+                .user()
+                .identity("remote_identity")
                 .bearerToken();
         authToken = authGrantContext.getToken();
         authGrantContext
@@ -113,8 +117,12 @@ public final class RefreshTokenGrantHandlerTest
 
         ownerCredsContext = new EnvironmentBuilder(getSession())
                 .client(ClientType.OwnerCredentials, true)
+                .authenticator("test")
                 .scope("debug")
                 .scope("debug1")
+                .role("test", new String[]{"debug", "debug1"})
+                .user()
+                .identity("remote_identity")
                 .bearerToken();
         authToken = ownerCredsContext.getToken();
         ownerCredsContext
@@ -123,7 +131,11 @@ public final class RefreshTokenGrantHandlerTest
 
         expiredContext = new EnvironmentBuilder(getSession())
                 .client(ClientType.OwnerCredentials, true)
+                .authenticator("test")
                 .scope("debug")
+                .role("test", new String[]{"debug"})
+                .user()
+                .identity("remote_identity")
                 .bearerToken();
         authToken = expiredContext.getToken();
         expiredContext
@@ -132,13 +144,18 @@ public final class RefreshTokenGrantHandlerTest
 
         zombieRefreshContext = new EnvironmentBuilder(getSession())
                 .client(ClientType.OwnerCredentials, true)
+                .authenticator("test")
                 .scope("debug")
+                .role("test", new String[]{"debug"})
+                .user()
+                .identity("remote_identity")
                 .refreshToken();
-
 
         implicitContext = new EnvironmentBuilder(getSession())
                 .client(ClientType.Implicit, true)
+                .authenticator("test")
                 .scope("debug")
+                .role("test", new String[]{"debug"})
                 .bearerToken();
         authToken = implicitContext.getToken();
         implicitContext

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/AbstractRFC6749Test.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/AbstractRFC6749Test.java
@@ -20,6 +20,7 @@ package net.krotscheck.kangaroo.servlet.oauth2.rfc6749;
 import net.krotscheck.kangaroo.servlet.oauth2.OAuthTestApp;
 import net.krotscheck.kangaroo.test.ContainerTest;
 import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.TestProperties;
 
 /**
  * Abstract testing class that bootstraps a full OAuthAPI that's ready for
@@ -37,6 +38,8 @@ public abstract class AbstractRFC6749Test extends ContainerTest {
      */
     @Override
     protected final ResourceConfig createApplication() {
+        enable(TestProperties.LOG_TRAFFIC);
+        enable(TestProperties.DUMP_ENTITY);
         return new OAuthTestApp();
     }
 }

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/Section430OwnerPasswordTest.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/Section430OwnerPasswordTest.java
@@ -83,12 +83,14 @@ public final class Section430OwnerPasswordTest
     public List<EnvironmentBuilder> fixtures() throws Exception {
         builder = new EnvironmentBuilder(getSession())
                 .scope("debug")
+                .role("debug", new String[]{"debug"})
                 .client(ClientType.OwnerCredentials)
                 .authenticator("password")
                 .user()
                 .login(username, password);
         authBuilder = new EnvironmentBuilder(getSession())
                 .scope("debug")
+                .role("debug", new String[]{"debug"})
                 .client(ClientType.OwnerCredentials, true)
                 .authenticator("password")
                 .user()

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/Section600RefreshTokenTest.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/Section600RefreshTokenTest.java
@@ -86,11 +86,11 @@ public final class Section600RefreshTokenTest
     @Override
     public List<EnvironmentBuilder> fixtures() {
         context = new EnvironmentBuilder(getSession())
-                .role("debug")
-                .client(ClientType.AuthorizationGrant)
-                .authenticator("debug")
                 .scope("debug")
                 .scope("debug2")
+                .role("test", new String[]{"debug", "debug2"})
+                .client(ClientType.AuthorizationGrant)
+                .authenticator("debug")
                 .user()
                 .identity("test_identity_1")
                 .bearerToken();
@@ -114,11 +114,11 @@ public final class Section600RefreshTokenTest
         expiredToken = context.getToken();
 
         authContext = new EnvironmentBuilder(getSession())
-                .role("debug")
-                .client(ClientType.OwnerCredentials, true)
-                .authenticator("debug")
                 .scope("debug")
                 .scope("debug2")
+                .role("test", new String[]{"debug", "debug2"})
+                .client(ClientType.OwnerCredentials, true)
+                .authenticator("debug")
                 .user()
                 .identity("test_identity_2")
                 .bearerToken()


### PR DESCRIPTION
In the flows where a specific user is making a token request
(all flows except for client_credentials), the list of scopes
a request may issue is now restricted by the scopes permitted
to the role assigned by the user. This patch includes
modifications to the Validationutil, associated tests, as
well as the TestAuthenticator.

Closes #105