### PR TITLE
Switched DatabaseTest to use static JUnit rules

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/OAuthToken.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/OAuthToken.java
@@ -88,11 +88,8 @@ public final class OAuthToken extends AbstractEntity implements Principal {
     /**
      * The authenticated user identity.
      */
-    @ManyToOne(fetch = FetchType.LAZY,
-            cascade = {CascadeType.REMOVE, CascadeType.MERGE}
-    )
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "identity", updatable = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
     @JsonIdentityReference(alwaysAsId = true)
     @JsonDeserialize(using = UserIdentity.Deserializer.class)
     @IndexedEmbedded(includePaths = {"id", "user.id"})

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/authenticator/PasswordAuthenticatorTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/authenticator/PasswordAuthenticatorTest.java
@@ -24,6 +24,7 @@ import net.krotscheck.kangaroo.database.entity.ClientType;
 import net.krotscheck.kangaroo.database.entity.UserIdentity;
 import net.krotscheck.kangaroo.test.DatabaseTest;
 import net.krotscheck.kangaroo.test.EnvironmentBuilder;
+import net.krotscheck.kangaroo.test.rule.TestDataResource;
 import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.api.ServiceLocatorFactory;
@@ -31,15 +32,16 @@ import org.glassfish.hk2.utilities.BuilderHelper;
 import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
 import org.glassfish.jersey.process.internal.RequestScoped;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+import java.util.List;
 
 /**
  * Unit tests for the password authenticator.
@@ -49,27 +51,27 @@ import javax.ws.rs.core.UriBuilder;
 public final class PasswordAuthenticatorTest extends DatabaseTest {
 
     /**
-     * Test context.
+     * Test data loading for this test.
      */
-    private EnvironmentBuilder context;
+    @ClassRule
+    public static final TestRule TEST_DATA_RULE = new TestDataResource() {
+        /**
+         * Initialize the test data.
+         */
+        @Override
+        protected void loadTestData() {
+            context = new EnvironmentBuilder(getSession());
+            context.client(ClientType.OwnerCredentials)
+                    .authenticator("password")
+                    .user()
+                    .login("login", "password");
+        }
+    };
 
     /**
-     * Load data fixtures for each test.
-     *
-     * @return A list of fixtures, which will be cleared after the test.
+     * The environment set up for this test suite.
      */
-    @Override
-    public List<EnvironmentBuilder> fixtures() throws Exception {
-        context = new EnvironmentBuilder(getSession());
-        context.client(ClientType.OwnerCredentials)
-                .authenticator("password")
-                .user()
-                .login("login", "password");
-
-        List<EnvironmentBuilder> fixtures = new ArrayList<>();
-        fixtures.add(context);
-        return fixtures;
-    }
+    private static EnvironmentBuilder context;
 
     /**
      * Assert that the test delegate does nothing.

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/config/HibernateConfigurationTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/config/HibernateConfigurationTest.java
@@ -18,7 +18,6 @@
 package net.krotscheck.kangaroo.database.config;
 
 import net.krotscheck.kangaroo.test.DatabaseTest;
-import net.krotscheck.kangaroo.test.EnvironmentBuilder;
 import org.apache.commons.configuration.Configuration;
 import org.junit.After;
 import org.junit.Assert;
@@ -65,17 +64,6 @@ public final class HibernateConfigurationTest extends DatabaseTest {
     public void teardown() {
         configOne.clear();
         configTwo.clear();
-    }
-
-    /**
-     * Load data fixtures for each test.
-     *
-     * @return A list of fixtures, which will be cleared after the test.
-     * @throws Exception An exception that indicates a failed fixture load.
-     */
-    @Override
-    public List<EnvironmentBuilder> fixtures() throws Exception {
-        return null; // No fixtures.
     }
 
     /**

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/listener/CreatedUpdatedListenerTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/listener/CreatedUpdatedListenerTest.java
@@ -23,6 +23,7 @@ import net.krotscheck.kangaroo.test.EnvironmentBuilder;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
+import org.hibernate.event.service.spi.EventListenerRegistrationException;
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
 import org.hibernate.event.spi.PreInsertEvent;
@@ -63,20 +64,15 @@ public final class CreatedUpdatedListenerTest extends DatabaseTest {
         EventListenerRegistry eventRegistry = registry
                 .getService(EventListenerRegistry.class);
 
-        eventRegistry.appendListeners(EventType.PRE_INSERT,
-                new CreatedUpdatedListener());
-        eventRegistry.appendListeners(EventType.PRE_UPDATE,
-                new CreatedUpdatedListener());
-    }
-
-    /**
-     * Load data fixtures for each test.
-     *
-     * @return A list of fixtures, which will be cleared after the test.
-     */
-    @Override
-    public List<EnvironmentBuilder> fixtures() {
-        return null;
+        try {
+            eventRegistry.appendListeners(EventType.PRE_INSERT,
+                    new CreatedUpdatedListener());
+            eventRegistry.appendListeners(EventType.PRE_UPDATE,
+                    new CreatedUpdatedListener());
+        } catch (EventListenerRegistrationException e) {
+            // Session Factories are class-static, so we may have already
+            // registered these listeners. i.e. do nothing.
+        }
     }
 
     /**

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/servlet/FirstRunContainerLifecycleListenerTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/servlet/FirstRunContainerLifecycleListenerTest.java
@@ -51,17 +51,6 @@ public final class FirstRunContainerLifecycleListenerTest
         extends DatabaseTest {
 
     /**
-     * Load data fixtures for each test.
-     *
-     * @return A list of fixtures, which will be cleared after the test.
-     * @throws Exception An exception that indicates a failed fixture load.
-     */
-    @Override
-    public List<EnvironmentBuilder> fixtures() throws Exception {
-        return null;
-    }
-
-    /**
      * Make sure that the lifecycle listener is only run when the firstRun
      * flag is called.
      */

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/servlet/ServletConfigFactoryTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/servlet/ServletConfigFactoryTest.java
@@ -42,17 +42,6 @@ import javax.inject.Singleton;
 public final class ServletConfigFactoryTest extends DatabaseTest {
 
     /**
-     * Load data fixtures for each test.
-     *
-     * @return A list of fixtures, which will be cleared after the test.
-     * @throws Exception An exception that indicates a failed fixture load.
-     */
-    @Override
-    public List<EnvironmentBuilder> fixtures() throws Exception {
-        return null;
-    }
-
-    /**
      * Assert that we can create a configuration.
      */
     @Test

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/grant/ClientCredentialsGrantHandlerTest.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/grant/ClientCredentialsGrantHandlerTest.java
@@ -27,12 +27,13 @@ import net.krotscheck.kangaroo.database.entity.OAuthTokenType;
 import net.krotscheck.kangaroo.servlet.oauth2.resource.TokenResponseEntity;
 import net.krotscheck.kangaroo.test.DatabaseTest;
 import net.krotscheck.kangaroo.test.EnvironmentBuilder;
+import net.krotscheck.kangaroo.test.rule.TestDataResource;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
-import java.util.ArrayList;
-import java.util.List;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -45,29 +46,53 @@ import javax.ws.rs.core.MultivaluedMap;
 public final class ClientCredentialsGrantHandlerTest extends DatabaseTest {
 
     /**
+     * Test data loading for this test.
+     */
+    @ClassRule
+    public static final TestRule TEST_DATA_RULE = new TestDataResource() {
+        /**
+         * Initialize the test data.
+         */
+        @Override
+        protected void loadTestData() {
+            context = new EnvironmentBuilder(getSession())
+                    .client(ClientType.ClientCredentials, true)
+                    .scope("debug");
+            noScopeContext = new EnvironmentBuilder(getSession())
+                    .client(ClientType.ClientCredentials, true);
+            implicitContext = new EnvironmentBuilder(getSession())
+                    .client(ClientType.Implicit, true)
+                    .scope("debug");
+            noSecretContext = new EnvironmentBuilder(getSession())
+                    .client(ClientType.ClientCredentials)
+                    .scope("debug");
+        }
+    };
+
+    /**
      * The harness under test.
      */
-    private ClientCredentialsGrantHandler handler;
+    private static ClientCredentialsGrantHandler handler;
 
     /**
      * A simple, scoped context.
      */
-    private EnvironmentBuilder context;
+    private static EnvironmentBuilder context;
 
     /**
      * A non-client-credentials context.
      */
-    private EnvironmentBuilder implicitContext;
+    private static EnvironmentBuilder implicitContext;
 
     /**
      * A context with no configured scopes.
      */
-    private EnvironmentBuilder noScopeContext;
+    private static EnvironmentBuilder noScopeContext;
 
     /**
      * A no-secret Context.
      */
-    private EnvironmentBuilder noSecretContext;
+    private static EnvironmentBuilder noSecretContext;
 
     /**
      * Setup the test.
@@ -75,43 +100,6 @@ public final class ClientCredentialsGrantHandlerTest extends DatabaseTest {
     @Before
     public void initializeEnvironment() {
         handler = new ClientCredentialsGrantHandler(getSession());
-    }
-
-    /**
-     * Set up the test harness data.
-     */
-    @Before
-    public void createTestData() {
-    }
-
-    /**
-     * Load data fixtures for each test.
-     *
-     * @return A list of fixtures, which will be cleared after the test.
-     */
-    @Override
-    public List<EnvironmentBuilder> fixtures() {
-        context = new EnvironmentBuilder(getSession())
-                .client(ClientType.ClientCredentials, true)
-                .scope("debug");
-        noScopeContext = new EnvironmentBuilder(getSession())
-                .client(ClientType.ClientCredentials, true);
-        implicitContext = new EnvironmentBuilder(getSession())
-                .client(ClientType.Implicit, true)
-                .scope("debug");
-        noSecretContext = new EnvironmentBuilder(getSession())
-                .client(ClientType.ClientCredentials)
-                .scope("debug");
-
-        // The environment builder detaches its data, this reconnects it.
-        getSession().refresh(context.getClient());
-
-        List<EnvironmentBuilder> fixtures = new ArrayList<>();
-        fixtures.add(context);
-        fixtures.add(noScopeContext);
-        fixtures.add(implicitContext);
-        fixtures.add(noSecretContext);
-        return fixtures;
     }
 
     /**


### PR DESCRIPTION
This patch updates the database test, and its inheriting suites,
to use the database rules created for this purpose.