### PR TITLE
Updated jersey2 to 2.25

### DIFF
--- a/kangaroo-common/src/test/resources/logback/default/logback-test.xml
+++ b/kangaroo-common/src/test/resources/logback/default/logback-test.xml
@@ -35,6 +35,7 @@
   <logger name="org.apache.http" level="WARN"/>
   <logger name="com.mchange" level="WARN"/>
   <logger name="org.hibernate" level="WARN"/>
+  <logger name="org.hibernate.internal.SessionImpl" level="OFF"/>
   <logger name="org.jboss" level="WARN"/>
   <logger name="net.sourceforge.cobertura" level="WARN"/>
   <logger name="liquibase" level="WARN"/>

--- a/kangaroo-common/src/test/resources/logback/travis/logback-test.xml
+++ b/kangaroo-common/src/test/resources/logback/travis/logback-test.xml
@@ -30,4 +30,6 @@
     <appender-ref ref="STDOUT"/>
   </root>
 
+  <logger name="org.hibernate.internal.SessionImpl" level="OFF"/>
+
 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
     <hibernate.version>5.0.6.Final</hibernate.version>
     <hibernate-validator.version>5.2.4.Final</hibernate-validator.version>
     <hibernate-search.version>5.5.1.Final</hibernate-search.version>
-    <jersey.version>2.24</jersey.version>
+    <jersey.version>2.25</jersey.version>
     <jetty.version>9.1.1.v20140108</jetty.version>
     <jersey2-toolkit.version>2.1.1</jersey2-toolkit.version>
     <slf4j.version>1.7.13</slf4j.version>


### PR DESCRIPTION
Also updated the test logback configurations to ignore errors
thrown inside of the SessionImpl, usually caused by constraint annotations.