### PR TITLE
Route all tests through a central JerseyTest

### DIFF
--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/config/ConfigurationFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/config/ConfigurationFeatureTest.java
@@ -17,9 +17,9 @@
 
 package net.krotscheck.kangaroo.common.config;
 
+import net.krotscheck.kangaroo.test.KangarooJerseyTest;
 import org.apache.http.HttpStatus;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -27,7 +27,6 @@ import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -36,7 +35,7 @@ import javax.ws.rs.core.Response;
  *
  * @author Michael Krotscheck
  */
-public final class ConfigurationFeatureTest extends JerseyTest {
+public final class ConfigurationFeatureTest extends KangarooJerseyTest {
 
     /**
      * Build the configured application.
@@ -44,7 +43,7 @@ public final class ConfigurationFeatureTest extends JerseyTest {
      * @return The configured application.
      */
     @Override
-    protected Application configure() {
+    protected ResourceConfig createApplication() {
         ResourceConfig a = new ResourceConfig();
         a.register(ConfigurationFeature.class);
         a.register(MockService.class);

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/exception/ExceptionFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/exception/ExceptionFeatureTest.java
@@ -21,12 +21,10 @@ import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder.ErrorResponse;
-import net.krotscheck.kangaroo.common.exception.ExceptionFeature;
 import net.krotscheck.kangaroo.common.exception.exception.HttpNotFoundException;
 import org.glassfish.jersey.CommonProperties;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
-import org.glassfish.jersey.test.TestProperties;
+import net.krotscheck.kangaroo.test.KangarooJerseyTest;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -34,7 +32,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -45,7 +42,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Michael Krotscheck
  */
-public final class ExceptionFeatureTest extends JerseyTest {
+public final class ExceptionFeatureTest extends KangarooJerseyTest {
 
     /**
      * Build the application.
@@ -53,10 +50,7 @@ public final class ExceptionFeatureTest extends JerseyTest {
      * @return An application that can parse exceptions.
      */
     @Override
-    protected Application configure() {
-        enable(TestProperties.LOG_TRAFFIC);
-        enable(TestProperties.DUMP_ENTITY);
-
+    protected ResourceConfig createApplication() {
         ResourceConfig a = new ResourceConfig();
         a.register(ExceptionFeature.class);
         a.register(MockService.class);

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/HibernateFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/HibernateFeatureTest.java
@@ -19,7 +19,7 @@
 package net.krotscheck.kangaroo.common.hibernate;
 
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
+import net.krotscheck.kangaroo.test.KangarooJerseyTest;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.search.FullTextSession;
@@ -32,7 +32,6 @@ import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -41,7 +40,7 @@ import javax.ws.rs.core.Response;
  *
  * @author Michael Krotscheck
  */
-public final class HibernateFeatureTest extends JerseyTest {
+public final class HibernateFeatureTest extends KangarooJerseyTest {
 
     /**
      * Run a service request.
@@ -59,7 +58,7 @@ public final class HibernateFeatureTest extends JerseyTest {
      * @return A properly configured application.
      */
     @Override
-    protected Application configure() {
+    protected ResourceConfig createApplication() {
         ResourceConfig config = new ResourceConfig();
         config.register(HibernateFeature.class);
         config.register(TestService.class);

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/jackson/JacksonFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/jackson/JacksonFeatureTest.java
@@ -20,8 +20,8 @@ package net.krotscheck.kangaroo.common.jackson;
 import net.krotscheck.kangaroo.common.jackson.mock.MockPojo;
 import net.krotscheck.kangaroo.common.jackson.mock.MockPojoDeserializer;
 import net.krotscheck.kangaroo.common.jackson.mock.MockPojoSerializer;
+import net.krotscheck.kangaroo.test.KangarooJerseyTest;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -29,17 +29,16 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 
 /**
  * Test the jackson feature injection.
- *
+ *ss
  * @author Michael Krotscheck
  */
-public final class JacksonFeatureTest extends JerseyTest {
+public final class JacksonFeatureTest extends KangarooJerseyTest {
 
     /**
      * Build an application.
@@ -47,7 +46,7 @@ public final class JacksonFeatureTest extends JerseyTest {
      * @return A configured application.
      */
     @Override
-    protected Application configure() {
+    protected ResourceConfig createApplication() {
         ResourceConfig config = new ResourceConfig();
         config.register(JacksonFeature.class);
         config.register(new MockPojoDeserializer.Binder());

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/logging/LoggingFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/logging/LoggingFeatureTest.java
@@ -17,9 +17,9 @@
 
 package net.krotscheck.kangaroo.common.logging;
 
+import net.krotscheck.kangaroo.test.KangarooJerseyTest;
 import org.apache.http.HttpStatus;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.bridge.SLF4JBridgeHandler;
@@ -27,7 +27,6 @@ import org.slf4j.bridge.SLF4JBridgeHandler;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -37,7 +36,7 @@ import javax.ws.rs.core.Response;
  *
  * @author Michael Krotscheck
  */
-public final class LoggingFeatureTest extends JerseyTest {
+public final class LoggingFeatureTest extends KangarooJerseyTest {
 
     /**
      * Build the configured application.
@@ -45,7 +44,7 @@ public final class LoggingFeatureTest extends JerseyTest {
      * @return The configured application.
      */
     @Override
-    protected Application configure() {
+    protected ResourceConfig createApplication() {
         ResourceConfig a = new ResourceConfig();
         a.register(LoggingFeature.class);
         a.register(MockService.class);

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/status/StatusFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/status/StatusFeatureTest.java
@@ -20,11 +20,10 @@ package net.krotscheck.kangaroo.common.status;
 
 import org.apache.http.HttpStatus;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
+import net.krotscheck.kangaroo.test.KangarooJerseyTest;
 import org.junit.Assert;
 import org.junit.Test;
 
-import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Response;
 
 /**
@@ -32,7 +31,7 @@ import javax.ws.rs.core.Response;
  *
  * @author Michael Krotscheck
  */
-public final class StatusFeatureTest extends JerseyTest {
+public final class StatusFeatureTest extends KangarooJerseyTest {
 
     /**
      * Configure the test application.
@@ -40,7 +39,7 @@ public final class StatusFeatureTest extends JerseyTest {
      * @return A configured app.
      */
     @Override
-    protected Application configure() {
+    protected ResourceConfig createApplication() {
         ResourceConfig a = new ResourceConfig();
         a.register(StatusFeature.class);
         return a;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/status/StatusServiceTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/status/StatusServiceTest.java
@@ -18,14 +18,12 @@
 
 package net.krotscheck.kangaroo.common.status;
 
-import net.krotscheck.kangaroo.common.config.ConfigurationFeature;
 import org.apache.http.HttpStatus;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
+import net.krotscheck.kangaroo.test.KangarooJerseyTest;
 import org.junit.Assert;
 import org.junit.Test;
 
-import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Response;
 
 /**
@@ -33,7 +31,7 @@ import javax.ws.rs.core.Response;
  *
  * @author Michael Krotscheck
  */
-public final class StatusServiceTest extends JerseyTest {
+public final class StatusServiceTest extends KangarooJerseyTest {
 
     /**
      * Setup the test application.
@@ -41,7 +39,7 @@ public final class StatusServiceTest extends JerseyTest {
      * @return A configured application for this test harness.
      */
     @Override
-    protected Application configure() {
+    protected ResourceConfig createApplication() {
         ResourceConfig a = new ResourceConfig();
         a.register(StatusService.class);
         return a;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/version/VersionFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/version/VersionFeatureTest.java
@@ -19,11 +19,10 @@ package net.krotscheck.kangaroo.common.version;
 
 import net.krotscheck.kangaroo.common.config.ConfigurationFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
+import net.krotscheck.kangaroo.test.KangarooJerseyTest;
 import org.junit.Assert;
 import org.junit.Test;
 
-import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Response;
 
 /**
@@ -31,7 +30,7 @@ import javax.ws.rs.core.Response;
  *
  * @author Michael Krotscheck
  */
-public final class VersionFeatureTest extends JerseyTest {
+public final class VersionFeatureTest extends KangarooJerseyTest {
 
     /**
      * Construct the application.
@@ -39,7 +38,7 @@ public final class VersionFeatureTest extends JerseyTest {
      * @return A filtered application.
      */
     @Override
-    protected Application configure() {
+    protected ResourceConfig createApplication() {
         ResourceConfig a = new ResourceConfig();
         a.register(ConfigurationFeature.class);
         a.register(VersionFeature.class);

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/version/VersionFilterTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/version/VersionFilterTest.java
@@ -19,11 +19,10 @@ package net.krotscheck.kangaroo.common.version;
 
 import net.krotscheck.kangaroo.common.config.ConfigurationFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
+import net.krotscheck.kangaroo.test.KangarooJerseyTest;
 import org.junit.Assert;
 import org.junit.Test;
 
-import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Response;
 
 /**
@@ -32,7 +31,7 @@ import javax.ws.rs.core.Response;
  *
  * @author Michael Krotscheck
  */
-public final class VersionFilterTest extends JerseyTest {
+public final class VersionFilterTest extends KangarooJerseyTest {
 
     /**
      * Build a test application.
@@ -40,7 +39,7 @@ public final class VersionFilterTest extends JerseyTest {
      * @return Configured version filter app.
      */
     @Override
-    protected Application configure() {
+    protected ResourceConfig createApplication() {
         ResourceConfig a = new ResourceConfig();
         a.register(ConfigurationFeature.class);
         a.register(VersionFeature.class);

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/ContainerTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/ContainerTest.java
@@ -22,10 +22,6 @@ import net.krotscheck.kangaroo.test.rule.DatabaseResource;
 import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
-import org.glassfish.jersey.client.ClientConfig;
-import org.glassfish.jersey.client.ClientProperties;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.JerseyTest;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.search.FullTextSession;
@@ -33,14 +29,11 @@ import org.hibernate.search.Search;
 import org.hibernate.search.SearchFactory;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import javax.inject.Inject;
 import javax.ws.rs.client.Invocation.Builder;
 import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Application;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import java.net.URI;
@@ -58,7 +51,7 @@ import static org.junit.Assert.assertTrue;
  * @author Michael Krotscheck
  */
 public abstract class ContainerTest
-        extends JerseyTest
+        extends KangarooJerseyTest
         implements IDatabaseTest {
 
     /**
@@ -101,37 +94,6 @@ public abstract class ContainerTest
     private Session session;
 
     /**
-     * Configure all jersey2 clients.
-     *
-     * @param config The configuration instance to modify.
-     */
-    @Override
-    protected final void configureClient(final ClientConfig config) {
-        config.property(ClientProperties.FOLLOW_REDIRECTS, false);
-    }
-
-    /**
-     * Ask the test to construct an application, and then inject this test
-     * into the context.
-     *
-     * @return The application itself
-     */
-    @Override
-    protected final Application configure() {
-        ResourceConfig config = createApplication();
-        config.register(this);
-
-        return config;
-    }
-
-    /**
-     * Create an application.
-     *
-     * @return The application to test.
-     */
-    protected abstract ResourceConfig createApplication();
-
-    /**
      * Set up the fixtures and any environment that's necessary.
      *
      * @throws Exception Thrown in the fixtures() interface.
@@ -162,20 +124,6 @@ public abstract class ContainerTest
         searchFactory = null;
         fullTextSession = null;
         session = null;
-    }
-
-    /**
-     * Install the JUL-to-SLF4J logging bridge, before any application is
-     * bootstrapped. This explicitly pre-empts the same code in the logging
-     * feature, to catch test-initialization related log messages from
-     * jerseytest.
-     */
-    @BeforeClass
-    public static void installLogging() {
-        if (!SLF4JBridgeHandler.isInstalled()) {
-            SLF4JBridgeHandler.removeHandlersForRootLogger();
-            SLF4JBridgeHandler.install();
-        }
     }
 
     /**

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/KangarooJerseyTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/KangarooJerseyTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.test;
+
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.TestProperties;
+import org.junit.BeforeClass;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+import javax.ws.rs.core.Application;
+
+/**
+ * A single extension point class for all of our jersey tests.
+ *
+ * @author Michael Krotscheck.
+ */
+public abstract class KangarooJerseyTest extends JerseyTest {
+
+    /**
+     * Ask the test to construct an application, and then inject this test
+     * into the context.
+     *
+     * @return The application itself
+     */
+    @Override
+    protected final Application configure() {
+        forceSet(TestProperties.CONTAINER_PORT, "0");
+        forceSet(TestProperties.LOG_TRAFFIC, "true");
+        forceSet(TestProperties.DUMP_ENTITY, "true");
+
+        ResourceConfig config = createApplication();
+        config.register(this);
+
+        return config;
+    }
+
+    /**
+     * Create an application.
+     *
+     * @return The application to test.
+     */
+    protected abstract ResourceConfig createApplication();
+
+    /**
+     * Configure all jersey2 clients.
+     *
+     * @param config The configuration instance to modify.
+     */
+    @Override
+    protected final void configureClient(final ClientConfig config) {
+        config.property(ClientProperties.FOLLOW_REDIRECTS, false);
+    }
+
+    /**
+     * Install the JUL-to-SLF4J logging bridge, before any application is
+     * bootstrapped. This explicitly pre-empts the same code in the logging
+     * feature, to catch test-initialization related log messages from
+     * jerseytest.
+     */
+    @BeforeClass
+    public static void installLogging() {
+        if (!SLF4JBridgeHandler.isInstalled()) {
+            SLF4JBridgeHandler.removeHandlersForRootLogger();
+            SLF4JBridgeHandler.install();
+        }
+    }
+}

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AbstractResourceTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AbstractResourceTest.java
@@ -32,11 +32,9 @@ import net.krotscheck.kangaroo.test.HttpUtil;
 import net.krotscheck.kangaroo.test.TestAuthenticator;
 import org.apache.commons.configuration.Configuration;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.TestProperties;
 import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.hibernate.Transaction;
 import org.junit.After;
 import org.junit.Assert;
 
@@ -88,9 +86,6 @@ public abstract class AbstractResourceTest extends ContainerTest {
      */
     @Override
     protected final ResourceConfig createApplication() {
-        enable(TestProperties.LOG_TRAFFIC);
-        enable(TestProperties.DUMP_ENTITY);
-
         ResourceConfig v1Api = new AdminV1API();
         v1Api.register(new TestAuthenticator.Binder());
         return v1Api;

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/AbstractRFC6749Test.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/AbstractRFC6749Test.java
@@ -20,7 +20,6 @@ package net.krotscheck.kangaroo.servlet.oauth2.rfc6749;
 import net.krotscheck.kangaroo.servlet.oauth2.OAuthTestApp;
 import net.krotscheck.kangaroo.test.ContainerTest;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.test.TestProperties;
 
 /**
  * Abstract testing class that bootstraps a full OAuthAPI that's ready for
@@ -38,8 +37,6 @@ public abstract class AbstractRFC6749Test extends ContainerTest {
      */
     @Override
     protected final ResourceConfig createApplication() {
-        enable(TestProperties.LOG_TRAFFIC);
-        enable(TestProperties.DUMP_ENTITY);
         return new OAuthTestApp();
     }
 }


### PR DESCRIPTION
This patch creates a parent test class that manages global test
configuration values.