### PR TITLE
Added testing edge case to OAuthToken

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/OAuthToken.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/OAuthToken.java
@@ -339,11 +339,15 @@ public final class OAuthToken extends AbstractEntity implements Principal {
     @Transient
     @JsonIgnore
     public String getName() {
-        if (getClient().getType().equals(ClientType.ClientCredentials)) {
-            return getClient().getName();
-        } else {
-            return getIdentity().getRemoteId();
+        Client c = getClient();
+        UserIdentity i = getIdentity();
+
+        if (c != null && c.getType().equals(ClientType.ClientCredentials)) {
+            return c.getName();
+        } else if (i != null) {
+            return i.getRemoteId();
         }
+        return null;
     }
 
     /**

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/OAuthTokenTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/OAuthTokenTest.java
@@ -185,6 +185,17 @@ public final class OAuthTokenTest {
     }
 
     /**
+     * Test getting the principal name with a null client.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testGetNullClient() throws Exception {
+        OAuthToken token = new OAuthToken();
+        Assert.assertNull(token.getName());
+    }
+
+    /**
      * Test get/set scope list.
      */
     @Test


### PR DESCRIPTION
There are some situations in which a principal name is evaluated,
however the oauth token is not associated with a client. This
addresses that error.