### PR TITLE
OAuth2 filter restricts on app.

### DIFF
--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/filter/OAuth2AuthorizationFilterTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/filter/OAuth2AuthorizationFilterTest.java
@@ -17,14 +17,12 @@
 
 package net.krotscheck.kangaroo.servlet.admin.v1.filter;
 
-import net.krotscheck.kangaroo.database.entity.ClientType;
 import net.krotscheck.kangaroo.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.database.entity.OAuthTokenType;
-import net.krotscheck.kangaroo.servlet.admin.v1.AdminV1API;
 import net.krotscheck.kangaroo.servlet.admin.v1.Scope;
 import net.krotscheck.kangaroo.servlet.admin.v1.filter.OAuth2AuthorizationFilter.Binder;
 import net.krotscheck.kangaroo.servlet.admin.v1.filter.OAuth2AuthorizationFilter.OAuthTokenContext;
-import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.servlet.admin.v1.resource.AbstractResourceTest;
 import net.krotscheck.kangaroo.test.EnvironmentBuilder;
 import net.krotscheck.kangaroo.test.EnvironmentBuilder;
 import org.apache.http.HttpStatus;
@@ -33,7 +31,6 @@ import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.api.ServiceLocatorFactory;
 import org.glassfish.hk2.utilities.BuilderHelper;
 import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
-import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -50,7 +47,8 @@ import javax.ws.rs.core.Response;
  *
  * @author Michael Krotscheck
  */
-public final class OAuth2AuthorizationFilterTest extends ContainerTest {
+public final class OAuth2AuthorizationFilterTest
+        extends AbstractResourceTest {
 
     /**
      * A valid, non-expired, bearer token.
@@ -73,51 +71,41 @@ public final class OAuth2AuthorizationFilterTest extends ContainerTest {
     private OAuthToken authToken;
 
     /**
-     * The application under test.
+     * Provided the admin context, build a list of all additional
+     * applications required for this test.
      *
-     * @return An instance of the Admin servlet.
+     * @param adminContext The admin context
+     * @return A list of fixtures.
+     * @throws Exception Thrown if something untoward happens.
      */
     @Override
-    protected ResourceConfig createApplication() {
-        return new AdminV1API();
-    }
-
-    /**
-     * Load data fixtures for each test.
-     *
-     * @return A list of fixtures, which will be cleared after the test.
-     * @throws Exception An exception that indicates a failed fixture load.
-     */
-    @Override
-    public List<EnvironmentBuilder> fixtures() throws Exception {
-        EnvironmentBuilder context = new EnvironmentBuilder(getSession())
-                .client(ClientType.Implicit)
-                .scope(Scope.USER)
-                .redirect("http://example.com/redirect")
-                .referrer("http://example.com/redirect")
-                .authenticator("test")
-                .user()
+    public List<EnvironmentBuilder> fixtures(
+            final EnvironmentBuilder adminContext)
+            throws Exception {
+        // Create a new user.
+        adminContext
+                .user(null)
                 .identity("remote_identity");
 
         // Valid token
-        context.token(OAuthTokenType.Bearer, false, Scope.USER, null, null);
-        validBearerToken = context.getToken();
+        adminContext
+                .token(OAuthTokenType.Bearer, false, Scope.USER, null, null);
+        validBearerToken = adminContext.getToken();
 
-        // Valid token
-        context.token(OAuthTokenType.Bearer, true, null, null, null);
-        noScopeBearerToken = context.getToken();
+        // Valid token, no scope.
+        adminContext.token(OAuthTokenType.Bearer, false, null, null, null);
+        noScopeBearerToken = adminContext.getToken();
 
         // Expired token.
-        context.token(OAuthTokenType.Bearer, true, Scope.USER, null, null);
-        expiredBearerToken = context.getToken();
+        adminContext.token(OAuthTokenType.Bearer, true, Scope.USER, null, null);
+        expiredBearerToken = adminContext.getToken();
 
-        // Auth token
-        context.authToken();
-        authToken = context.getToken();
+        // Auth token.
+        adminContext.token(OAuthTokenType.Authorization, false, Scope.USER,
+                null, null);
+        authToken = adminContext.getToken();
 
-        List<EnvironmentBuilder> fixtures = new ArrayList<>();
-        fixtures.add(context);
-        return fixtures;
+        return new ArrayList<>();
     }
 
     /**
@@ -275,5 +263,16 @@ public final class OAuth2AuthorizationFilterTest extends ContainerTest {
 
         Assert.assertFalse(context.isSecure());
         Assert.assertEquals("OAuth2", context.getAuthenticationScheme());
+    }
+
+    /**
+     * Construct the request URL for this test given a specific resource ID.
+     *
+     * @param id The ID to use.
+     * @return The resource URL.
+     */
+    @Override
+    protected String getUrlForId(final String id) {
+        return null;
     }
 }

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/UserServiceCRUDTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/UserServiceCRUDTest.java
@@ -88,8 +88,7 @@ public final class UserServiceCRUDTest extends AbstractResourceTest {
         EnvironmentBuilder context =
                 new EnvironmentBuilder(getSession(), "Test Name")
                         .owner(adminApp.getUser())
-                        .scope(Scope.USER)
-                        .client(ClientType.Implicit, "Test Client")
+                        .client(ClientType.Implicit)
                         .authenticator("test");
 
         // User 1
@@ -121,13 +120,13 @@ public final class UserServiceCRUDTest extends AbstractResourceTest {
         users.add(context.getUser());
 
         // Build an auth header.
-        context.bearerToken(Scope.USER);
-        authHeader = String.format("Bearer %s", context.getToken().getId());
+        adminApp.bearerToken(Scope.USER);
+        authHeader = String.format("Bearer %s", adminApp.getToken().getId());
 
         // Build an auth header with no valid scope.
-        context.bearerToken();
+        adminApp.bearerToken(null);
         authHeaderNoScope =
-                String.format("Bearer %s", context.getToken().getId());
+                String.format("Bearer %s", adminApp.getToken().getId());
 
         List<EnvironmentBuilder> fixtures = new ArrayList<>();
         fixtures.add(context);

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/UserServiceSearchTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/UserServiceSearchTest.java
@@ -86,7 +86,6 @@ public final class UserServiceSearchTest extends AbstractResourceTest {
         users.clear();
         EnvironmentBuilder context =
                 new EnvironmentBuilder(getSession(), "Test Name")
-                        .scope(Scope.USER)
                         .client(ClientType.Implicit, "Test Client")
                         .authenticator("test");
 
@@ -119,13 +118,13 @@ public final class UserServiceSearchTest extends AbstractResourceTest {
         users.add(context.getUser());
 
         // Build an auth header.
-        context.bearerToken(Scope.USER);
-        authHeader = String.format("Bearer %s", context.getToken().getId());
+        adminApp.bearerToken(Scope.USER);
+        authHeader = String.format("Bearer %s", adminApp.getToken().getId());
 
         // Build an auth header with no valid scope.
-        context.bearerToken();
+        adminApp.bearerToken();
         authHeaderNoScope =
-                String.format("Bearer %s", context.getToken().getId());
+                String.format("Bearer %s", adminApp.getToken().getId());
 
         List<EnvironmentBuilder> fixtures = new ArrayList<>();
         fixtures.add(context);


### PR DESCRIPTION
This fixes a bug where any application, if it happens to grant a scope
that matches (by string comparison) the scopes issued by kangaroo, would
be able to access anything and everything on the admin API.