### PR TITLE
Migraded oauth2 api to use Database Rules

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/Client.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/Client.java
@@ -163,7 +163,7 @@ public final class Client extends AbstractEntity {
     /**
      * A collection of referral URL's, used for CORS matching.
      */
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "client_referrers",
             joinColumns = @JoinColumn(name = "client"))
     @Column(name = "referrer")
@@ -173,7 +173,7 @@ public final class Client extends AbstractEntity {
     /**
      * A list of redirect URL's, used for redirection-based flows.
      */
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "client_redirects",
             joinColumns = @JoinColumn(name = "client"))
     @Column(name = "redirect")

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/authenticator/PasswordAuthenticatorTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/authenticator/PasswordAuthenticatorTest.java
@@ -31,6 +31,7 @@ import org.glassfish.hk2.api.ServiceLocatorFactory;
 import org.glassfish.hk2.utilities.BuilderHelper;
 import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
 import org.glassfish.jersey.process.internal.RequestScoped;
+import org.hibernate.Session;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -59,8 +60,8 @@ public final class PasswordAuthenticatorTest extends DatabaseTest {
          * Initialize the test data.
          */
         @Override
-        protected void loadTestData() {
-            context = new EnvironmentBuilder(getSession());
+        protected void loadTestData(final Session session) {
+            context = new EnvironmentBuilder(session);
             context.client(ClientType.OwnerCredentials)
                     .authenticator("password")
                     .user()

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/EnvironmentBuilderTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/EnvironmentBuilderTest.java
@@ -54,8 +54,8 @@ public final class EnvironmentBuilderTest extends DatabaseTest {
          * Initialize the test data.
          */
         @Override
-        protected void loadTestData() {
-            context = new EnvironmentBuilder(getSession(), "Test App")
+        protected void loadTestData(final Session session) {
+            context = new EnvironmentBuilder(session, "Test App")
                     .client(ClientType.OwnerCredentials)
                     .authenticator("password")
                     .scopes(Arrays.asList("one", "two", "three"))

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/AbstractDBRule.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/AbstractDBRule.java
@@ -115,6 +115,7 @@ public abstract class AbstractDBRule implements TestRule {
             newSource.setUrl(getDbJdbcPath());
             newSource.setUsername(getDbLogin());
             newSource.setPassword(getDbPassword());
+            newSource.setMaxIdle(1);
             dataSource.set(newSource);
         }
         dsCounter++;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/HibernateResource.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/HibernateResource.java
@@ -22,6 +22,7 @@ import net.krotscheck.kangaroo.common.hibernate.factory.HibernateServiceRegistry
 import net.krotscheck.kangaroo.test.rule.hibernate.TestDirectoryProvider;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.Search;
@@ -208,5 +209,9 @@ public class HibernateResource implements TestRule {
         logger.debug("Creating FullTextSession");
         fullTextSession = Search.getFullTextSession(session);
         searchFactory = fullTextSession.getSearchFactory();
+
+        // Force hibernate to grab a connection
+        Transaction t = session.beginTransaction();
+        t.rollback();
     }
 }

--- a/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ClientService.java
+++ b/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ClientService.java
@@ -169,6 +169,7 @@ public final class ClientService extends AbstractService {
                 .createAlias("application", "a")
                 .setFirstResult(offset)
                 .setMaxResults(limit)
+                .setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY)
                 .addOrder(SortUtil.order(order, sort));
 
         if (filterByApp != null) {

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/OAuthAPITest.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/OAuthAPITest.java
@@ -18,14 +18,12 @@
 package net.krotscheck.kangaroo.servlet.oauth2;
 
 import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder.ErrorResponse;
-import net.krotscheck.kangaroo.test.DContainerTest;
-import net.krotscheck.kangaroo.test.EnvironmentBuilder;
+import net.krotscheck.kangaroo.test.ContainerTest;
 import org.apache.http.HttpStatus;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.List;
 import javax.ws.rs.core.Response;
 
 /**
@@ -33,7 +31,7 @@ import javax.ws.rs.core.Response;
  *
  * @author Michael Krotscheck
  */
-public final class OAuthAPITest extends DContainerTest {
+public final class OAuthAPITest extends ContainerTest {
 
     /**
      * Create a test instance of the application to test against.
@@ -43,16 +41,6 @@ public final class OAuthAPITest extends DContainerTest {
     @Override
     protected ResourceConfig createApplication() {
         return new OAuthAPI();
-    }
-
-    /**
-     * Load data fixtures for each test.
-     *
-     * @return A list of fixtures, which will be cleared after the test.
-     */
-    @Override
-    public List<EnvironmentBuilder> fixtures() {
-        return null;
     }
 
     /**

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/filter/ClientAuthorizationFilterTest.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/filter/ClientAuthorizationFilterTest.java
@@ -26,8 +26,7 @@ import net.krotscheck.kangaroo.database.entity.Client;
 import net.krotscheck.kangaroo.database.entity.ClientType;
 import net.krotscheck.kangaroo.servlet.oauth2.annotation.OAuthFilterChain;
 import net.krotscheck.kangaroo.servlet.oauth2.factory.CredentialsFactory.Credentials;
-import net.krotscheck.kangaroo.test.DContainerTest;
-import net.krotscheck.kangaroo.test.EnvironmentBuilder;
+import net.krotscheck.kangaroo.test.ContainerTest;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
@@ -36,7 +35,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.List;
 import java.util.UUID;
 import javax.ws.rs.container.ContainerRequestContext;
 
@@ -47,7 +45,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Michael Krotscheck
  */
-public final class ClientAuthorizationFilterTest extends DContainerTest {
+public final class ClientAuthorizationFilterTest extends ContainerTest {
 
     /**
      * Test cpplication.
@@ -76,16 +74,6 @@ public final class ClientAuthorizationFilterTest extends DContainerTest {
         config.register(HibernateFeature.class);
 
         return config;
-    }
-
-    /**
-     * Load data fixtures for each test.
-     *
-     * @return A list of fixtures, which will be cleared after the test.
-     */
-    @Override
-    public List<EnvironmentBuilder> fixtures() {
-        return null;
     }
 
     /**

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/TokenServiceTest.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/TokenServiceTest.java
@@ -22,15 +22,17 @@ import net.krotscheck.kangaroo.database.entity.ClientConfig;
 import net.krotscheck.kangaroo.database.entity.ClientType;
 import net.krotscheck.kangaroo.database.entity.OAuthTokenType;
 import net.krotscheck.kangaroo.servlet.oauth2.OAuthAPI;
-import net.krotscheck.kangaroo.test.DContainerTest;
+import net.krotscheck.kangaroo.test.ContainerTest;
 import net.krotscheck.kangaroo.test.EnvironmentBuilder;
+import net.krotscheck.kangaroo.test.rule.TestDataResource;
 import org.apache.http.HttpStatus;
 import org.glassfish.jersey.server.ResourceConfig;
+import org.hibernate.Session;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
-import java.util.ArrayList;
-import java.util.List;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Form;
 import javax.ws.rs.core.MediaType;
@@ -43,12 +45,27 @@ import javax.ws.rs.core.Response;
  *
  * @author Michael Krotscheck
  */
-public final class TokenServiceTest extends DContainerTest {
+public final class TokenServiceTest extends ContainerTest {
+
+    /**
+     * Test data loading for this test.
+     */
+    @ClassRule
+    public static final TestRule TEST_DATA_RULE = new TestDataResource() {
+        /**
+         * Initialize the test data.
+         */
+        @Override
+        protected void loadTestData(final Session session) {
+            context = new EnvironmentBuilder(session)
+                    .client(ClientType.ClientCredentials, true);
+        }
+    };
 
     /**
      * Simple testing context.
      */
-    private EnvironmentBuilder context;
+    private static EnvironmentBuilder context;
 
     /**
      * Build and configure the application.
@@ -58,21 +75,6 @@ public final class TokenServiceTest extends DContainerTest {
     @Override
     protected ResourceConfig createApplication() {
         return new OAuthAPI();
-    }
-
-    /**
-     * Load data fixtures for each test.
-     *
-     * @return A list of fixtures, which will be cleared after the test.
-     */
-    @Override
-    public List<EnvironmentBuilder> fixtures() {
-        context = new EnvironmentBuilder(getSession())
-                .client(ClientType.ClientCredentials, true);
-
-        List<EnvironmentBuilder> fixtures = new ArrayList<>();
-        fixtures.add(context);
-        return fixtures;
     }
 
     /**

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/grant/ClientCredentialsGrantHandlerTest.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/grant/ClientCredentialsGrantHandlerTest.java
@@ -28,6 +28,7 @@ import net.krotscheck.kangaroo.servlet.oauth2.resource.TokenResponseEntity;
 import net.krotscheck.kangaroo.test.DatabaseTest;
 import net.krotscheck.kangaroo.test.EnvironmentBuilder;
 import net.krotscheck.kangaroo.test.rule.TestDataResource;
+import org.hibernate.Session;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -54,16 +55,16 @@ public final class ClientCredentialsGrantHandlerTest extends DatabaseTest {
          * Initialize the test data.
          */
         @Override
-        protected void loadTestData() {
-            context = new EnvironmentBuilder(getSession())
+        protected void loadTestData(final Session session) {
+            context = new EnvironmentBuilder(session)
                     .client(ClientType.ClientCredentials, true)
                     .scope("debug");
-            noScopeContext = new EnvironmentBuilder(getSession())
+            noScopeContext = new EnvironmentBuilder(session)
                     .client(ClientType.ClientCredentials, true);
-            implicitContext = new EnvironmentBuilder(getSession())
+            implicitContext = new EnvironmentBuilder(session)
                     .client(ClientType.Implicit, true)
                     .scope("debug");
-            noSecretContext = new EnvironmentBuilder(getSession())
+            noSecretContext = new EnvironmentBuilder(session)
                     .client(ClientType.ClientCredentials)
                     .scope("debug");
         }

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/grant/RefreshTokenGrantHandlerTest.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/grant/RefreshTokenGrantHandlerTest.java
@@ -28,6 +28,7 @@ import net.krotscheck.kangaroo.servlet.oauth2.resource.TokenResponseEntity;
 import net.krotscheck.kangaroo.test.DatabaseTest;
 import net.krotscheck.kangaroo.test.EnvironmentBuilder;
 import net.krotscheck.kangaroo.test.rule.TestDataResource;
+import org.hibernate.Session;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -56,8 +57,8 @@ public final class RefreshTokenGrantHandlerTest extends DatabaseTest {
          * Initialize the test data.
          */
         @Override
-        protected void loadTestData() {
-            authGrantContext = new EnvironmentBuilder(getSession())
+        protected void loadTestData(final Session session) {
+            authGrantContext = new EnvironmentBuilder(session)
                     .client(ClientType.AuthorizationGrant, true)
                     .authenticator("test")
                     .scope("debug")
@@ -66,7 +67,7 @@ public final class RefreshTokenGrantHandlerTest extends DatabaseTest {
                     .user()
                     .identity("remote_identity");
 
-            ownerCredsContext = new EnvironmentBuilder(getSession())
+            ownerCredsContext = new EnvironmentBuilder(session)
                     .client(ClientType.OwnerCredentials, true)
                     .authenticator("test")
                     .scope("debug")
@@ -75,7 +76,7 @@ public final class RefreshTokenGrantHandlerTest extends DatabaseTest {
                     .user()
                     .identity("remote_identity");
 
-            implicitContext = new EnvironmentBuilder(getSession())
+            implicitContext = new EnvironmentBuilder(session)
                     .client(ClientType.Implicit, true)
                     .authenticator("test")
                     .scope("debug")

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/AbstractRFC6749Test.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/AbstractRFC6749Test.java
@@ -18,7 +18,7 @@
 package net.krotscheck.kangaroo.servlet.oauth2.rfc6749;
 
 import net.krotscheck.kangaroo.servlet.oauth2.OAuthTestApp;
-import net.krotscheck.kangaroo.test.DContainerTest;
+import net.krotscheck.kangaroo.test.ContainerTest;
 import org.glassfish.jersey.server.ResourceConfig;
 
 /**
@@ -28,7 +28,7 @@ import org.glassfish.jersey.server.ResourceConfig;
  * @author Michael Krotscheck
  * @see <a href="https://tools.ietf.org/html/rfc6749#section-2.3">https://tools.ietf.org/html/rfc6749#section-2.3</a>
  */
-public abstract class AbstractRFC6749Test extends DContainerTest {
+public abstract class AbstractRFC6749Test extends ContainerTest {
 
     /**
      * Create a small dummy app to test against.

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/Section300EndpointsTest.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/Section300EndpointsTest.java
@@ -17,12 +17,10 @@
 
 package net.krotscheck.kangaroo.servlet.oauth2.rfc6749;
 
-import net.krotscheck.kangaroo.test.EnvironmentBuilder;
 import org.apache.http.HttpStatus;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.List;
 import javax.ws.rs.core.Response;
 
 /**
@@ -31,16 +29,6 @@ import javax.ws.rs.core.Response;
  * @see <a href="https://tools.ietf.org/html/rfc6749#section-3">https://tools.ietf.org/html/rfc6749#section-3</a>
  */
 public final class Section300EndpointsTest extends AbstractRFC6749Test {
-
-    /**
-     * Load data fixtures for each test.
-     *
-     * @return A list of fixtures, which will be cleared after the test.
-     */
-    @Override
-    public List<EnvironmentBuilder> fixtures() {
-        return null;
-    }
 
     /**
      * Assert that the /authorize endpoint exists.


### PR DESCRIPTION
This patch updates the OAuth2 project to use the Database Rules
created in a previous patch. It should improve the speed of these
tests as the database is only constructed once.