### PR TITLE
Wrap all EnvironmentBuilder DB access into transactions.

### DIFF
--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/EnvironmentBuilderTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/EnvironmentBuilderTest.java
@@ -289,8 +289,9 @@ public final class EnvironmentBuilderTest extends DatabaseTest {
         Assert.assertEquals(22, e.size());
 
         // Delete one of our entities to make sure it's skipped during clearing.
+        OAuthToken tokenToDelete = b.getToken();
         Transaction t = getSession().beginTransaction();
-        getSession().delete(b.getToken());
+        getSession().delete(tokenToDelete);
         t.commit();
 
         // Assert that everything clears.


### PR DESCRIPTION
The Jersey context cleans up sessions per request, however that cleanup
is not available during the test cycle. This patch adds the necessary
transaction handling for all DB calls in the EnvironmentBuilder, so that
we do not end up with any lingering connections.