### PR TITLE
Centralized hibernate session creation into JUnit rule

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateServiceRegistryFactory.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateServiceRegistryFactory.java
@@ -56,6 +56,7 @@ public final class HibernateServiceRegistryFactory
 
         return new StandardServiceRegistryBuilder()
                 .configure() // configures settings from hibernate.cfg.xml
+                .applySettings(System.getProperties())
                 .build();
     }
 

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/listener/CreatedUpdatedListenerTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/listener/CreatedUpdatedListenerTest.java
@@ -23,6 +23,7 @@ import net.krotscheck.kangaroo.test.EnvironmentBuilder;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
+import org.hibernate.event.service.spi.EventListenerRegistrationException;
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
 import org.hibernate.event.spi.PreInsertEvent;
@@ -63,10 +64,15 @@ public final class CreatedUpdatedListenerTest extends DatabaseTest {
         EventListenerRegistry eventRegistry = registry
                 .getService(EventListenerRegistry.class);
 
-        eventRegistry.appendListeners(EventType.PRE_INSERT,
-                new CreatedUpdatedListener());
-        eventRegistry.appendListeners(EventType.PRE_UPDATE,
-                new CreatedUpdatedListener());
+        try {
+            eventRegistry.appendListeners(EventType.PRE_INSERT,
+                    new CreatedUpdatedListener());
+            eventRegistry.appendListeners(EventType.PRE_UPDATE,
+                    new CreatedUpdatedListener());
+        } catch (EventListenerRegistrationException e) {
+            // Session Factories are class-static, so we may have already
+            // registered these listeners. i.e. do nothing.
+        }
     }
 
     /**

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/HibernateResource.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/HibernateResource.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.test.rule;
+
+import net.krotscheck.kangaroo.test.rule.hibernate.TestDirectoryProvider;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.SearchFactory;
+import org.hibernate.service.ServiceRegistry;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * This JUnit Rule creates and maintains a set of Hibernate entities that
+ * match the configuration settings for the application database itself.
+ *
+ * @author Michael Krotscheck
+ */
+public class HibernateResource implements TestRule {
+
+    /**
+     * Internal session factory, reconstructed for every test run.
+     */
+    private SessionFactory sessionFactory;
+
+    /**
+     * The last created session.
+     */
+    private Session session;
+
+    /**
+     * Search factory.
+     */
+    private SearchFactory searchFactory;
+
+    /**
+     * Fulltext session.
+     */
+    private FullTextSession fullTextSession;
+
+    /**
+     * Create and return a hibernate session for the test database.
+     *
+     * @return The constructed session.
+     */
+    public Session getSession() {
+        return session;
+    }
+
+    /**
+     * Retrieve the search factory for the test.
+     *
+     * @return The session factory
+     */
+    public final SearchFactory getSearchFactory() {
+        return searchFactory;
+    }
+
+    /**
+     * Retrieve the fulltext session for the test.
+     *
+     * @return The session factory
+     */
+    public final FullTextSession getFullTextSession() {
+        return fullTextSession;
+    }
+
+    /**
+     * Create and return a hibernate session factory the test database.
+     *
+     * @return The session factory
+     */
+    public SessionFactory getSessionFactory() {
+        return sessionFactory;
+    }
+
+    /**
+     * Modifies the method-running {@link Statement} to implement this
+     * test-running rule.
+     *
+     * @param base        The {@link Statement} to be modified
+     * @param description A {@link Description} of the test implemented in
+     *                    {@code base}
+     * @return a new statement, which may be the same as {@code base},
+     * a wrapper around {@code base}, or a completely new Statement.
+     */
+    @Override
+    public Statement apply(final Statement base,
+                           final Description description) {
+        return new Statement() {
+
+            @Override
+            public void evaluate() throws Throwable {
+                overrideSettings();
+                createHibernateConnection();
+                try {
+                    base.evaluate();
+                } finally {
+                    closeHibernateConnection();
+                    clearSettings();
+                }
+            }
+        };
+    }
+
+    /**
+     * Override any settings automatically loaded from the hibernate
+     * configuration file.
+     */
+    private void overrideSettings() {
+        // Override the cache directory implementation setting for hibernate
+        // search. This provider is essentially a RAMDirectory, except that
+        // it can be accessed by all the different SessionFactories
+        // instantiated during a full test.
+        String name = TestDirectoryProvider.class.getTypeName();
+        System.setProperty("hibernate.search.default.directory_provider", name);
+    }
+
+    /**
+     * Clear any settings we've previously set.
+     */
+    private void clearSettings() {
+        System.clearProperty("hibernate.search.default.directory_provider");
+    }
+
+    /**
+     * Ensure that the hibernate connection is closed even if a test fails.
+     */
+    private void closeHibernateConnection() {
+        searchFactory = null;
+
+        if (fullTextSession.isOpen()) {
+            fullTextSession.close();
+        }
+        fullTextSession = null;
+
+        // Clean any outstanding sessions.
+        if (session.isOpen()) {
+            session.close();
+        }
+        session = null;
+
+        if (!sessionFactory.isClosed()) {
+            sessionFactory.close();
+        }
+        sessionFactory = null;
+    }
+
+    /**
+     * Create a session factory for the database.
+     */
+    private void createHibernateConnection() {
+        // Create the session factory.
+        ServiceRegistry serviceRegistry =
+                new StandardServiceRegistryBuilder()
+                        .configure()
+                        .applySettings(System.getProperties())
+                        .build();
+        sessionFactory = new MetadataSources(serviceRegistry)
+                .buildMetadata()
+                .buildSessionFactory();
+        session = sessionFactory.openSession();
+
+        fullTextSession = Search.getFullTextSession(session);
+        searchFactory = fullTextSession.getSearchFactory();
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/hibernate/TestDirectoryProvider.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/hibernate/TestDirectoryProvider.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.test.rule.hibernate;
+
+import org.apache.lucene.store.NoLockFactory;
+import org.apache.lucene.store.RAMDirectory;
+import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
+import org.hibernate.search.spi.BuildContext;
+import org.hibernate.search.store.DirectoryProvider;
+import org.hibernate.search.store.impl.RAMDirectoryProvider;
+import org.hibernate.search.store.spi.DirectoryHelper;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * This component is a hibernate search directory provider intended for use
+ * during Jersey2 tests, where the lifecycle of the search index needs to be
+ * decoupled from the application container and independently managed.
+ * <p>
+ * Under the hood it is simply a RamDirectoryProvider, however one that must
+ * be explicitly (statically) initialized and cleared. This leads to a far
+ * more performant test environment, as filesystem and/or infinispan based
+ * directories can slow down the testing harness.
+ *
+ * @author Michael Krotscheck
+ */
+public final class TestDirectoryProvider
+        implements DirectoryProvider<RAMDirectory> {
+
+    /**
+     * Static, shared storage of all providers.
+     */
+    private static Map<String, RAMDirectory> cachedProviders = new HashMap<>();
+
+    /**
+     * The number of times this particular cache has been requested.
+     */
+    private static Map<String, Integer> referenceCounts = new HashMap<>();
+
+    /**
+     * The name of the index.
+     */
+    private String indexName;
+
+    @Override
+    public void initialize(final String directoryProviderName,
+                           final Properties properties,
+                           final BuildContext context) {
+        this.indexName = directoryProviderName;
+    }
+
+
+    @Override
+    public void start(final DirectoryBasedIndexManager indexManager) {
+        if (cachedProviders.containsKey(indexName)) {
+            return;
+        }
+
+        RAMDirectory d = new RAMDirectory(NoLockFactory.INSTANCE);
+        cachedProviders.put(indexName, d);
+        DirectoryHelper.initializeIndexIfNeeded(d);
+        referenceCounts.put(indexName, 0);
+    }
+
+    @Override
+    public synchronized RAMDirectory getDirectory() {
+        Integer referenceCount = referenceCounts.get(indexName);
+        referenceCounts.put(indexName, referenceCount + 1);
+        return cachedProviders.get(indexName);
+    }
+
+    @Override
+    public synchronized void stop() {
+        Integer referenceCount = referenceCounts.get(indexName);
+        referenceCounts.put(indexName, referenceCount - 1);
+
+        if (referenceCounts.get(indexName) == 0) {
+            RAMDirectory d = cachedProviders.get(indexName);
+            d.close();
+            cachedProviders.remove(indexName);
+        }
+    }
+
+    /**
+     * Equality operator.
+     *
+     * @param obj The object to test.
+     * @return Whether these two objects are equal.
+     */
+    @Override
+    public boolean equals(final Object obj) {
+        // this code is actually broken since the value change after initialize call
+        // but from a practical POV this is fine since we only call this method
+        // after initialize call
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || !(obj instanceof RAMDirectoryProvider)) {
+            return false;
+        }
+        return indexName.equals(((TestDirectoryProvider) obj).indexName);
+    }
+
+    /**
+     * Hashcode generation off the index name.
+     *
+     * @return The hashcode.
+     */
+    @Override
+    public int hashCode() {
+        // this code is actually broken since the value change after initialize call
+        // but from a practical POV this is fine since we only call this method
+        // after initialize call
+        int hash = 7;
+        return 29 * hash + indexName.hashCode();
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/hibernate/package-info.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/hibernate/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Supporting implementations for the hibernate test resource.
+ */
+package net.krotscheck.kangaroo.test.rule.hibernate;


### PR DESCRIPTION
This patch adds various improvements to how database sessions are
managed during our JUnit tests. These include.

- Hibernate configuration may now be overridden using system config.
  This should also assist in deployment configuration.
- Maintaining the hibernate session accessed by the test classes is
  now delegated to a JUnit rule, which allows us to explicitly close
  it even if a test fails. This should prevent lockups in CI.
- The hibernate test environment overrides the configured lucene index
  directory provider, with one that can be accessed across all current
  active SessionFactories. This allows us to load data into one
  sessionfactory environment, and have it be searchable in another.
  As this must only be available during test time, it's explicitly
  overridden in the hibernate rule.