### PR TITLE
Switched to Grizzly test container.

### DIFF
--- a/kangaroo-common/src/main/resources/logback.xml
+++ b/kangaroo-common/src/main/resources/logback.xml
@@ -41,7 +41,6 @@
   <logger name="ResourceAccessorXsdStreamResolver" level="WARN"/>
   <logger name="ContextClassLoaderXsdStreamResolver" level="WARN"/>
   <logger name="jndi" level="WARN"/>
-  <logger name="org.eclipse.jetty" level="WARN"/>
   <logger name="ch.qos" level="WARN"/>
   <logger name="org.glassfish.jersey.test" level="INFO"/>
   <logger name="org.glassfish.jersey.internal" level="ERROR"/>

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/DatabaseResource.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/DatabaseResource.java
@@ -26,6 +26,7 @@ import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.LiquibaseException;
 import liquibase.resource.ClassLoaderResourceAccessor;
+import org.glassfish.jersey.test.grizzly.GrizzlyTestContainerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,10 +46,11 @@ import java.sql.SQLException;
 public final class DatabaseResource extends AbstractDBRule {
 
     static {
+        //javax.naming.NoInitialContextException
         System.setProperty(Context.INITIAL_CONTEXT_FACTORY,
-                "org.eclipse.jetty.jndi.InitialContextFactory");
-        System.setProperty(Context.URL_PKG_PREFIXES,
-                "org.eclipse.jetty.jndi");
+                "org.apache.naming.java.javaURLContextFactory");
+//        System.setProperty(Context.URL_PKG_PREFIXES,
+//                "org.eclipse.jetty.jndi");
     }
 
     /**
@@ -103,9 +105,10 @@ public final class DatabaseResource extends AbstractDBRule {
      */
     private void ensureSubcontextExists(final Context context) {
         String[] names = new String[]{
+                "java:",
                 "java://comp",
                 "java://comp/env",
-                "java://comp/env/jdbc",
+                "java://comp/env/jdbc"
         };
 
         for (String name : names) {

--- a/kangaroo-common/src/test/resources/logback/default/logback-test.xml
+++ b/kangaroo-common/src/test/resources/logback/default/logback-test.xml
@@ -43,9 +43,9 @@
   <logger name="ResourceAccessorXsdStreamResolver" level="WARN"/>
   <logger name="ContextClassLoaderXsdStreamResolver" level="WARN"/>
   <logger name="jndi" level="WARN"/>
-  <logger name="org.eclipse.jetty" level="WARN"/>
   <logger name="ch.qos" level="WARN"/>
-  <logger name="org.glassfish.jersey.test.jetty" level="ERROR"/>
+  <logger name="org.glassfish.grizzly" level="ERROR"/>
+  <logger name="org.glassfish.jersey.test.grizzly" level="ERROR"/>
   <logger name="org.glassfish.jersey.test" level="INFO"/>
   <logger name="org.glassfish.jersey.internal" level="ERROR"/>
 

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,6 @@
     <hibernate-validator.version>5.3.4.Final</hibernate-validator.version>
     <hibernate-search.version>5.5.5.Final</hibernate-search.version>
     <jersey.version>2.25</jersey.version>
-    <jetty.version>9.1.1.v20140108</jetty.version>
     <jersey2-toolkit.version>2.1.1</jersey2-toolkit.version>
     <slf4j.version>1.7.13</slf4j.version>
     <powermock.version>1.6.6</powermock.version>
@@ -607,18 +606,6 @@
 
     <!-- Jetty test environment -->
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-jndi</artifactId>
-      <version>${jetty.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
-      <version>${jetty.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.jersey.test-framework</groupId>
       <artifactId>jersey-test-framework-core</artifactId>
       <version>${jersey.version}</version>
@@ -626,8 +613,14 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-      <artifactId>jersey-test-framework-provider-jetty</artifactId>
+      <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
       <version>${jersey.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>tomcat-catalina</artifactId>
+      <version>8.5.9</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
The jetty test container seems to have lifecycle issues where
dereferencing resources out-of-band are concerned.