### PR TITLE
Properly dispose of service registries.

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/context/SearchIndexContextListener.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/context/SearchIndexContextListener.java
@@ -50,19 +50,36 @@ public final class SearchIndexContextListener
             LoggerFactory.getLogger(SearchIndexContextListener.class);
 
     /**
+     * The service registry initialized by this class.
+     */
+    private ServiceRegistry registry;
+
+    /**
+     * Build/Retrieve the service registry.
+     *
+     * @return The service registry.
+     */
+    private ServiceRegistry getServiceRegistry() {
+        // configures settings from hibernate.cfg.xml
+        registry = new StandardServiceRegistryBuilder().configure().build();
+        return registry;
+    }
+
+    /**
+     * Dispose of the service registry.
+     */
+    private void disposeServiceRegistry() {
+        StandardServiceRegistryBuilder.destroy(registry);
+    }
+
+    /**
      * Create a session factory given the current configuration method.
      *
      * @return A constructed session factory.
      */
     protected SessionFactory createSessionFactory() {
-        // Set up a service registry.
-        StandardServiceRegistryBuilder b = new StandardServiceRegistryBuilder();
-
-        // configures settings from hibernate.cfg.xml
-        ServiceRegistry registry = b.configure().build();
-
         // Build the session factory.
-        return new MetadataSources(registry)
+        return new MetadataSources(getServiceRegistry())
                 .buildMetadata()
                 .buildSessionFactory();
     }
@@ -97,6 +114,7 @@ public final class SearchIndexContextListener
             // Close everything and release the lock file.
             session.close();
             factory.close();
+            disposeServiceRegistry();
         }
     }
 

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/DatabaseTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/DatabaseTest.java
@@ -47,6 +47,11 @@ public abstract class DatabaseTest {
     public static final DatabaseResource JNDI = new DatabaseResource();
 
     /**
+     * Service registry, as built from the configuration.
+     */
+    private ServiceRegistry serviceRegistry;
+
+    /**
      * Internal session factory, reconstructed for every test run.
      */
     private SessionFactory sessionFactory;
@@ -77,7 +82,7 @@ public abstract class DatabaseTest {
     @Before
     public final void setupData() throws Exception {
         // Create the session factory.
-        ServiceRegistry serviceRegistry =
+        serviceRegistry =
                 new StandardServiceRegistryBuilder()
                         .configure()
                         .build();
@@ -112,6 +117,8 @@ public abstract class DatabaseTest {
 
         sessionFactory.close();
         sessionFactory = null;
+
+        StandardServiceRegistryBuilder.destroy(serviceRegistry);
     }
 
     /**


### PR DESCRIPTION
While not a huge memory leak, nevertheless something we should clean up.