### PR TITLE
Added makefile to simplify travis simulation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+#
+# Convenience Makefile, by which we can simulate the travis build environment.
+#
+
+TAG ?= latest
+IMAGE ?= kangaroo/travis-toolbox
+
+build:
+	docker build -t $(IMAGE):$(TAG) --file ./tools/travis/Dockerfile .
+
+travis: build
+	docker run -ti -v `pwd`:/home/travis/build/kangaroo-server/kangaroo -v ~/.m2/repository/:/home/travis/.m2/repository/ $(IMAGE):$(TAG)


### PR DESCRIPTION
We can now simulate the travis environment with the `make travis` command.
The container will be launched with both the working directory and the
maven cache mounted.