### PR TITLE
Switch to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
 - oraclejdk8
+dist: trusty
 sudo: required
 branches:
   only:


### PR DESCRIPTION
This patch changes the travis build distro to use trusty instead
of precise.