### PR TITLE
Hard delete the database after a test, instead of by record

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ target
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# jacoco reports
+jacoco.exec

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/EnvironmentBuilder.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/EnvironmentBuilder.java
@@ -132,11 +132,6 @@ public final class EnvironmentBuilder {
     private URI referrerUri;
 
     /**
-     * The list of entities that are under management by this builder.
-     */
-    private final List<AbstractEntity> trackedEntities = new ArrayList<>();
-
-    /**
      * Get the current application.
      *
      * @return The current application.
@@ -152,15 +147,6 @@ public final class EnvironmentBuilder {
      */
     public Role getRole() {
         return getRefreshed(role);
-    }
-
-    /**
-     * Get the list of tracked entities.
-     *
-     * @return The current list of tracked entities.
-     */
-    public List<AbstractEntity> getTrackedEntities() {
-        return Collections.unmodifiableList(getRefreshed(trackedEntities));
     }
 
     /**
@@ -538,10 +524,6 @@ public final class EnvironmentBuilder {
         session.saveOrUpdate(e);
         t.commit();
 
-        if (!trackedEntities.contains(e)) {
-            trackedEntities.add(e);
-        }
-
         // Persist all changes.
         session.flush();
     }
@@ -776,49 +758,8 @@ public final class EnvironmentBuilder {
         // Since the session user may not be tracked by this environment
         // builder, we manually persist it.
         persist(a);
-//        Transaction t = session.beginTransaction();
-//        session.update(sessionUser);
-//        session.update(a);
-//        t.commit();
 
         return this;
-    }
-
-    /**
-     * Clear all created entities from the database.
-     */
-    public void clear() {
-        // Delete the entities in reverse order.
-        for (int i = trackedEntities.size() - 1; i >= 0; i--) {
-            AbstractEntity e = trackedEntities.get(i);
-
-            // First, evict the entity.
-            session.evict(e);
-
-            // Now, reload it.
-            e = session.get(e.getClass(), e.getId());
-
-            // Is it still in the database?
-            if (e != null) {
-                Transaction t = session.beginTransaction();
-                session.delete(e);
-                t.commit();
-            }
-        }
-        trackedEntities.clear();
-
-        application = null;
-        scopes.clear();
-        scope = null;
-        role = null;
-        client = null;
-        authenticator = null;
-        user = null;
-        userIdentity = null;
-        token = null;
-        redirectUri = null;
-        referrerUri = null;
-        authenticatorState = null;
     }
 
     /**

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/EnvironmentBuilderTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/EnvironmentBuilderTest.java
@@ -281,27 +281,10 @@ public final class EnvironmentBuilderTest extends DatabaseTest {
         Assert.assertEquals(b.getClient(), aState.getClient());
         Assert.assertEquals(b.getAuthenticator(), aState.getAuthenticator());
 
-        // Test getting all entities.
-        List<AbstractEntity> e = b.getTrackedEntities();
-        Assert.assertEquals(22, e.size());
-
         // Delete one of our entities to make sure it's skipped during clearing.
         Transaction t = getSession().beginTransaction();
         getSession().delete(b.getToken());
         t.commit();
-
-        // Assert that everything clears.
-        b.clear();
-        Assert.assertNull(b.getApplication());
-        Assert.assertNull(b.getClient());
-        Assert.assertNull(b.getRole());
-        Assert.assertNull(b.getUser());
-        Assert.assertNull(b.getUserIdentity());
-        Assert.assertNull(b.getScope());
-        Assert.assertEquals(0, b.getScopes().size());
-        Assert.assertNull(b.getAuthenticator());
-        Assert.assertNull(b.getToken());
-        Assert.assertEquals(0, b.getTrackedEntities().size());
     }
 
     /**
@@ -321,12 +304,8 @@ public final class EnvironmentBuilderTest extends DatabaseTest {
         b.user();
         User createdUser = b.getUser();
 
-        // Ensure that clearing does not delete the app, but does delete the
-        // user.
-        b.clear();
-
         User oldUser = session.get(User.class, createdUser.getId());
-        Assert.assertNull(oldUser);
+        Assert.assertNotNull(oldUser);
 
         adminApp = session.get(Application.class, adminApp.getId());
         Assert.assertNotNull(adminApp);
@@ -404,8 +383,7 @@ public final class EnvironmentBuilderTest extends DatabaseTest {
         t.commit();
         manualSession.close();
 
-        // Now clear the builder.
-        b.clear();
+        // Now close the session.
         builderSession.close();
     }
 }

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AbstractServiceCRUDTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AbstractServiceCRUDTest.java
@@ -494,7 +494,6 @@ public abstract class AbstractServiceCRUDTest<T extends AbstractEntity>
         } else {
             assertErrorResponse(r, Status.BAD_REQUEST);
         }
-        thirdApp.clear();
     }
 
 

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ScopeServiceCRUDTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ScopeServiceCRUDTest.java
@@ -124,37 +124,6 @@ public final class ScopeServiceCRUDTest
                 }
         });
     }
-//
-//    /**
-//     * Load data fixtures for each test.
-//     *
-//     * @return A list of fixtures, which will be cleared after the test.
-//     * @throws Exception An exception that indicates a failed fixture load.
-//     */
-//    @Override
-//    public List<EnvironmentBuilder> fixtures(final EnvironmentBuilder adminApp)
-//            throws Exception {
-//        // Build the admin context with the provided parameters.
-//        EnvironmentBuilder context = getAdminContext();
-//        context.client(clientType);
-//        if (createUser) {
-//            context.user().identity();
-//        }
-//        adminAppToken = context.bearerToken(tokenScope).getToken();
-//
-//        // Build a second app to run some tests against.
-//        otherApp = new EnvironmentBuilder(getSession())
-//                .scopes(Scope.allScopes())
-//                .owner(context.getOwner())
-//                .client(clientType)
-//                .authenticator("test")
-//                .user().identity()
-//                .bearerToken(tokenScope);
-//
-//        List<EnvironmentBuilder> fixtures = new ArrayList<>();
-//        fixtures.add(otherApp);
-//        return fixtures;
-//    }
 
     /**
      * Construct the request URL for this test given a specific resource ID.
@@ -335,8 +304,6 @@ public final class ScopeServiceCRUDTest
             Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, r.getStatus());
             Assert.assertEquals("bad_request", response.getError());
         }
-
-        yetAnotherApp.clear();
     }
 
     /**


### PR DESCRIPTION
This patch changes the test data cleanup mechanism to issuing direct SQL
queries, rather than trying to delete entities individually and trusting
on cascade to handle the rest.