### PR TITLE
Updated DatabaseResource to handle full JNDI Path

### DIFF
--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/TestConfig.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/TestConfig.java
@@ -27,12 +27,13 @@ package net.krotscheck.kangaroo.test;
 public final class TestConfig {
 
     /**
-     * The JNDI path where the database may be accessed.
+     * Fully qualified jndi path for the database.
      *
-     * @return A fully qualified JNDI Path.
+     * @return The path.
      */
-    public static String getDbJndiName() {
-        return System.getProperty("test.db.jndiName", "OIDServerDB");
+    public static String getDbJndiPath() {
+        return System.getProperty("test.db.jndiPath",
+                "java://comp/env/jdbc/OIDServerDB");
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -292,8 +292,8 @@
                 <value>oid</value>
               </property>
               <property>
-                <name>test.db.jndiName</name>
-                <value>OIDServerDB</value>
+                <name>test.db.jndiPath</name>
+                <value>java://comp/env/jdbc/OIDServerDB</value>
               </property>
             </systemProperties>
           </configuration>


### PR DESCRIPTION
This patch expands the purpose of the databaseResource to properly split/create
a configured JNDI path during test harnessing. In the future, hopefully this change
will let us run multiple DB tests in parallel.