### PR TITLE
Removed maxpermsize

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
             </dependency>
           </dependencies>
           <configuration>
-            <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+            <argLine>-Xmx1024m</argLine>
 
             <systemProperties>
               <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>


### PR DESCRIPTION
It was deprecated in the v8 JDK.