### PR TITLE
Deprecated ContainerTest

### DIFF
--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/DatabaseFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/DatabaseFeatureTest.java
@@ -18,7 +18,7 @@
 package net.krotscheck.kangaroo.database;
 
 import net.krotscheck.kangaroo.database.listener.CreatedUpdatedListener;
-import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.DContainerTest;
 import net.krotscheck.kangaroo.test.EnvironmentBuilder;
 import org.apache.http.HttpStatus;
 import org.glassfish.hk2.api.ServiceLocator;
@@ -41,7 +41,7 @@ import java.util.List;
  *
  * @author Michael Krotscheck
  */
-public final class DatabaseFeatureTest extends ContainerTest {
+public final class DatabaseFeatureTest extends DContainerTest {
 
     /**
      * Setup an application.

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/DContainerTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/DContainerTest.java
@@ -50,7 +50,8 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Michael Krotscheck
  */
-public abstract class ContainerTest
+@Deprecated
+public abstract class DContainerTest
         extends KangarooJerseyTest {
 
     /**

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/AdminV1APITest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/AdminV1APITest.java
@@ -17,7 +17,7 @@
 
 package net.krotscheck.kangaroo.servlet.admin.v1;
 
-import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.DContainerTest;
 import net.krotscheck.kangaroo.test.EnvironmentBuilder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Assert;
@@ -29,7 +29,7 @@ import javax.ws.rs.core.Response;
 /**
  * Test for the admin API.
  */
-public final class AdminV1APITest extends ContainerTest {
+public final class AdminV1APITest extends DContainerTest {
 
     /**
      * Create a test instance of the application to test against.

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AbstractResourceTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AbstractResourceTest.java
@@ -26,7 +26,7 @@ import net.krotscheck.kangaroo.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.servlet.admin.v1.AdminV1API;
 import net.krotscheck.kangaroo.servlet.admin.v1.servlet.Config;
 import net.krotscheck.kangaroo.servlet.admin.v1.servlet.ServletConfigFactory;
-import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.DContainerTest;
 import net.krotscheck.kangaroo.test.EnvironmentBuilder;
 import net.krotscheck.kangaroo.test.HttpUtil;
 import net.krotscheck.kangaroo.test.TestAuthenticator;
@@ -67,7 +67,7 @@ import java.util.stream.Collectors;
  *
  * @author Michael Krotscheck
  */
-public abstract class AbstractResourceTest extends ContainerTest {
+public abstract class AbstractResourceTest extends DContainerTest {
 
     /**
      * The Admin context.

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/OAuthAPITest.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/OAuthAPITest.java
@@ -18,7 +18,7 @@
 package net.krotscheck.kangaroo.servlet.oauth2;
 
 import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder.ErrorResponse;
-import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.DContainerTest;
 import net.krotscheck.kangaroo.test.EnvironmentBuilder;
 import org.apache.http.HttpStatus;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -33,7 +33,7 @@ import javax.ws.rs.core.Response;
  *
  * @author Michael Krotscheck
  */
-public final class OAuthAPITest extends ContainerTest {
+public final class OAuthAPITest extends DContainerTest {
 
     /**
      * Create a test instance of the application to test against.

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/filter/ClientAuthorizationFilterTest.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/filter/ClientAuthorizationFilterTest.java
@@ -26,7 +26,7 @@ import net.krotscheck.kangaroo.database.entity.Client;
 import net.krotscheck.kangaroo.database.entity.ClientType;
 import net.krotscheck.kangaroo.servlet.oauth2.annotation.OAuthFilterChain;
 import net.krotscheck.kangaroo.servlet.oauth2.factory.CredentialsFactory.Credentials;
-import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.DContainerTest;
 import net.krotscheck.kangaroo.test.EnvironmentBuilder;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.hibernate.Session;
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Michael Krotscheck
  */
-public final class ClientAuthorizationFilterTest extends ContainerTest {
+public final class ClientAuthorizationFilterTest extends DContainerTest {
 
     /**
      * Test cpplication.

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/AuthorizationServiceTest.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/AuthorizationServiceTest.java
@@ -21,7 +21,7 @@ import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder.ErrorRespon
 import net.krotscheck.kangaroo.database.entity.AuthenticatorState;
 import net.krotscheck.kangaroo.database.entity.ClientType;
 import net.krotscheck.kangaroo.servlet.oauth2.OAuthTestApp;
-import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.DContainerTest;
 import net.krotscheck.kangaroo.test.EnvironmentBuilder;
 import net.krotscheck.kangaroo.test.HttpUtil;
 import org.apache.http.HttpStatus;
@@ -45,7 +45,7 @@ import javax.ws.rs.core.Response;
  *
  * @author Michael Krotscheck
  */
-public final class AuthorizationServiceTest extends ContainerTest {
+public final class AuthorizationServiceTest extends DContainerTest {
 
     /**
      * Simple testing context.

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/TokenServiceTest.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/TokenServiceTest.java
@@ -22,7 +22,7 @@ import net.krotscheck.kangaroo.database.entity.ClientConfig;
 import net.krotscheck.kangaroo.database.entity.ClientType;
 import net.krotscheck.kangaroo.database.entity.OAuthTokenType;
 import net.krotscheck.kangaroo.servlet.oauth2.OAuthAPI;
-import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.DContainerTest;
 import net.krotscheck.kangaroo.test.EnvironmentBuilder;
 import org.apache.http.HttpStatus;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -43,7 +43,7 @@ import javax.ws.rs.core.Response;
  *
  * @author Michael Krotscheck
  */
-public final class TokenServiceTest extends ContainerTest {
+public final class TokenServiceTest extends DContainerTest {
 
     /**
      * Simple testing context.

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/AbstractRFC6749Test.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/AbstractRFC6749Test.java
@@ -18,7 +18,7 @@
 package net.krotscheck.kangaroo.servlet.oauth2.rfc6749;
 
 import net.krotscheck.kangaroo.servlet.oauth2.OAuthTestApp;
-import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.DContainerTest;
 import org.glassfish.jersey.server.ResourceConfig;
 
 /**
@@ -28,7 +28,7 @@ import org.glassfish.jersey.server.ResourceConfig;
  * @author Michael Krotscheck
  * @see <a href="https://tools.ietf.org/html/rfc6749#section-2.3">https://tools.ietf.org/html/rfc6749#section-2.3</a>
  */
-public abstract class AbstractRFC6749Test extends ContainerTest {
+public abstract class AbstractRFC6749Test extends DContainerTest {
 
     /**
      * Create a small dummy app to test against.


### PR DESCRIPTION
Renamed, and deprecated, the ContainerTest. This makes room for a new
ContainerTest that uses JUnit Rules.