### PR TITLE
Password authenticator is now injected by name.

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/authenticator/PasswordAuthenticator.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/authenticator/PasswordAuthenticator.java
@@ -126,6 +126,8 @@ public final class PasswordAuthenticator
         protected void configure() {
             bind(PasswordAuthenticator.class)
                     .to(PasswordAuthenticator.class)
+                    .to(IAuthenticator.class)
+                    .named("password")
                     .in(RequestScoped.class);
         }
     }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/authenticator/PasswordAuthenticatorTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/authenticator/PasswordAuthenticatorTest.java
@@ -181,7 +181,7 @@ public final class PasswordAuthenticatorTest extends DatabaseTest {
         Assert.assertEquals(RequestScoped.class.getCanonicalName(),
                 descriptor.getScope());
 
-        // ... with no name.
-        Assert.assertNull(descriptor.getName());
+        // ... with the 'password' name.
+        Assert.assertEquals("password", descriptor.getName());
     }
 }


### PR DESCRIPTION
This patch ensures that the password authenticator is available by name
in the injection context. We need to make sure it's filtered out
when configuring authenticators for other contexts.