### PR TITLE
ContainerTest now validates no zombie DB Connections

### DIFF
--- a/kangaroo-common/src/main/resources/hibernate.cfg.xml
+++ b/kangaroo-common/src/main/resources/hibernate.cfg.xml
@@ -23,7 +23,7 @@
   <session-factory>
     <!-- Connection properties -->
     <property name="connection.datasource">
-      java:comp/env/jdbc/OIDServerDB
+      java://comp/env/jdbc/OIDServerDB
     </property>
 
     <!-- Generic hibernate configuration -->

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/HibernateFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/HibernateFeatureTest.java
@@ -18,6 +18,7 @@
 
 package net.krotscheck.kangaroo.common.hibernate;
 
+import net.krotscheck.kangaroo.test.rule.DatabaseResource;
 import org.glassfish.jersey.server.ResourceConfig;
 import net.krotscheck.kangaroo.test.KangarooJerseyTest;
 import org.hibernate.Session;
@@ -26,7 +27,9 @@ import org.hibernate.search.FullTextSession;
 import org.hibernate.search.SearchFactory;
 import org.hibernate.service.ServiceRegistry;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -41,6 +44,12 @@ import javax.ws.rs.core.Response;
  * @author Michael Krotscheck
  */
 public final class HibernateFeatureTest extends KangarooJerseyTest {
+
+    /**
+     * Ensure that the JNDI Resource exists.
+     */
+    @ClassRule
+    public static final TestRule DATABASE = new DatabaseResource();
 
     /**
      * Run a service request.

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/FulltextSearchFactoryFactoryTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/FulltextSearchFactoryFactoryTest.java
@@ -18,6 +18,7 @@
 
 package net.krotscheck.kangaroo.common.hibernate.factory;
 
+import net.krotscheck.kangaroo.test.rule.DatabaseResource;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.jersey.server.ApplicationHandler;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -29,7 +30,9 @@ import org.hibernate.search.SearchFactory;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
@@ -40,6 +43,12 @@ import javax.ws.rs.core.FeatureContext;
  * @author Michael Krotscheck
  */
 public final class FulltextSearchFactoryFactoryTest {
+
+    /**
+     * Ensure that the JNDI Resource exists.
+     */
+    @ClassRule
+    public static final TestRule DATABASE = new DatabaseResource();
 
     /**
      * The jersey application handler.

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/FulltextSessionFactoryTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/FulltextSessionFactoryTest.java
@@ -18,6 +18,7 @@
 
 package net.krotscheck.kangaroo.common.hibernate.factory;
 
+import net.krotscheck.kangaroo.test.rule.DatabaseResource;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.jersey.server.ApplicationHandler;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -27,7 +28,9 @@ import org.hibernate.search.FullTextSession;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
@@ -38,6 +41,12 @@ import javax.ws.rs.core.FeatureContext;
  * @author Michael Krotscheck
  */
 public final class FulltextSessionFactoryTest {
+
+    /**
+     * Ensure that the JNDI Resource exists.
+     */
+    @ClassRule
+    public static final TestRule DATABASE = new DatabaseResource();
 
     /**
      * The jersey application handler.

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateServiceRegistryFactoryTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateServiceRegistryFactoryTest.java
@@ -19,6 +19,7 @@
 package net.krotscheck.kangaroo.common.hibernate.factory;
 
 
+import net.krotscheck.kangaroo.test.rule.DatabaseResource;
 import org.glassfish.jersey.server.ApplicationHandler;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.hibernate.boot.MetadataSources;
@@ -26,7 +27,9 @@ import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.service.ServiceRegistry;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
@@ -37,6 +40,12 @@ import javax.ws.rs.core.FeatureContext;
  * @author Michael Krotscheck
  */
 public final class HibernateServiceRegistryFactoryTest {
+
+    /**
+     * Ensure that the JNDI Resource exists.
+     */
+    @ClassRule
+    public static final TestRule DATABASE = new DatabaseResource();
 
     /**
      * Test provide and dispose.

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateSessionFactoryFactoryTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateSessionFactoryFactoryTest.java
@@ -18,6 +18,7 @@
 
 package net.krotscheck.kangaroo.common.hibernate.factory;
 
+import net.krotscheck.kangaroo.test.rule.DatabaseResource;
 import org.glassfish.hk2.api.PerThread;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
@@ -49,7 +50,9 @@ import org.hibernate.service.ServiceRegistry;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
@@ -60,6 +63,12 @@ import javax.ws.rs.core.FeatureContext;
  * @author Michael Krotscheck
  */
 public final class HibernateSessionFactoryFactoryTest {
+
+    /**
+     * Ensure that the JNDI Resource exists.
+     */
+    @ClassRule
+    public static final TestRule DATABASE = new DatabaseResource();
 
     /**
      * The jersey application handler.

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateSessionFactoryTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateSessionFactoryTest.java
@@ -18,6 +18,7 @@
 
 package net.krotscheck.kangaroo.common.hibernate.factory;
 
+import net.krotscheck.kangaroo.test.rule.DatabaseResource;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.jersey.server.ApplicationHandler;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -26,7 +27,9 @@ import org.hibernate.SessionFactory;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
@@ -37,6 +40,12 @@ import javax.ws.rs.core.FeatureContext;
  * @author Michael Krotscheck
  */
 public final class HibernateSessionFactoryTest {
+
+    /**
+     * Ensure that the JNDI Resource exists.
+     */
+    @ClassRule
+    public static final TestRule DATABASE = new DatabaseResource();
 
     /**
      * The jersey application handler.

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/AbstractDBRule.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/AbstractDBRule.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.test.rule;
+
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+
+/**
+ * An abstract class that makes available various database resources,
+ * including connection construction.
+ *
+ * @author Michael Krotscheck
+ */
+public abstract class AbstractDBRule implements TestRule {
+
+    static {
+        // Force the database to use UTC.
+        System.setProperty("user.timezone", "UTC");
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    }
+
+    /**
+     * The single pooled data source from which all connections in the test
+     * suite are sourced.
+     */
+    private static ThreadLocal<BasicDataSource> dataSource
+            = new ThreadLocal<>();
+
+    /**
+     * The number of DS invocations there've been so far.
+     */
+    private static Integer dsCounter = 0;
+
+    /**
+     * Evaluate the Test Database JDBC Address.
+     *
+     * @return The test database address.
+     */
+    protected final String getDbJdbcPath() {
+        return System.getProperty("test.db.jdbc",
+                "jdbc:h2:mem:target/test/db/h2/hibernate");
+    }
+
+    /**
+     * Evaluate the Test Database Driver.
+     *
+     * @return The test database driver class as a string.
+     */
+    protected final String getDbDriver() {
+        return System.getProperty("test.db.driver", "org.h2.Driver");
+    }
+
+    /**
+     * Evaluate the Test Database Login.
+     *
+     * @return The test database login.
+     */
+    protected final String getDbLogin() {
+        return System.getProperty("test.db.user", "oid");
+    }
+
+    /**
+     * Evaluate the Test Database Password.
+     *
+     * @return The test database password.
+     */
+    protected final String getDbPassword() {
+        return System.getProperty("test.db.password", "oid");
+    }
+
+    /**
+     * Return the current datasource.
+     *
+     * @return The datasource.
+     */
+    protected BasicDataSource getDataSource() {
+        return dataSource.get();
+    }
+
+    /**
+     * Initialize the datasource before.
+     */
+    private void initializeDatasource() {
+        if (dataSource.get() == null) {
+            BasicDataSource newSource = new BasicDataSource();
+            newSource.setDriverClassName(getDbDriver());
+            newSource.setUrl(getDbJdbcPath());
+            newSource.setUsername(getDbLogin());
+            newSource.setPassword(getDbPassword());
+            dataSource.set(newSource);
+        }
+        dsCounter++;
+    }
+
+    /**
+     * Destroy the existing datasource.
+     *
+     * @throws SQLException If we can't close the connection.
+     */
+    private void destroyDatasource() throws SQLException {
+        dsCounter--;
+        if (dsCounter == 0) {
+            BasicDataSource oldSource = dataSource.get();
+            if (!oldSource.isClosed()) {
+                oldSource.close();
+            }
+            dataSource.remove();
+        }
+    }
+
+    /**
+     * Modifies the method-running {@link Statement} to implement this
+     * test-running rule.
+     *
+     * @param base        The {@link Statement} to be modified
+     * @param description A {@link Description} of the test implemented in
+     *                    {@code base}
+     * @return a new statement, which may be the same as {@code base},
+     * a wrapper around {@code base}, or a completely new Statement.
+     */
+    @Override
+    public final Statement apply(final Statement base,
+                                 final Description description) {
+        return new Statement() {
+
+            @Override
+            public void evaluate() throws Throwable {
+                initializeDatasource();
+                before();
+                try {
+                    base.evaluate();
+                } finally {
+                    after();
+                    destroyDatasource();
+                }
+            }
+        };
+    }
+
+    /**
+     * Execute a query against the current database, and return the results.
+     *
+     * @param query The query to execute.
+     * @return A map of the results.
+     * @throws SQLException Thrown if the query borks.
+     */
+    protected final List<Map<String, String>> executeQuery(final String query)
+            throws SQLException {
+
+        try (
+                Connection conn = getDataSource().getConnection();
+                java.sql.Statement stmt = conn.createStatement()
+        ) {
+            ResultSet rs = stmt.executeQuery(query);
+
+            List<Map<String, String>> results = new ArrayList<>();
+
+            ResultSetMetaData metaData = rs.getMetaData();
+            List<String> columnNames = new ArrayList<>();
+            for (Integer i = 1; i <= metaData.getColumnCount(); i++) {
+                columnNames.add(metaData.getColumnLabel(i));
+            }
+
+            while (rs.next()) {
+                Map<String, String> row = new HashMap<>();
+                columnNames.forEach((name) -> {
+                    try {
+                        row.put(name, rs.getString(name));
+                    } catch (SQLException e) {
+                        e.printStackTrace();
+                    }
+                });
+                results.add(row);
+            }
+            rs.close();
+            return results;
+        }
+    }
+
+    /**
+     * Actions to perform before the test.
+     *
+     * @throws Throwable Exceptions thrown during setup.
+     */
+    protected abstract void before() throws Throwable;
+
+    /**
+     * Actions to perform after the test.
+     *
+     * @throws Throwable Exceptions thrown during teardown.
+     */
+    protected abstract void after() throws Throwable;
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/ActiveSessions.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/ActiveSessions.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.test.rule;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This JUnit4 rule ensures that the JNDI resource has been bootstrapped, and
+ * that the database schema has been migrated into the test database.
+ *
+ * @author Michael Krotscheck
+ */
+public final class ActiveSessions extends AbstractDBRule {
+
+    /**
+     * Logger instance.
+     */
+    private static Logger logger =
+            LoggerFactory.getLogger(DatabaseResource.class);
+
+    /**
+     * THe marked list of initial sessions.
+     */
+    private List<Map<String, String>> initialSessions = new ArrayList<>();
+
+    /**
+     * Mark the current number of active sessions.
+     */
+    public void mark() {
+        initialSessions = getActiveSessions();
+    }
+
+    /**
+     * Check that the previously marked number of active sessions has not
+     * been modified.
+     *
+     * @return Whether there are extra, lingering sessions.
+     */
+    public Boolean check() {
+        List<Map<String, String>> results = getActiveSessions();
+        Integer remainderSessions = results.size() - initialSessions.size();
+        if (remainderSessions > 0) {
+            String message = String.format("Database sessions did not clean "
+                    + "up after themselves. %s extra sessions "
+                    + "detected.", remainderSessions);
+            // Log out the problems.
+            results.forEach((item) -> logger.error(item.toString()));
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Retrieve the current number of active sessions.
+     *
+     * @return The number of active connections.
+     */
+    private List<Map<String, String>> getActiveSessions() {
+        try {
+            switch (getDbDriver()) {
+                case "com.mysql.jdbc.Driver":
+                    return new ArrayList<>();
+                case "org.h2.Driver":
+                default:
+                    return executeQuery("select * from information_schema"
+                            + ".sessions");
+            }
+        } catch (SQLException sqle) {
+            // Don't do this. Fix it.
+            throw new RuntimeException(sqle);
+        }
+    }
+
+    /**
+     * Actions to perform before the test.
+     *
+     * @throws Throwable Exceptions thrown during setup.
+     */
+    @Override
+    protected void before() throws Throwable {
+
+    }
+
+    /**
+     * Actions to perform after the test.
+     *
+     * @throws Throwable Exceptions thrown during teardown.
+     */
+    @Override
+    protected void after() throws Throwable {
+
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/DatabaseResource.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/DatabaseResource.java
@@ -24,20 +24,17 @@ import liquibase.Liquibase;
 import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.LiquibaseException;
 import liquibase.resource.ClassLoaderResourceAccessor;
-import org.apache.commons.dbcp2.BasicDataSource;
-import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
+import javax.naming.NameAlreadyBoundException;
 import javax.naming.NamingException;
 import java.sql.Connection;
-import java.sql.DriverManager;
-import java.util.TimeZone;
+import java.sql.SQLException;
 
 /**
  * This JUnit4 rule ensures that the JNDI resource has been bootstrapped, and
@@ -45,54 +42,13 @@ import java.util.TimeZone;
  *
  * @author Michael Krotscheck
  */
-public final class DatabaseResource implements TestRule {
+public final class DatabaseResource extends AbstractDBRule {
 
-    /**
-     * Evaluate the Test Database JDBC Address.
-     *
-     * @return The test database address.
-     */
-    private static String getDbJdbcPath() {
-        return System.getProperty("test.db.jdbc",
-                "jdbc:h2:mem:target/test/db/h2/hibernate");
-    }
-
-    /**
-     * Evaluate the Test Database Driver.
-     *
-     * @return The test database driver class as a string.
-     */
-    private static String getDbDriver() {
-        return System.getProperty("test.db.driver", "org.h2.Driver");
-    }
-
-    /**
-     * Evaluate the Test Database Login.
-     *
-     * @return The test database login.
-     */
-    private static String getDbLogin() {
-        return System.getProperty("test.db.user", "oid");
-    }
-
-    /**
-     * Evaluate the Test Database Password.
-     *
-     * @return The test database password.
-     */
-    private static String getDbPassword() {
-        return System.getProperty("test.db.password", "oid");
-    }
-
-    /**
-     * Evaluate the JNDI Identity.
-     *
-     * @return The JNDI Identity path.
-     */
-    private static String getJndiAddress() {
-        String jndiName = System.getProperty("test.db.jndiName",
-                "OIDServerDB");
-        return String.format("java:/comp/env/jdbc/%s", jndiName);
+    static {
+        System.setProperty(Context.INITIAL_CONTEXT_FACTORY,
+                "org.eclipse.jetty.jndi.InitialContextFactory");
+        System.setProperty(Context.URL_PKG_PREFIXES,
+                "org.eclipse.jetty.jndi");
     }
 
     /**
@@ -102,86 +58,97 @@ public final class DatabaseResource implements TestRule {
             LoggerFactory.getLogger(DatabaseResource.class);
 
     /**
-     * Database connection, currently active.
+     * Path to the liquibase changelog master file.
      */
-    private Connection conn;
+    private static final String CHANGELOG = "liquibase/db" +
+            ".changelog-master.yaml";
 
     /**
-     * The currently active liquibase context.
+     * Evaluate the JNDI Identity.
+     *
+     * @return The JNDI Identity path.
      */
-    private Liquibase liquibase;
+    private String getJndiAddress() {
+        String jndiName = System.getProperty("test.db.jndiName",
+                "OIDServerDB");
+        return String.format("%s/%s", "java://comp/env/jdbc", jndiName);
+    }
 
     /**
      * Set up a JDNI connection for your tests.
+     *
+     * @throws Throwable In case something odd happens.
      */
-    private void setupJNDI() {
-        logger.debug("Setting up JNDI.");
-        // Create initial context
-        System.setProperty(Context.INITIAL_CONTEXT_FACTORY,
-                "org.eclipse.jetty.jndi.InitialContextFactory");
-        System.setProperty(Context.URL_PKG_PREFIXES,
-                "org.eclipse.jetty.jndi");
+    private void setupJNDI() throws Throwable {
+        InitialContext context = new InitialContext();
+        ensureSubcontextExists(context);
+        context.bind(getJndiAddress(), getDataSource());
+    }
 
-        logger.debug(String.format("Setting up [%s] database at [%s]",
-                getDbDriver(), getDbJdbcPath()));
+    /**
+     * Clean up the JNDI Binding.
+     *
+     * @throws Throwable Thrown if something goes sideways in the context.
+     */
+    private void cleanJNDI() throws Throwable {
+        // Clean anything opened in the initial context.
+        InitialContext ctx = new InitialContext();
+        ctx.unbind(getJndiAddress());
+    }
 
-        try {
-            InitialContext ic = new InitialContext();
+    /**
+     * Ensure the required subcontext namespaces exist on the provided context.
+     *
+     * @param context The context on which to create the subcontext.
+     */
+    private void ensureSubcontextExists(final Context context) {
+        String[] names = new String[]{
+                "java://comp",
+                "java://comp/env",
+                "java://comp/env/jdbc",
+        };
 
-            ic.createSubcontext("java:/comp/env");
-            ic.createSubcontext("java:/comp/env/jdbc");
-
-            BasicDataSource bds = new BasicDataSource();
-            bds.setDriverClassName(getDbDriver());
-            bds.setUrl(getDbJdbcPath());
-            bds.setUsername(getDbLogin());
-            bds.setPassword(getDbPassword());
-            ic.bind(getJndiAddress(), bds);
-        } catch (NamingException e) {
-            // Do nothing, this is only thrown if the context already exists,
-            // which will happen in a second test run.
-            logger.debug("JDNI Naming Exception, resource likely already "
-                    + "exists.");
+        for (String name : names) {
+            try {
+                context.createSubcontext(name);
+            } catch (NameAlreadyBoundException nae) {
+                logger.trace(String.format("Subcontext [%s] already exists",
+                        name));
+            } catch (NamingException ne) {
+                throw new RuntimeException(ne);
+            }
         }
     }
 
     /**
      * Migrate the current database using the existing liquibase schema.
      *
-     * @throws Exception Exceptions thrown during migration. If these fail,
-     *                   fix your tests!
+     * @throws SQLException Exceptions thrown during migration. If these fail,
+     *                      fix your tests!
      */
-    private void setupDatabase() throws Exception {
+    private void setupDatabase() throws SQLException {
         logger.debug("Migrating Database Schema.");
 
-        // Force the database to use UTC.
-        System.setProperty("user.timezone", "UTC");
-        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        try (Connection conn = getDataSource().getConnection()) {
 
-        // We need to persist this connection so that the in-memory database
-        // is not destroyed when the connection drops.
-        Class.forName(getDbDriver());
-        logger.debug("Opening connection.");
-        conn = DriverManager.getConnection(
-                getDbJdbcPath(),
-                getDbLogin(),
-                getDbPassword());
+            // Flush the database if necessary
+            if (conn instanceof MySQLConnection) {
+                java.sql.Statement s = conn.createStatement();
+                s.addBatch("DROP DATABASE IF EXISTS oid");
+                s.addBatch("CREATE DATABASE IF NOT EXISTS oid;");
+                s.executeBatch();
+                s.close();
+            }
 
-        // Flush the database if necessary
-        if (conn instanceof MySQLConnection) {
-            java.sql.Statement s = conn.createStatement();
-            s.addBatch("DROP DATABASE IF EXISTS oid");
-            s.addBatch("CREATE DATABASE IF NOT EXISTS oid;");
-            s.executeBatch();
-            s.close();
+            logger.debug("Migrating schema.");
+            Database database = DatabaseFactory.getInstance()
+                    .findCorrectDatabaseImplementation(new JdbcConnection(conn));
+            Liquibase liquibase = new Liquibase(CHANGELOG,
+                    new ClassLoaderResourceAccessor(), database);
+            liquibase.update(new Contexts());
+        } catch (LiquibaseException lbe) {
+            throw new RuntimeException(lbe);
         }
-
-        logger.debug("Migrating schema.");
-        Database database = DatabaseFactory.getInstance()
-                .findCorrectDatabaseImplementation(new JdbcConnection(conn));
-        liquibase = new Liquibase("liquibase/db.changelog-master.yaml",
-                new ClassLoaderResourceAccessor(), database);
-        liquibase.update(new Contexts());
     }
 
     /**
@@ -190,41 +157,36 @@ public final class DatabaseResource implements TestRule {
      * @throws Throwable An exception encountered during teardown.
      */
     private void cleanDatabase() throws Throwable {
-        logger.debug("Cleaning Database.");
-        liquibase.rollback(1000, null);
-        liquibase = null;
-
-        logger.debug("Closing connection.");
-        conn.close();
-        conn = null;
+        try (Connection conn = getDataSource().getConnection()) {
+            Database database = DatabaseFactory.getInstance()
+                    .findCorrectDatabaseImplementation(
+                            new JdbcConnection(conn));
+            Liquibase l = new Liquibase(CHANGELOG,
+                    new ClassLoaderResourceAccessor(),
+                    database);
+            l.rollback(1000, null);
+        }
     }
 
     /**
-     * Modifies the method-running {@link Statement} to implement this
-     * test-running rule.
+     * Bind the datasource to JNDI, and migrate the database schema.
      *
-     * @param base        The {@link Statement} to be modified
-     * @param description A {@link Description} of the test implemented in
-     *                    {@code base}
-     * @return a new statement, which may be the same as {@code base},
-     * a wrapper around {@code base}, or a completely new Statement.
+     * @throws Throwable Exceptions thrown during setup.
      */
     @Override
-    public Statement apply(
-            final Statement base,
-            final Description description) {
-        return new Statement() {
+    protected void before() throws Throwable {
+        setupJNDI();
+        setupDatabase();
+    }
 
-            @Override
-            public void evaluate() throws Throwable {
-                setupJNDI();
-                setupDatabase();
-                try {
-                    base.evaluate();
-                } finally {
-                    cleanDatabase();
-                }
-            }
-        };
+    /**
+     * Rollback the database schema.
+     *
+     * @throws Throwable Exceptions thrown during setup.
+     */
+    @Override
+    protected void after() throws Throwable {
+        cleanDatabase();
+        cleanJNDI();
     }
 }

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AuthenticatorServiceCRUDTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AuthenticatorServiceCRUDTest.java
@@ -252,26 +252,6 @@ public final class AuthenticatorServiceCRUDTest
         assertErrorResponse(r, Status.BAD_REQUEST);
     }
 
-//    /**
-//     * Assert that we cannot modify the client we're currently using to
-//     * access this application.
-//     *
-//     * @throws Exception Exception encountered during test.
-//     */
-//    @Test
-//    public void testPutCannotModifyCurrentClient() throws Exception {
-//        Client client = getAdminToken().getClient();
-//        client.setName("New Name");
-//
-//        Response r = putEntity(client, getAdminToken());
-//
-//        if (shouldSucceed()) {
-//            assertErrorResponse(r, Status.CONFLICT);
-//        } else {
-//            assertErrorResponse(r, Status.NOT_FOUND);
-//        }
-//    }
-
     /**
      * Assert that a regular entity can be updated, from the admin app, with
      * appropriate credentials.


### PR DESCRIPTION
This patch makes several changes to available JUnit rules, in order
to better control how database connections are managed and tested.
- AbstractDBRule has been written to manage a simple data source in
  a static, threadsafe way, so that other rules can use a database
  connection that is properly managed.
- DatabaseResource now only handles the binding of an above-created
  datasource to the JNDI context. This ensures that all connections
  access the same database.
- An ActiveSession rule has been added, which will mark and check
  the current number of open database sessions. This is used
  in a new class test in ContainerTest that ensures that no
  lingering database connections are left.
- Cleaning up properly then required that the database resource be
  added to the hibernate session construction tests.