### PR TITLE
Added admin scopes

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -104,7 +104,7 @@
 
 
         <!-- Checks for common coding problems               -->
-        <module name="AvoidInlineConditionals"/>
+        <!--<module name="AvoidInlineConditionals"/>-->
         <module name="EmptyStatement"/>
         <module name="EqualsHashCode"/>
         <!--<module name="HiddenField"/>-->

--- a/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/Scope.java
+++ b/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/Scope.java
@@ -17,6 +17,16 @@
 
 package net.krotscheck.kangaroo.servlet.admin.v1;
 
+import net.krotscheck.kangaroo.database.entity.AbstractEntity;
+import net.krotscheck.kangaroo.database.entity.Application;
+import net.krotscheck.kangaroo.database.entity.ApplicationScope;
+import net.krotscheck.kangaroo.database.entity.Authenticator;
+import net.krotscheck.kangaroo.database.entity.Client;
+import net.krotscheck.kangaroo.database.entity.OAuthToken;
+import net.krotscheck.kangaroo.database.entity.Role;
+import net.krotscheck.kangaroo.database.entity.User;
+import net.krotscheck.kangaroo.database.entity.UserIdentity;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -38,32 +48,96 @@ public final class Scope {
     /**
      * Authorization scope for the user resource.
      */
-    public static final String USER = "kangaroo:user";
+    public static final String USER
+            = "kangaroo:user";
+
+    /**
+     * Administration scope for the user resource.
+     */
+    public static final String USER_ADMIN
+            = "kangaroo:user_admin";
 
     /**
      * Authorization scope for the application resource.
      */
-    public static final String APPLICATION = "kangaroo:application";
+    public static final String APPLICATION
+            = "kangaroo:application";
+
+    /**
+     * Administration scope for the application resource.
+     */
+    public static final String APPLICATION_ADMIN
+            = "kangaroo:application_admin";
 
     /**
      * Authorization scope for the authenticator resource.
      */
-    public static final String AUTHENTICATOR = "kangaroo:authenticator";
+    public static final String AUTHENTICATOR
+            = "kangaroo:authenticator";
+
+    /**
+     * Authorization scope for the authenticator resource.
+     */
+    public static final String AUTHENTICATOR_ADMIN =
+            "kangaroo:authenticator_admin";
 
     /**
      * Authorization scope for the client resource.
      */
-    public static final String CLIENT = "kangaroo:client";
+    public static final String CLIENT
+            = "kangaroo:client";
+
+    /**
+     * Administration scope for the client resource.
+     */
+    public static final String CLIENT_ADMIN
+            = "kangaroo:client_admin";
 
     /**
      * Authorization scope for the identity resource.
      */
-    public static final String IDENTITY = "kangaroo:identity";
+    public static final String IDENTITY
+            = "kangaroo:identity";
+
+    /**
+     * Administration scope for the identity resource.
+     */
+    public static final String IDENTITY_ADMIN
+            = "kangaroo:identity_admin";
+
+    /**
+     * Authorization scope for the token resource.
+     */
+    public static final String TOKEN
+            = "kangaroo:token";
+
+    /**
+     * Administration scope for the token resource.
+     */
+    public static final String TOKEN_ADMIN
+            = "kangaroo:token_admin";
 
     /**
      * Authorization scope for the roles resource.
      */
     public static final String ROLE = "kangaroo:role";
+
+    /**
+     * Administration scope for the roles resource.
+     */
+    public static final String ROLE_ADMIN = "kangaroo:role_admin";
+
+    /**
+     * Authorization scope for the scopes resource (not to be mistaken with
+     * this class).
+     */
+    public static final String SCOPE = "kangaroo:scope";
+
+    /**
+     * Administration scope for the scopes resource (not to be mistaken with
+     * this class).
+     */
+    public static final String SCOPE_ADMIN = "kangaroo:scope_admin";
 
     /**
      * Get a list of all the scopes.
@@ -72,7 +146,68 @@ public final class Scope {
      */
     public static List<String> allScopes() {
         return Collections.unmodifiableList(
+                Arrays.asList(APPLICATION, APPLICATION_ADMIN, AUTHENTICATOR,
+                        AUTHENTICATOR_ADMIN, CLIENT, CLIENT_ADMIN, IDENTITY,
+                        IDENTITY_ADMIN, ROLE, ROLE_ADMIN, USER, USER_ADMIN,
+                        SCOPE, SCOPE_ADMIN, TOKEN, TOKEN_ADMIN));
+    }
+
+    /**
+     * List of all scopes granted to admins.
+     *
+     * @return List of all administrator scopes.
+     */
+    public static List<String> adminScopes() {
+        return Collections.unmodifiableList(
+                Arrays.asList(APPLICATION_ADMIN, AUTHENTICATOR_ADMIN,
+                        CLIENT_ADMIN, IDENTITY_ADMIN, ROLE_ADMIN, USER_ADMIN,
+                        SCOPE_ADMIN, TOKEN_ADMIN));
+    }
+
+    /**
+     * List of all scopes granted to users.
+     *
+     * @return List of all user scopes.
+     */
+    public static List<String> userScopes() {
+        return Collections.unmodifiableList(
                 Arrays.asList(APPLICATION, AUTHENTICATOR, CLIENT, IDENTITY,
-                        ROLE, USER));
+                        ROLE, USER, SCOPE, TOKEN));
+    }
+
+    /**
+     * Determine the required scope for the given entity.
+     *
+     * @param entity The entity to check.
+     * @param admin  Whether to get the admin role or the regular one.
+     * @return The name of the scope for admin rights.
+     */
+    public static String forEntity(final AbstractEntity entity,
+                                   final Boolean admin) {
+        if (entity instanceof Application) {
+            return admin ? APPLICATION_ADMIN : APPLICATION;
+        }
+        if (entity instanceof Authenticator) {
+            return admin ? AUTHENTICATOR_ADMIN : AUTHENTICATOR;
+        }
+        if (entity instanceof Client) {
+            return admin ? CLIENT_ADMIN : CLIENT;
+        }
+        if (entity instanceof UserIdentity) {
+            return admin ? IDENTITY_ADMIN : IDENTITY;
+        }
+        if (entity instanceof Role) {
+            return admin ? ROLE_ADMIN : ROLE;
+        }
+        if (entity instanceof User) {
+            return admin ? USER_ADMIN : USER;
+        }
+        if (entity instanceof ApplicationScope) {
+            return admin ? SCOPE_ADMIN : SCOPE;
+        }
+        if (entity instanceof OAuthToken) {
+            return admin ? TOKEN_ADMIN : TOKEN;
+        }
+        return "kangaroo:unknown";
     }
 }

--- a/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/servlet/FirstRunContainerLifecycleListener.java
+++ b/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/servlet/FirstRunContainerLifecycleListener.java
@@ -111,24 +111,31 @@ public final class FirstRunContainerLifecycleListener
         passwordAuth.setClient(servletClient);
 
         // Create the scopes
-        SortedMap<String, ApplicationScope> scopes = new TreeMap<>();
-        for (String scopeName : Scope.allScopes()) {
+        SortedMap<String, ApplicationScope> userScopes = new TreeMap<>();
+        for (String scopeName : Scope.userScopes()) {
             ApplicationScope newScope = new ApplicationScope();
             newScope.setApplication(servletApp);
             newScope.setName(scopeName);
-            scopes.put(scopeName, newScope);
+            userScopes.put(scopeName, newScope);
+        }
+        SortedMap<String, ApplicationScope> adminScopes = new TreeMap<>();
+        for (String scopeName : Scope.adminScopes()) {
+            ApplicationScope newScope = new ApplicationScope();
+            newScope.setApplication(servletApp);
+            newScope.setName(scopeName);
+            adminScopes.put(scopeName, newScope);
         }
 
         // Create the roles.
         Role adminRole = new Role();
         adminRole.setName("admin");
         adminRole.setApplication(servletApp);
-        adminRole.setScopes(scopes);
+        adminRole.setScopes(adminScopes);
 
         Role memberRole = new Role();
         memberRole.setName("member");
         memberRole.setApplication(servletApp);
-        memberRole.setScopes(scopes);
+        memberRole.setScopes(userScopes);
 
         // Create the first admin
         User adminUser = new User();
@@ -151,7 +158,8 @@ public final class FirstRunContainerLifecycleListener
         s.save(servletApp);
         s.save(servletClient);
         s.save(passwordAuth);
-        scopes.forEach(s::save);
+        adminScopes.forEach(s::save);
+        userScopes.forEach(s::save);
         s.save(adminRole);
         s.save(memberRole);
         s.save(adminUser);

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/ScopeTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/ScopeTest.java
@@ -17,6 +17,14 @@
 
 package net.krotscheck.kangaroo.servlet.admin.v1;
 
+import net.krotscheck.kangaroo.database.entity.Application;
+import net.krotscheck.kangaroo.database.entity.ApplicationScope;
+import net.krotscheck.kangaroo.database.entity.Authenticator;
+import net.krotscheck.kangaroo.database.entity.Client;
+import net.krotscheck.kangaroo.database.entity.OAuthToken;
+import net.krotscheck.kangaroo.database.entity.Role;
+import net.krotscheck.kangaroo.database.entity.User;
+import net.krotscheck.kangaroo.database.entity.UserIdentity;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -51,12 +59,38 @@ public final class ScopeTest {
      */
     @Test
     public void testExpectedConstants() {
-        Assert.assertEquals("kangaroo:application", Scope.APPLICATION);
-        Assert.assertEquals("kangaroo:authenticator", Scope.AUTHENTICATOR);
-        Assert.assertEquals("kangaroo:client", Scope.CLIENT);
-        Assert.assertEquals("kangaroo:user", Scope.USER);
-        Assert.assertEquals("kangaroo:role", Scope.ROLE);
-        Assert.assertEquals("kangaroo:identity", Scope.IDENTITY);
+        Assert.assertEquals("kangaroo:application",
+                Scope.APPLICATION);
+        Assert.assertEquals("kangaroo:application_admin",
+                Scope.APPLICATION_ADMIN);
+        Assert.assertEquals("kangaroo:authenticator",
+                Scope.AUTHENTICATOR);
+        Assert.assertEquals("kangaroo:authenticator_admin",
+                Scope.AUTHENTICATOR_ADMIN);
+        Assert.assertEquals("kangaroo:client",
+                Scope.CLIENT);
+        Assert.assertEquals("kangaroo:client_admin",
+                Scope.CLIENT_ADMIN);
+        Assert.assertEquals("kangaroo:user",
+                Scope.USER);
+        Assert.assertEquals("kangaroo:user_admin",
+                Scope.USER_ADMIN);
+        Assert.assertEquals("kangaroo:role",
+                Scope.ROLE);
+        Assert.assertEquals("kangaroo:role_admin",
+                Scope.ROLE_ADMIN);
+        Assert.assertEquals("kangaroo:identity",
+                Scope.IDENTITY);
+        Assert.assertEquals("kangaroo:identity_admin",
+                Scope.IDENTITY_ADMIN);
+        Assert.assertEquals("kangaroo:scope",
+                Scope.SCOPE);
+        Assert.assertEquals("kangaroo:scope_admin",
+                Scope.SCOPE_ADMIN);
+        Assert.assertEquals("kangaroo:token",
+                Scope.TOKEN);
+        Assert.assertEquals("kangaroo:token_admin",
+                Scope.TOKEN_ADMIN);
     }
 
     /**
@@ -67,12 +101,117 @@ public final class ScopeTest {
         List<String> allScopes = Scope.allScopes();
 
         Assert.assertTrue(allScopes.contains(Scope.APPLICATION));
+        Assert.assertTrue(allScopes.contains(Scope.APPLICATION_ADMIN));
         Assert.assertTrue(allScopes.contains(Scope.AUTHENTICATOR));
+        Assert.assertTrue(allScopes.contains(Scope.AUTHENTICATOR_ADMIN));
         Assert.assertTrue(allScopes.contains(Scope.CLIENT));
+        Assert.assertTrue(allScopes.contains(Scope.CLIENT_ADMIN));
         Assert.assertTrue(allScopes.contains(Scope.USER));
+        Assert.assertTrue(allScopes.contains(Scope.USER_ADMIN));
         Assert.assertTrue(allScopes.contains(Scope.ROLE));
+        Assert.assertTrue(allScopes.contains(Scope.ROLE_ADMIN));
         Assert.assertTrue(allScopes.contains(Scope.IDENTITY));
+        Assert.assertTrue(allScopes.contains(Scope.IDENTITY_ADMIN));
+        Assert.assertTrue(allScopes.contains(Scope.SCOPE));
+        Assert.assertTrue(allScopes.contains(Scope.SCOPE_ADMIN));
+        Assert.assertTrue(allScopes.contains(Scope.TOKEN));
+        Assert.assertTrue(allScopes.contains(Scope.TOKEN_ADMIN));
 
-        Assert.assertEquals(6, allScopes.size());
+        Assert.assertEquals(16, allScopes.size());
+    }
+
+    /**
+     * Test that the list of admin scopes is all there.
+     */
+    @Test
+    public void testAdminScopeList() {
+        List<String> allScopes = Scope.adminScopes();
+
+        Assert.assertFalse(allScopes.contains(Scope.APPLICATION));
+        Assert.assertTrue(allScopes.contains(Scope.APPLICATION_ADMIN));
+        Assert.assertFalse(allScopes.contains(Scope.AUTHENTICATOR));
+        Assert.assertTrue(allScopes.contains(Scope.AUTHENTICATOR_ADMIN));
+        Assert.assertFalse(allScopes.contains(Scope.CLIENT));
+        Assert.assertTrue(allScopes.contains(Scope.CLIENT_ADMIN));
+        Assert.assertFalse(allScopes.contains(Scope.USER));
+        Assert.assertTrue(allScopes.contains(Scope.USER_ADMIN));
+        Assert.assertFalse(allScopes.contains(Scope.ROLE));
+        Assert.assertTrue(allScopes.contains(Scope.ROLE_ADMIN));
+        Assert.assertFalse(allScopes.contains(Scope.IDENTITY));
+        Assert.assertTrue(allScopes.contains(Scope.IDENTITY_ADMIN));
+        Assert.assertFalse(allScopes.contains(Scope.SCOPE));
+        Assert.assertTrue(allScopes.contains(Scope.SCOPE_ADMIN));
+        Assert.assertFalse(allScopes.contains(Scope.TOKEN));
+        Assert.assertTrue(allScopes.contains(Scope.TOKEN_ADMIN));
+
+        Assert.assertEquals(8, allScopes.size());
+    }
+
+    /**
+     * Test that the list of admin scopes is all there.
+     */
+    @Test
+    public void testUserScopeList() {
+        List<String> allScopes = Scope.userScopes();
+
+        Assert.assertTrue(allScopes.contains(Scope.APPLICATION));
+        Assert.assertFalse(allScopes.contains(Scope.APPLICATION_ADMIN));
+        Assert.assertTrue(allScopes.contains(Scope.AUTHENTICATOR));
+        Assert.assertFalse(allScopes.contains(Scope.AUTHENTICATOR_ADMIN));
+        Assert.assertTrue(allScopes.contains(Scope.CLIENT));
+        Assert.assertFalse(allScopes.contains(Scope.CLIENT_ADMIN));
+        Assert.assertTrue(allScopes.contains(Scope.USER));
+        Assert.assertFalse(allScopes.contains(Scope.USER_ADMIN));
+        Assert.assertTrue(allScopes.contains(Scope.ROLE));
+        Assert.assertFalse(allScopes.contains(Scope.ROLE_ADMIN));
+        Assert.assertTrue(allScopes.contains(Scope.IDENTITY));
+        Assert.assertFalse(allScopes.contains(Scope.IDENTITY_ADMIN));
+        Assert.assertTrue(allScopes.contains(Scope.SCOPE));
+        Assert.assertFalse(allScopes.contains(Scope.SCOPE_ADMIN));
+        Assert.assertTrue(allScopes.contains(Scope.TOKEN));
+        Assert.assertFalse(allScopes.contains(Scope.TOKEN_ADMIN));
+
+        Assert.assertEquals(8, allScopes.size());
+    }
+
+    /**
+     * Test all the cases for retrieving appropriate scope names for entities.
+     */
+    @Test
+    public void testGetScopeForEntity() {
+        Assert.assertEquals(Scope.APPLICATION,
+                Scope.forEntity(new Application(), false));
+        Assert.assertEquals(Scope.APPLICATION_ADMIN,
+                Scope.forEntity(new Application(), true));
+        Assert.assertEquals(Scope.AUTHENTICATOR,
+                Scope.forEntity(new Authenticator(), false));
+        Assert.assertEquals(Scope.AUTHENTICATOR_ADMIN,
+                Scope.forEntity(new Authenticator(), true));
+        Assert.assertEquals(Scope.CLIENT,
+                Scope.forEntity(new Client(), false));
+        Assert.assertEquals(Scope.CLIENT_ADMIN,
+                Scope.forEntity(new Client(), true));
+        Assert.assertEquals(Scope.USER,
+                Scope.forEntity(new User(), false));
+        Assert.assertEquals(Scope.USER_ADMIN,
+                Scope.forEntity(new User(), true));
+        Assert.assertEquals(Scope.ROLE,
+                Scope.forEntity(new Role(), false));
+        Assert.assertEquals(Scope.ROLE_ADMIN,
+                Scope.forEntity(new Role(), true));
+        Assert.assertEquals(Scope.IDENTITY,
+                Scope.forEntity(new UserIdentity(), false));
+        Assert.assertEquals(Scope.IDENTITY_ADMIN,
+                Scope.forEntity(new UserIdentity(), true));
+        Assert.assertEquals(Scope.SCOPE,
+                Scope.forEntity(new ApplicationScope(), false));
+        Assert.assertEquals(Scope.SCOPE_ADMIN,
+                Scope.forEntity(new ApplicationScope(), true));
+        Assert.assertEquals(Scope.TOKEN,
+                Scope.forEntity(new OAuthToken(), false));
+        Assert.assertEquals(Scope.TOKEN_ADMIN,
+                Scope.forEntity(new OAuthToken(), true));
+        Assert.assertEquals("kangaroo:unknown",
+                Scope.forEntity(null, true));
     }
 }


### PR DESCRIPTION
This patch adds scopes specific for administration activities against
the admin API. They are intended to permit a user to access all
applications, users, etc. Also, a convenience method was added to
allow retrieving the appropriate scope for a given entity.