### PR TITLE
OAuth2 filter restricts on app.

### DIFF
--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/UserServiceCRUDTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/UserServiceCRUDTest.java
@@ -88,8 +88,7 @@ public final class UserServiceCRUDTest extends AbstractResourceTest {
         EnvironmentBuilder context =
                 new EnvironmentBuilder(getSession(), "Test Name")
                         .owner(adminApp.getUser())
-                        .scope(Scope.USER)
-                        .client(ClientType.Implicit, "Test Client")
+                        .client(ClientType.Implicit)
                         .authenticator("test");
 
         // User 1
@@ -121,13 +120,13 @@ public final class UserServiceCRUDTest extends AbstractResourceTest {
         users.add(context.getUser());
 
         // Build an auth header.
-        context.bearerToken(Scope.USER);
-        authHeader = String.format("Bearer %s", context.getToken().getId());
+        adminApp.bearerToken(Scope.USER);
+        authHeader = String.format("Bearer %s", adminApp.getToken().getId());
 
         // Build an auth header with no valid scope.
-        context.bearerToken();
+        adminApp.bearerToken((String) null);
         authHeaderNoScope =
-                String.format("Bearer %s", context.getToken().getId());
+                String.format("Bearer %s", adminApp.getToken().getId());
 
         List<EnvironmentBuilder> fixtures = new ArrayList<>();
         fixtures.add(context);

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/UserServiceSearchTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/UserServiceSearchTest.java
@@ -86,7 +86,6 @@ public final class UserServiceSearchTest extends AbstractResourceTest {
         users.clear();
         EnvironmentBuilder context =
                 new EnvironmentBuilder(getSession(), "Test Name")
-                        .scope(Scope.USER)
                         .client(ClientType.Implicit, "Test Client")
                         .authenticator("test");
 
@@ -119,13 +118,13 @@ public final class UserServiceSearchTest extends AbstractResourceTest {
         users.add(context.getUser());
 
         // Build an auth header.
-        context.bearerToken(Scope.USER);
-        authHeader = String.format("Bearer %s", context.getToken().getId());
+        adminApp.bearerToken(Scope.USER);
+        authHeader = String.format("Bearer %s", adminApp.getToken().getId());
 
         // Build an auth header with no valid scope.
-        context.bearerToken();
+        adminApp.bearerToken();
         authHeaderNoScope =
-                String.format("Bearer %s", context.getToken().getId());
+                String.format("Bearer %s", adminApp.getToken().getId());
 
         List<EnvironmentBuilder> fixtures = new ArrayList<>();
         fixtures.add(context);


### PR DESCRIPTION
This fixes a bug where any application, if it happens to grant a scope
that matches (by string comparison) the scopes issued by kangaroo, would
be able to access anything and everything on the admin API.