### PR TITLE
Switched from Cobertura to Jacoco code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,7 @@ branches:
   - /^feature\/.*$/
   - /^hotfix\/.*$/
   - /^release\/.*$/
-before_script:
-  - mvn clean -Ptravis
 script:
-  - mvn checkstyle:check -Ptravis
-  - mvn pmd:check -Ptravis
-  - mvn pmd:cpd-check -Ptravis
-  - mvn install -Ptravis
-  - mvn cobertura:check -Ptravis
+  - mvn clean install -Ptravis
 after_success:
-  - mvn cobertura:cobertura coveralls:report -DskipTests -Ptravis
+  - mvn coveralls:report -Ptravis

--- a/kangaroo-common/pom.xml
+++ b/kangaroo-common/pom.xml
@@ -81,13 +81,18 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
       </plugin>
 
     </plugins>

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/type/URITypeDescriptor.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/type/URITypeDescriptor.java
@@ -88,7 +88,9 @@ public final class URITypeDescriptor extends AbstractTypeDescriptor<URI> {
         if (String.class.isAssignableFrom(type)) {
             return (X) toString(value);
         }
-        throw unknownUnwrap(type);
+        throw new HibernateException(
+                "Unknown unwrap conversion requested: URI to " + type.getName()
+        );
     }
 
     /**
@@ -106,6 +108,7 @@ public final class URITypeDescriptor extends AbstractTypeDescriptor<URI> {
         if (String.class.isInstance(value)) {
             return fromString((String) value);
         }
-        throw unknownWrap(value.getClass());
+        throw new HibernateException("Unknown wrap conversion requested: "
+                + value.getClass().getName() + " to URI");
     }
 }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/logging/JULRedirectContextListenerTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/logging/JULRedirectContextListenerTest.java
@@ -29,7 +29,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
 /**
- * Unit tests for the java.util.logging -> slf4j redirect.
+ * Unit tests for the java.util.logging to slf4j redirect.
  *
  * @author Michael Krotscheck
  */

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/response/SortOrderTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/response/SortOrderTest.java
@@ -34,6 +34,7 @@ public final class SortOrderTest {
     public void testAllVariablesPresent() {
         Assert.assertNotNull(SortOrder.ASC);
         Assert.assertNotNull(SortOrder.DESC);
+        Assert.assertEquals(2, SortOrder.values().length);
     }
 
     /**
@@ -61,5 +62,20 @@ public final class SortOrderTest {
         Assert.assertEquals(SortOrder.DESC, lowerCaseOrder);
         Assert.assertEquals("DESC", SortOrder.DESC.toString());
 
+    }
+
+    /**
+     * Assert that valueOf conversions work
+     */
+    @Test
+    public void testValueOf() {
+        Assert.assertEquals(
+                SortOrder.DESC,
+                SortOrder.valueOf("DESC")
+        );
+        Assert.assertEquals(
+                SortOrder.ASC,
+                SortOrder.valueOf("ASC")
+        );
     }
 }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/ClientTypeTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/ClientTypeTest.java
@@ -104,5 +104,26 @@ public final class ClientTypeTest {
         ));
     }
 
-
+    /**
+     * Assert that valueOf conversions work
+     */
+    @Test
+    public void testValueOf() {
+        Assert.assertEquals(
+                ClientType.AuthorizationGrant,
+                ClientType.valueOf("AuthorizationGrant")
+        );
+        Assert.assertEquals(
+                ClientType.Implicit,
+                ClientType.valueOf("Implicit")
+        );
+        Assert.assertEquals(
+                ClientType.ClientCredentials,
+                ClientType.valueOf("ClientCredentials")
+        );
+        Assert.assertEquals(
+                ClientType.OwnerCredentials,
+                ClientType.valueOf("OwnerCredentials")
+        );
+    }
 }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/OAuthTokenTypeTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/OAuthTokenTypeTest.java
@@ -67,4 +67,23 @@ public final class OAuthTokenTypeTest {
                 m.readValue("\"Refresh\"", OAuthTokenType.class);
         Assert.assertSame(refreshOutput, OAuthTokenType.Refresh);
     }
+
+    /**
+     * Assert that valueOf conversions work
+     */
+    @Test
+    public void testValueOf() {
+        Assert.assertEquals(
+                OAuthTokenType.Bearer,
+                OAuthTokenType.valueOf("Bearer")
+        );
+        Assert.assertEquals(
+                OAuthTokenType.Authorization,
+                OAuthTokenType.valueOf("Authorization")
+        );
+        Assert.assertEquals(
+                OAuthTokenType.Refresh,
+                OAuthTokenType.valueOf("Refresh")
+        );
+    }
 }

--- a/kangaroo-server-admin/pom.xml
+++ b/kangaroo-server-admin/pom.xml
@@ -50,13 +50,18 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
       </plugin>
 
     </plugins>

--- a/kangaroo-server-oauth2/pom.xml
+++ b/kangaroo-server-oauth2/pom.xml
@@ -50,13 +50,18 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
       </plugin>
 
     </plugins>

--- a/kangaroo-server-oauth2/src/main/java/net/krotscheck/kangaroo/servlet/oauth2/resource/AuthorizationService.java
+++ b/kangaroo-server-oauth2/src/main/java/net/krotscheck/kangaroo/servlet/oauth2/resource/AuthorizationService.java
@@ -217,13 +217,12 @@ public final class AuthorizationService {
 
             // Since this code won't execute without a valid state, we should be
             // safe to do a simple if/else here. Except we're paranoid.
-            switch (s.getClient().getType()) {
-                case AuthorizationGrant:
-                    return handleGrantResponse(s, i);
-                case Implicit:
-                    return handleImplicitResponse(s, i);
-                default:
-                    throw new InvalidRequestException();
+            if (s.getClient().getType() == ClientType.AuthorizationGrant) {
+                return handleGrantResponse(s, i);
+            } else if (s.getClient().getType() == ClientType.Implicit) {
+                return handleImplicitResponse(s, i);
+            } else {
+                throw new InvalidRequestException();
             }
         } catch (HttpStatusException e) {
             // Any caught exceptions here should be redirected to the

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,8 @@
     <jetty.version>9.1.1.v20140108</jetty.version>
     <jersey2-toolkit.version>2.1.1</jersey2-toolkit.version>
     <slf4j.version>1.7.13</slf4j.version>
+    <powermock.version>1.6.6</powermock.version>
+    <jacoco.version>0.7.7.201606060606</jacoco.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
@@ -254,6 +256,7 @@
             <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
 
             <systemProperties>
+              <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
               <property>
                 <name>test.db.jdbc</name>
                 <value>jdbc:h2:mem:target/test/db/h2/hibernate</value>
@@ -276,31 +279,68 @@
 
         <!-- Test coverage -->
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>cobertura-maven-plugin</artifactId>
-          <version>2.7</version>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>${jacoco.version}</version>
+          <executions>
+            <execution>
+              <id>default-instrument</id>
+              <goals>
+                <goal>instrument</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>default-restore-instrumented-classes</id>
+              <goals>
+                <goal>restore-instrumented-classes</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>default-report</id>
+              <goals>
+                <goal>report</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>default-check</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
           <configuration>
-            <aggregate>true</aggregate>
-            <check>
-              <haltOnFailure>true</haltOnFailure>
-              <branchRate>100</branchRate>
-              <lineRate>100</lineRate>
-              <totalBranchRate>100</totalBranchRate>
-              <totalLineRate>100</totalLineRate>
-              <packageLineRate>100</packageLineRate>
-              <packageBranchRate>100</packageBranchRate>
-            </check>
-            <formats>
-              <format>xml</format>
-              <format>html</format>
-            </formats>
-            <instrumentation>
-              <ignoreMethodAnnotations>
-                <ignoreMethodAnnotation>
-                  net.krotscheck.cobertura.IgnoreCoverage
-                </ignoreMethodAnnotation>
-              </ignoreMethodAnnotations>
-            </instrumentation>
+            <rules>
+              <rule>
+                <element>BUNDLE</element>
+                <limits>
+                  <limit>
+                    <counter>INSTRUCTION</counter>
+                    <value>MISSEDCOUNT</value>
+                    <maximum>0</maximum>
+                  </limit>
+                  <limit>
+                    <counter>BRANCH</counter>
+                    <value>MISSEDCOUNT</value>
+                    <maximum>0</maximum>
+                  </limit>
+                  <limit>
+                    <counter>LINE</counter>
+                    <value>MISSEDCOUNT</value>
+                    <maximum>0</maximum>
+                  </limit>
+                  <limit>
+                    <counter>METHOD</counter>
+                    <value>MISSEDCOUNT</value>
+                    <minimum>0</minimum>
+                  </limit>
+                  <limit>
+                    <counter>CLASS</counter>
+                    <value>MISSEDCOUNT</value>
+                    <maximum>0</maximum>
+                  </limit>
+                </limits>
+              </rule>
+            </rules>
           </configuration>
         </plugin>
 
@@ -313,6 +353,20 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
           <version>3.6</version>
+          <executions>
+            <execution>
+              <id>default-check</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>default-cpd-check</id>
+              <goals>
+                <goal>cpd-check</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
 
         <!-- Attach sources -->
@@ -388,8 +442,7 @@
           </configuration>
           <executions>
             <execution>
-              <id>validate</id>
-              <phase>validate</phase>
+              <id>default-check</id>
               <goals>
                 <goal>check</goal>
               </goals>
@@ -459,10 +512,6 @@
         <artifactId>maven-surefire-report-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
       </plugin>
@@ -506,6 +555,23 @@
 
     <!-- JUnit -->
     <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>${powermock.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>org.jacoco.agent</artifactId>
+      <classifier>runtime</classifier>
+      <version>${jacoco.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>
@@ -514,16 +580,6 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>1.10.19</version>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>1.6.5</version>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>1.6.5</version>
     </dependency>
 
     <!-- Jetty test environment -->
@@ -561,26 +617,12 @@
     </dependency>
 
     <!-- Apache Commons -->
-    <!--<dependency>-->
-      <!--<groupId>org.apache.httpcomponents</groupId>-->
-      <!--<artifactId>httpclient</artifactId>-->
-    <!--</dependency>-->
-    <!--<dependency>-->
-      <!--<groupId>commons-io</groupId>-->
-      <!--<artifactId>commons-io</artifactId>-->
-    <!--</dependency>-->
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-dbcp2</artifactId>
       <version>2.1.1</version>
       <scope>test</scope>
     </dependency>
-
-    <!--&lt;!&ndash; Jersey (JAX-RS) &ndash;&gt;-->
-    <!--<dependency>-->
-      <!--<groupId>org.glassfish.jersey.containers</groupId>-->
-      <!--<artifactId>jersey-container-servlet</artifactId>-->
-    <!--</dependency>-->
 
     <!-- H2 database, used for testing. -->
     <dependency>


### PR DESCRIPTION
Two benefits: Jacoco only has to run coverage once, which can be
done with the regular unit test run, and there's IDE integration for
IntelliJ. It should reduce the # of test runs down to one. Tests
have been updated to ensure code coverage remains at 100%.