### PR TITLE
Created JUnit rules for hibernate session creation and test data loading.

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateServiceRegistryFactory.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateServiceRegistryFactory.java
@@ -56,6 +56,7 @@ public final class HibernateServiceRegistryFactory
 
         return new StandardServiceRegistryBuilder()
                 .configure() // configures settings from hibernate.cfg.xml
+                .applySettings(System.getProperties())
                 .build();
     }
 

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/DatabaseResource.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/DatabaseResource.java
@@ -55,8 +55,6 @@ public final class DatabaseResource implements TestRule {
     private static String getDbJdbcPath() {
         return System.getProperty("test.db.jdbc",
                 "jdbc:h2:mem:target/test/db/h2/hibernate");
-//        return System.getProperty("test.db.jdbc",
-//                "jdbc:mysql://localhost:3306/oid?useUnicode=yes");
     }
 
     /**
@@ -66,7 +64,6 @@ public final class DatabaseResource implements TestRule {
      */
     private static String getDbDriver() {
         return System.getProperty("test.db.driver", "org.h2.Driver");
-//        return System.getProperty("test.db.driver", "com.mysql.jdbc.Driver");
     }
 
     /**
@@ -125,7 +122,7 @@ public final class DatabaseResource implements TestRule {
         System.setProperty(Context.URL_PKG_PREFIXES,
                 "org.eclipse.jetty.jndi");
 
-        logger.info(String.format("Setting up [%s] database at [%s]",
+        logger.debug(String.format("Setting up [%s] database at [%s]",
                 getDbDriver(), getDbJdbcPath()));
 
         try {
@@ -155,7 +152,7 @@ public final class DatabaseResource implements TestRule {
      *                   fix your tests!
      */
     private void setupDatabase() throws Exception {
-        logger.info("Migrating Database Schema.");
+        logger.debug("Migrating Database Schema.");
 
         // Force the database to use UTC.
         System.setProperty("user.timezone", "UTC");
@@ -164,6 +161,7 @@ public final class DatabaseResource implements TestRule {
         // We need to persist this connection so that the in-memory database
         // is not destroyed when the connection drops.
         Class.forName(getDbDriver());
+        logger.debug("Opening connection.");
         conn = DriverManager.getConnection(
                 getDbJdbcPath(),
                 getDbLogin(),
@@ -178,9 +176,9 @@ public final class DatabaseResource implements TestRule {
             s.close();
         }
 
+        logger.debug("Migrating schema.");
         Database database = DatabaseFactory.getInstance()
                 .findCorrectDatabaseImplementation(new JdbcConnection(conn));
-
         liquibase = new Liquibase("liquibase/db.changelog-master.yaml",
                 new ClassLoaderResourceAccessor(), database);
         liquibase.update(new Contexts());
@@ -192,7 +190,7 @@ public final class DatabaseResource implements TestRule {
      * @throws Throwable An exception encountered during teardown.
      */
     private void cleanDatabase() throws Throwable {
-        logger.info("Cleaning Database.");
+        logger.debug("Cleaning Database.");
         liquibase.rollback(1000, null);
         liquibase = null;
 

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/HibernateResource.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/HibernateResource.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.test.rule;
+
+import net.krotscheck.kangaroo.test.rule.hibernate.TestDirectoryProvider;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.SearchFactory;
+import org.hibernate.service.ServiceRegistry;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This JUnit Rule creates and maintains a set of Hibernate entities that
+ * match the configuration settings for the application database itself.
+ *
+ * @author Michael Krotscheck
+ */
+public class HibernateResource implements TestRule {
+
+    /**
+     * Logger instance.
+     */
+    private static Logger logger =
+            LoggerFactory.getLogger(HibernateResource.class);
+
+    /**
+     * Service registry, constructed from the configuration.
+     */
+    private ServiceRegistry registry;
+
+    /**
+     * Internal session factory, reconstructed for every test run.
+     */
+    private SessionFactory sessionFactory;
+
+    /**
+     * The last created session.
+     */
+    private Session session;
+
+    /**
+     * Search factory.
+     */
+    private SearchFactory searchFactory;
+
+    /**
+     * Fulltext session.
+     */
+    private FullTextSession fullTextSession;
+
+    /**
+     * Create and return a hibernate session for the test database.
+     *
+     * @return The constructed session.
+     */
+    public Session getSession() {
+        return session;
+    }
+
+    /**
+     * Retrieve the search factory for the test.
+     *
+     * @return The session factory
+     */
+    public final SearchFactory getSearchFactory() {
+        return searchFactory;
+    }
+
+    /**
+     * Retrieve the fulltext session for the test.
+     *
+     * @return The session factory
+     */
+    public final FullTextSession getFullTextSession() {
+        return fullTextSession;
+    }
+
+    /**
+     * Create and return a hibernate session factory the test database.
+     *
+     * @return The session factory
+     */
+    public SessionFactory getSessionFactory() {
+        return sessionFactory;
+    }
+
+    /**
+     * Modifies the method-running {@link Statement} to implement this
+     * test-running rule.
+     *
+     * @param base        The {@link Statement} to be modified
+     * @param description A {@link Description} of the test implemented in
+     *                    {@code base}
+     * @return a new statement, which may be the same as {@code base},
+     * a wrapper around {@code base}, or a completely new Statement.
+     */
+    @Override
+    public Statement apply(final Statement base,
+                           final Description description) {
+        return new Statement() {
+
+            @Override
+            public void evaluate() throws Throwable {
+                overrideSettings();
+                createHibernateConnection();
+                try {
+                    base.evaluate();
+                } finally {
+                    closeHibernateConnection();
+                    clearSettings();
+                }
+            }
+        };
+    }
+
+    /**
+     * Override any settings automatically loaded from the hibernate
+     * configuration file.
+     */
+    private void overrideSettings() {
+        // Override the cache directory implementation setting for hibernate
+        // search. This provider is essentially a RAMDirectory, except that
+        // it can be accessed by all the different SessionFactories
+        // instantiated during a full test.
+        String name = TestDirectoryProvider.class.getTypeName();
+        System.setProperty("hibernate.search.default.directory_provider",
+                name);
+        System.setProperty("hibernate.search.default.exclusive_index_use",
+                "false");
+    }
+
+    /**
+     * Clear any settings we've previously set.
+     */
+    private void clearSettings() {
+        System.clearProperty("hibernate.search.default.directory_provider");
+        System.clearProperty("hibernate.search.default.exclusive_index_use");
+    }
+
+    /**
+     * Ensure that the hibernate connection is closed even if a test fails.
+     */
+    private void closeHibernateConnection() {
+        searchFactory = null;
+
+        if (fullTextSession.isOpen()) {
+            logger.debug("Closing FullTextSession");
+            fullTextSession.close();
+        }
+        fullTextSession = null;
+
+        // Clean any outstanding sessions.
+        if (session.isOpen()) {
+            logger.debug("Closing Session");
+            session.close();
+        }
+        session = null;
+
+        if (!sessionFactory.isClosed()) {
+            logger.debug("Closing SessionFactory");
+            sessionFactory.close();
+        }
+        sessionFactory = null;
+
+        logger.debug("Disposing ServiceRegistry");
+        StandardServiceRegistryBuilder.destroy(registry);
+    }
+
+    /**
+     * Create a session factory for the database.
+     */
+    private void createHibernateConnection() {
+        // Create the session factory.
+        logger.debug("Creating ServiceRegistry");
+        registry = new StandardServiceRegistryBuilder()
+                .configure()
+                .applySettings(System.getProperties())
+                .build();
+        logger.debug("Creating SessionFactory");
+        sessionFactory = new MetadataSources(registry)
+                .buildMetadata()
+                .buildSessionFactory();
+        logger.debug("Opening Session");
+        session = sessionFactory.openSession();
+
+        logger.debug("Creating FullTextSession");
+        fullTextSession = Search.getFullTextSession(session);
+        searchFactory = fullTextSession.getSearchFactory();
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/TestDataResource.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/TestDataResource.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.test.rule;
+
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.service.ServiceRegistry;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A rule which, by extension, can act as a test data loader for any test.
+ *
+ * @author Michael Krotscheck
+ */
+public abstract class TestDataResource implements TestRule {
+
+    /**
+     * Logger instance.
+     */
+    private static Logger logger =
+            LoggerFactory.getLogger(TestDataResource.class);
+
+    /**
+     * Service registry, constructed from the configuration.
+     */
+    private ServiceRegistry registry;
+
+    /**
+     * Internal session factory, reconstructed for every test run.
+     */
+    private SessionFactory sessionFactory;
+
+    /**
+     * The last created session.
+     */
+    private Session session;
+
+    /**
+     * Retrieve the session from within this resource.
+     *
+     * @return The initialized session.
+     */
+    protected final Session getSession() {
+        return session;
+    }
+
+    /**
+     * Retrieve the session factory from within this resource.
+     *
+     * @return The initialized session.
+     */
+    protected final SessionFactory getSessionFactory() {
+        return sessionFactory;
+    }
+
+    /**
+     * Modifies the method-running {@link Statement} to implement this
+     * test-running rule.
+     *
+     * @param base        The {@link Statement} to be modified
+     * @param description A {@link Description} of the test implemented in
+     *                    {@code base}
+     * @return a new statement, which may be the same as {@code base},
+     * a wrapper around {@code base}, or a completely new Statement.
+     */
+    @Override
+    public final Statement apply(final Statement base,
+                           final Description description) {
+        return new Statement() {
+
+            @Override
+            public void evaluate() throws Throwable {
+                openHibernateSession();
+                loadTestData();
+                try {
+                    base.evaluate();
+                } finally {
+                    clearTestData();
+                    closeHibernateSession();
+                }
+            }
+        };
+    }
+
+    /**
+     * Create a session factory for the database.
+     */
+    private void openHibernateSession() {
+        // Create the session factory.
+        logger.debug("Creating ServiceRegistry");
+        registry = new StandardServiceRegistryBuilder()
+                        .configure()
+                        .applySettings(System.getProperties())
+                        .build();
+
+        logger.debug("Creating SessionFactory");
+        sessionFactory = new MetadataSources(registry)
+                .buildMetadata()
+                .buildSessionFactory();
+
+        logger.debug("Opening Session");
+        session = sessionFactory.openSession();
+    }
+
+    /**
+     * Ensure that the hibernate connection is closed even if a test fails.
+     */
+    private void closeHibernateSession() {
+        // Clean any outstanding sessions.
+        logger.debug("Closing Session");
+        if (session.isOpen()) {
+            session.close();
+        }
+        session = null;
+
+        logger.debug("Closing SessionFactory");
+        if (!sessionFactory.isClosed()) {
+            sessionFactory.close();
+        }
+        sessionFactory = null;
+
+        logger.debug("Closing ServiceRegistry");
+        StandardServiceRegistryBuilder.destroy(registry);
+    }
+
+    /**
+     * Load data into the database.
+     */
+    protected abstract void loadTestData();
+
+    /**
+     * Wipe the database clean.
+     */
+    private void clearTestData() {
+        Query removeOwners =
+                session.createQuery("UPDATE Application SET owner = null");
+        Query removeApplications =
+                session.createQuery("DELETE FROM Application");
+        Query removeConfiguration =
+                session.createQuery("DELETE FROM ConfigurationEntry");
+
+        Transaction t = session.beginTransaction();
+        removeOwners.executeUpdate();
+        removeApplications.executeUpdate();
+        removeConfiguration.executeUpdate();
+        t.commit();
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/hibernate/TestDirectoryProvider.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/hibernate/TestDirectoryProvider.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.test.rule.hibernate;
+
+import org.apache.lucene.store.LockFactory;
+import org.apache.lucene.store.RAMDirectory;
+import org.hibernate.search.engine.service.spi.ServiceManager;
+import org.hibernate.search.indexes.spi.DirectoryBasedIndexManager;
+import org.hibernate.search.spi.BuildContext;
+import org.hibernate.search.store.DirectoryProvider;
+import org.hibernate.search.store.impl.RAMDirectoryProvider;
+import org.hibernate.search.store.spi.DirectoryHelper;
+import org.hibernate.search.store.spi.LockFactoryCreator;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * This component is a hibernate search directory provider intended for use
+ * during Jersey2 tests, where the lifecycle of the search index needs to be
+ * decoupled from the application container and independently managed.
+ * <p>
+ * Under the hood it is simply a RamDirectoryProvider, however one that must
+ * be explicitly (statically) initialized and cleared. This leads to a far
+ * more performant test environment, as filesystem and/or infinispan based
+ * directories can slow down the testing harness.
+ *
+ * @author Michael Krotscheck
+ */
+public final class TestDirectoryProvider
+        implements DirectoryProvider<RAMDirectory> {
+
+    /**
+     * Static, shared storage of all providers.
+     */
+    private static Map<String, RAMDirectory> cachedProviders = new HashMap<>();
+
+    /**
+     * The number of times this particular cache has been requested.
+     */
+    private static Map<String, Integer> referenceCounts = new HashMap<>();
+
+    /**
+     * The name of the index.
+     */
+    private String indexName;
+
+    /**
+     * Configuration, passed through to the lock factory creator.
+     */
+    private Properties properties;
+
+    /**
+     * Hibernate service manager.
+     */
+    private ServiceManager serviceManager;
+
+    /**
+     * Initialize the directory provider.
+     *
+     * @param directoryProviderName Directory name.
+     * @param properties            Configuration properties.
+     * @param context               Hibernate execution context.
+     */
+    @Override
+    public void initialize(final String directoryProviderName,
+                           final Properties properties,
+                           final BuildContext context) {
+        this.indexName = directoryProviderName;
+        this.properties = properties;
+        this.serviceManager = context.getServiceManager();
+    }
+
+
+    @Override
+    public synchronized void start(final DirectoryBasedIndexManager indexManager) {
+        Integer referenceCount = referenceCounts.getOrDefault(indexName, 0);
+        if (referenceCount == 0) {
+            LockFactory lockFactory = serviceManager
+                    .requestService(LockFactoryCreator.class)
+                    .createLockFactory(null, properties);
+
+            RAMDirectory d = new RAMDirectory(lockFactory);
+            DirectoryHelper.initializeIndexIfNeeded(d);
+            cachedProviders.put(indexName, d);
+
+            serviceManager.releaseService(LockFactoryCreator.class);
+        }
+        referenceCounts.put(indexName, referenceCount + 1);
+    }
+
+    @Override
+    public synchronized RAMDirectory getDirectory() {
+        return cachedProviders.get(indexName);
+    }
+
+    @Override
+    public synchronized void stop() {
+        referenceCounts.put(indexName, referenceCounts.get(indexName) - 1);
+
+        if (referenceCounts.get(indexName) == 0) {
+            RAMDirectory d = cachedProviders.get(indexName);
+            d.close();
+            cachedProviders.remove(indexName);
+            referenceCounts.remove(indexName);
+        }
+    }
+
+    /**
+     * Equality operator.
+     *
+     * @param obj The object to test.
+     * @return Whether these two objects are equal.
+     */
+    @Override
+    public boolean equals(final Object obj) {
+        // this code is actually broken since the value change after initialize call
+        // but from a practical POV this is fine since we only call this method
+        // after initialize call
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || !(obj instanceof RAMDirectoryProvider)) {
+            return false;
+        }
+        return indexName.equals(((TestDirectoryProvider) obj).indexName);
+    }
+
+    /**
+     * Hashcode generation off the index name.
+     *
+     * @return The hashcode.
+     */
+    @Override
+    public int hashCode() {
+        // this code is actually broken since the value change after initialize call
+        // but from a practical POV this is fine since we only call this method
+        // after initialize call
+        int hash = 7;
+        return 29 * hash + indexName.hashCode();
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/hibernate/package-info.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/hibernate/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Supporting implementations for the hibernate test resource.
+ */
+package net.krotscheck.kangaroo.test.rule.hibernate;


### PR DESCRIPTION
These two rules allow us to control whether our database sessions, and our
test data, are loaded either at a class or at a test level. There's a
tradeoff: In order to be useful and accessible during the test, they
must open their own connections to the database; using these in combination
with the DatabaseResource means that each test requires the creation of
4 connections to the database. Thankfully, these ones are able to dispose
of themselves cleanly in the finally{} blocks.

A side effect of this change is that the hibernate configuration can also
be configured using system properties. This should come in handy when
we finally wrap it all into a docker container.