### PR TITLE
Updates to database session checks.

### DIFF
--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/authenticator/PasswordAuthenticatorTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/authenticator/PasswordAuthenticatorTest.java
@@ -56,20 +56,21 @@ public final class PasswordAuthenticatorTest extends DatabaseTest {
      * Test data loading for this test.
      */
     @ClassRule
-    public static final TestRule TEST_DATA_RULE = new TestDataResource() {
-        /**
-         * Initialize the test data.
-         */
-        @Override
-        protected void loadTestData(final Session session) {
-            context = ApplicationBuilder.newApplication(session)
-                    .client(ClientType.OwnerCredentials)
-                    .authenticator("password")
-                    .user()
-                    .login("login", "password")
-                    .build();
-        }
-    };
+    public static final TestRule TEST_DATA_RULE =
+            new TestDataResource(HIBERNATE_RESOURCE) {
+                /**
+                 * Initialize the test data.
+                 */
+                @Override
+                protected void loadTestData(final Session session) {
+                    context = ApplicationBuilder.newApplication(session)
+                            .client(ClientType.OwnerCredentials)
+                            .authenticator("password")
+                            .user()
+                            .login("login", "password")
+                            .build();
+                }
+            };
 
     /**
      * The environment set up for this test suite.

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/ActiveSessions.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/ActiveSessions.java
@@ -20,6 +20,7 @@ package net.krotscheck.kangaroo.test.rule;
 
 import net.krotscheck.kangaroo.test.TestConfig;
 import org.apache.commons.dbcp2.BasicDataSource;
+import org.junit.Assert;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -60,7 +61,7 @@ public final class ActiveSessions implements TestRule {
     /**
      * Mark the current number of active sessions.
      */
-    public void mark() {
+    private void mark() {
         initialSessions = getActiveSessions();
     }
 
@@ -70,8 +71,9 @@ public final class ActiveSessions implements TestRule {
      *
      * @return Whether there are extra, lingering sessions.
      */
-    public Boolean check() {
-        List<Map<String, String>> lingeringSessions = getActiveSessions()
+    private Boolean check() {
+        List<Map<String, String>> currentSessions = getActiveSessions();
+        List<Map<String, String>> lingeringSessions = currentSessions
                 .stream()
                 .filter(row -> !initialSessions.contains(row))
                 .collect(Collectors.toList());
@@ -174,7 +176,10 @@ public final class ActiveSessions implements TestRule {
 
             @Override
             public void evaluate() throws Throwable {
+                mark();
                 base.evaluate();
+                Assert.assertFalse("Zombie DB Sessions Detected",
+                        check());
             }
         };
     }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/HibernateTestResource.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/HibernateTestResource.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.test.rule;
+
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.resource.transaction.spi.TransactionStatus;
+import org.hibernate.search.FullTextSession;
+import org.hibernate.search.Search;
+import org.hibernate.search.SearchFactory;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * This rule exists to bootstrap the hibernate constructs necessary to
+ * properly isolate a test. It provides sessions, query builders, and wraps
+ * the entire test in a transaction.
+ *
+ * @author Michael Krotscheck
+ */
+public class HibernateTestResource implements TestRule {
+
+    /**
+     * The source of our hibernate session factory.
+     */
+    private final HibernateResource factoryProvider;
+
+    /**
+     * The last created session.
+     */
+    private Session session;
+
+    /**
+     * Search factory.
+     */
+    private SearchFactory searchFactory;
+
+    /**
+     * Fulltext session.
+     */
+    private FullTextSession fullTextSession;
+
+    /**
+     * Create and return a hibernate session for the test database.
+     *
+     * @return The constructed session.
+     */
+    public Session getSession() {
+        return session;
+    }
+
+    /**
+     * Retrieve the search factory for the test.
+     *
+     * @return The session factory
+     */
+    public final SearchFactory getSearchFactory() {
+        return searchFactory;
+    }
+
+    /**
+     * Retrieve the fulltext session for the test.
+     *
+     * @return The session factory
+     */
+    public final FullTextSession getFullTextSession() {
+        return fullTextSession;
+    }
+
+    /**
+     * Create a new instance of the hibernate session rule.
+     *
+     * @param factoryProvider The source of the session factory.
+     */
+    public HibernateTestResource(final HibernateResource factoryProvider) {
+        this.factoryProvider = factoryProvider;
+    }
+
+    /**
+     * Modifies the method-running {@link Statement} to implement this
+     * test-running rule.
+     *
+     * @param base        The {@link Statement} to be modified
+     * @param description A {@link Description} of the test implemented in
+     *                    {@code base}
+     * @return a new statement, which may be the same as {@code base},
+     * a wrapper around {@code base}, or a completely new Statement.
+     */
+    @Override
+    public Statement apply(final Statement base,
+                           final Description description) {
+        return new Statement() {
+
+            @Override
+            public void evaluate() throws Throwable {
+                createHibernateConnection();
+                startTransaction();
+                try {
+                    base.evaluate();
+                } finally {
+                    closeTransaction();
+                    closeHibernateConnection();
+                }
+            }
+        };
+    }
+
+    /**
+     * Start a transaction.
+     */
+    private void startTransaction() {
+        getSession().beginTransaction();
+    }
+
+    /**
+     * Close the transaction, if necessary.
+     */
+    private void closeTransaction() {
+        Transaction t = getSession().getTransaction();
+        try {
+            if (t.getStatus().equals(TransactionStatus.ACTIVE)) {
+                t.commit();
+            }
+        } catch (HibernateException he) {
+            t.rollback();
+
+            // Rethrow, because we're in tests.
+            throw he;
+        }
+    }
+
+    /**
+     * Ensure that the hibernate connection is closed even if a test fails.
+     */
+    private void closeHibernateConnection() {
+        searchFactory = null;
+
+        if (fullTextSession.isOpen()) {
+            fullTextSession.close();
+        }
+        fullTextSession = null;
+
+        // Clean any outstanding sessions.
+        if (session.isOpen()) {
+            session.close();
+        }
+        session = null;
+    }
+
+    /**
+     * Create a session factory for the database.
+     */
+    private void createHibernateConnection() {
+        session = factoryProvider.getSessionFactory().openSession();
+        fullTextSession = Search.getFullTextSession(session);
+        searchFactory = fullTextSession.getSearchFactory();
+    }
+}

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/servlet/FirstRunContainerLifecycleListenerTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/servlet/FirstRunContainerLifecycleListenerTest.java
@@ -21,7 +21,6 @@ import net.krotscheck.kangaroo.database.config.HibernateConfiguration;
 import net.krotscheck.kangaroo.database.entity.Application;
 import net.krotscheck.kangaroo.servlet.admin.v1.servlet.FirstRunContainerLifecycleListener.Binder;
 import net.krotscheck.kangaroo.test.DatabaseTest;
-import net.krotscheck.kangaroo.test.EnvironmentBuilder;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.MapConfiguration;
 import org.glassfish.hk2.api.ActiveDescriptor;
@@ -37,10 +36,10 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import javax.inject.Singleton;
 import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
-import javax.inject.Singleton;
 
 /**
  * Unit test our application bootstrap.

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/AuthorizationServiceTest.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/AuthorizationServiceTest.java
@@ -53,26 +53,27 @@ public final class AuthorizationServiceTest extends ContainerTest {
      * Test data loading for this test.
      */
     @ClassRule
-    public static final TestRule TEST_DATA_RULE = new TestDataResource() {
-        /**
-         * Initialize the test data.
-         */
-        @Override
-        protected void loadTestData(final Session session) {
-            context = ApplicationBuilder.newApplication(session)
-                    .client(ClientType.Implicit)
-                    .authenticator("foo")
-                    .redirect("http://valid.example.com/redirect")
-                    .build();
+    public static final TestRule TEST_DATA_RULE =
+            new TestDataResource(HIBERNATE_RESOURCE) {
+                /**
+                 * Initialize the test data.
+                 */
+                @Override
+                protected void loadTestData(final Session session) {
+                    context = ApplicationBuilder.newApplication(session)
+                            .client(ClientType.Implicit)
+                            .authenticator("foo")
+                            .redirect("http://valid.example.com/redirect")
+                            .build();
 
-            ownerContext = ApplicationBuilder.newApplication(session)
-                    .client(ClientType.OwnerCredentials)
-                    .authenticator("test")
-                    .redirect("http://valid.example.com/redirect")
-                    .authenticatorState()
-                    .build();
-        }
-    };
+                    ownerContext = ApplicationBuilder.newApplication(session)
+                            .client(ClientType.OwnerCredentials)
+                            .authenticator("test")
+                            .redirect("http://valid.example.com/redirect")
+                            .authenticatorState()
+                            .build();
+                }
+            };
 
     /**
      * Simple testing context.

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/TokenServiceTest.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/TokenServiceTest.java
@@ -52,17 +52,18 @@ public final class TokenServiceTest extends ContainerTest {
      * Test data loading for this test.
      */
     @ClassRule
-    public static final TestRule TEST_DATA_RULE = new TestDataResource() {
-        /**
-         * Initialize the test data.
-         */
-        @Override
-        protected void loadTestData(final Session session) {
-            context = ApplicationBuilder.newApplication(session)
-                    .client(ClientType.ClientCredentials, true)
-                    .build();
-        }
-    };
+    public static final TestRule TEST_DATA_RULE =
+            new TestDataResource(HIBERNATE_RESOURCE) {
+                /**
+                 * Initialize the test data.
+                 */
+                @Override
+                protected void loadTestData(final Session session) {
+                    context = ApplicationBuilder.newApplication(session)
+                            .client(ClientType.ClientCredentials, true)
+                            .build();
+                }
+            };
 
     /**
      * Simple testing context.

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/grant/RefreshTokenGrantHandlerTest.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/resource/grant/RefreshTokenGrantHandlerTest.java
@@ -53,40 +53,41 @@ public final class RefreshTokenGrantHandlerTest extends DatabaseTest {
      * Test data loading for this test.
      */
     @ClassRule
-    public static final TestRule TEST_DATA_RULE = new TestDataResource() {
-        /**
-         * Initialize the test data.
-         */
-        @Override
-        protected void loadTestData(final Session session) {
-            authGrantContext = ApplicationBuilder.newApplication(session)
-                    .client(ClientType.AuthorizationGrant, true)
-                    .authenticator("test")
-                    .scope("debug")
-                    .scope("debug1")
-                    .role("test", new String[]{"debug", "debug1"})
-                    .user()
-                    .identity("remote_identity")
-                    .build();
+    public static final TestRule TEST_DATA_RULE =
+            new TestDataResource(HIBERNATE_RESOURCE) {
+                /**
+                 * Initialize the test data.
+                 */
+                @Override
+                protected void loadTestData(final Session session) {
+                    authGrantContext = ApplicationBuilder.newApplication(session)
+                            .client(ClientType.AuthorizationGrant, true)
+                            .authenticator("test")
+                            .scope("debug")
+                            .scope("debug1")
+                            .role("test", new String[]{"debug", "debug1"})
+                            .user()
+                            .identity("remote_identity")
+                            .build();
 
-            ownerCredsContext = ApplicationBuilder.newApplication(session)
-                    .client(ClientType.OwnerCredentials, true)
-                    .authenticator("test")
-                    .scope("debug")
-                    .scope("debug1")
-                    .role("test", new String[]{"debug", "debug1"})
-                    .user()
-                    .identity("remote_identity")
-                    .build();
+                    ownerCredsContext = ApplicationBuilder.newApplication(session)
+                            .client(ClientType.OwnerCredentials, true)
+                            .authenticator("test")
+                            .scope("debug")
+                            .scope("debug1")
+                            .role("test", new String[]{"debug", "debug1"})
+                            .user()
+                            .identity("remote_identity")
+                            .build();
 
-            implicitContext = ApplicationBuilder.newApplication(session)
-                    .client(ClientType.Implicit, true)
-                    .authenticator("test")
-                    .scope("debug")
-                    .role("test", new String[]{"debug"})
-                    .build();
-        }
-    };
+                    implicitContext = ApplicationBuilder.newApplication(session)
+                            .client(ClientType.Implicit, true)
+                            .authenticator("test")
+                            .scope("debug")
+                            .role("test", new String[]{"debug"})
+                            .build();
+                }
+            };
 
     /**
      * The harness under test.

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/Section410AuthorizationCodeGrantTest.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/Section410AuthorizationCodeGrantTest.java
@@ -58,81 +58,82 @@ public final class Section410AuthorizationCodeGrantTest
      * Test data loading for this test.
      */
     @ClassRule
-    public static final TestRule TEST_DATA_RULE = new TestDataResource() {
-        /**
-         * Initialize the test data.
-         */
-        @Override
-        protected void loadTestData(final Session session) {
-            context = ApplicationBuilder
-                    .newApplication(session)
-                    .scope("debug")
-                    .scope("debug1")
-                    .role("test", new String[]{"debug"})
-                    .client(ClientType.AuthorizationGrant)
-                    .authenticator("test")
-                    .redirect("http://valid.example.com/redirect")
-                    .build();
-            bareContext = ApplicationBuilder
-                    .newApplication(session)
-                    .scope("debug")
-                    .client(ClientType.AuthorizationGrant)
-                    .authenticator("test")
-                    .build();
-            noScopeRoleContext = ApplicationBuilder
-                    .newApplication(session)
-                    .scope("debug")
-                    .role("test", new String[]{})
-                    .client(ClientType.AuthorizationGrant)
-                    .authenticator("test")
-                    .redirect("http://valid.example.com/redirect")
-                    .build();
-            noUserRoleContext = ApplicationBuilder
-                    .newApplication(session)
-                    .scope("debug")
-                    .client(ClientType.AuthorizationGrant)
-                    .authenticator("test")
-                    .redirect("http://valid.example.com/redirect")
-                    .build();
-            authContext = ApplicationBuilder
-                    .newApplication(session)
-                    .scope("debug")
-                    .role("test", new String[]{"debug"})
-                    .client(ClientType.AuthorizationGrant, true)
-                    .authenticator("test")
-                    .redirect("http://valid.example.com/redirect")
-                    .redirect("http://redirect.example.com/redirect")
-                    .user()
-                    .identity("remote_identity")
-                    .build();
-            noauthContext = ApplicationBuilder
-                    .newApplication(session)
-                    .scope("debug")
-                    .role("test", new String[]{"debug"})
-                    .client(ClientType.AuthorizationGrant)
-                    .redirect("http://valid.example.com/redirect")
-                    .build();
-            misconfiguredAuthContext = ApplicationBuilder
-                    .newApplication(session)
-                    .client(ClientType.AuthorizationGrant)
-                    .authenticator("foo")
-                    .redirect("http://valid.example.com/redirect")
-                    .scope("debug")
-                    .build();
-            invalidClientContext = ApplicationBuilder
-                    .newApplication(session)
-                    .scope("debug")
-                    .role("test", new String[]{"debug"})
-                    .client(ClientType.Implicit)
-                    .authenticator("foo")
-                    .redirect("http://valid.example.com/redirect")
-                    .build();
+    public static final TestRule TEST_DATA_RULE =
+            new TestDataResource(HIBERNATE_RESOURCE) {
+                /**
+                 * Initialize the test data.
+                 */
+                @Override
+                protected void loadTestData(final Session session) {
+                    context = ApplicationBuilder
+                            .newApplication(session)
+                            .scope("debug")
+                            .scope("debug1")
+                            .role("test", new String[]{"debug"})
+                            .client(ClientType.AuthorizationGrant)
+                            .authenticator("test")
+                            .redirect("http://valid.example.com/redirect")
+                            .build();
+                    bareContext = ApplicationBuilder
+                            .newApplication(session)
+                            .scope("debug")
+                            .client(ClientType.AuthorizationGrant)
+                            .authenticator("test")
+                            .build();
+                    noScopeRoleContext = ApplicationBuilder
+                            .newApplication(session)
+                            .scope("debug")
+                            .role("test", new String[]{})
+                            .client(ClientType.AuthorizationGrant)
+                            .authenticator("test")
+                            .redirect("http://valid.example.com/redirect")
+                            .build();
+                    noUserRoleContext = ApplicationBuilder
+                            .newApplication(session)
+                            .scope("debug")
+                            .client(ClientType.AuthorizationGrant)
+                            .authenticator("test")
+                            .redirect("http://valid.example.com/redirect")
+                            .build();
+                    authContext = ApplicationBuilder
+                            .newApplication(session)
+                            .scope("debug")
+                            .role("test", new String[]{"debug"})
+                            .client(ClientType.AuthorizationGrant, true)
+                            .authenticator("test")
+                            .redirect("http://valid.example.com/redirect")
+                            .redirect("http://redirect.example.com/redirect")
+                            .user()
+                            .identity("remote_identity")
+                            .build();
+                    noauthContext = ApplicationBuilder
+                            .newApplication(session)
+                            .scope("debug")
+                            .role("test", new String[]{"debug"})
+                            .client(ClientType.AuthorizationGrant)
+                            .redirect("http://valid.example.com/redirect")
+                            .build();
+                    misconfiguredAuthContext = ApplicationBuilder
+                            .newApplication(session)
+                            .client(ClientType.AuthorizationGrant)
+                            .authenticator("foo")
+                            .redirect("http://valid.example.com/redirect")
+                            .scope("debug")
+                            .build();
+                    invalidClientContext = ApplicationBuilder
+                            .newApplication(session)
+                            .scope("debug")
+                            .role("test", new String[]{"debug"})
+                            .client(ClientType.Implicit)
+                            .authenticator("foo")
+                            .redirect("http://valid.example.com/redirect")
+                            .build();
 
-            authHeader = HttpUtil.authHeaderBasic(
-                    authContext.getClient().getId(),
-                    authContext.getClient().getClientSecret());
-        }
-    };
+                    authHeader = HttpUtil.authHeaderBasic(
+                            authContext.getClient().getId(),
+                            authContext.getClient().getClientSecret());
+                }
+            };
 
     /**
      * The test context for a regular application.

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/Section420ImplicitGrantTest.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/Section420ImplicitGrantTest.java
@@ -55,51 +55,52 @@ public final class Section420ImplicitGrantTest
      * Test data loading for this test.
      */
     @ClassRule
-    public static final TestRule TEST_DATA_RULE = new TestDataResource() {
-        /**
-         * Initialize the test data.
-         */
-        @Override
-        protected void loadTestData(final Session session) {
-            context = ApplicationBuilder.newApplication(session)
-                    .scope("debug")
-                    .role("test", new String[]{"debug"})
-                    .client(ClientType.Implicit)
-                    .authenticator("test")
-                    .redirect("http://valid.example.com/redirect")
-                    .build();
-            twoRedirectContext = ApplicationBuilder.newApplication(session)
-                    .scope("debug")
-                    .role("test", new String[]{"debug"})
-                    .client(ClientType.Implicit)
-                    .authenticator("test")
-                    .redirect("http://valid.example.com/redirect")
-                    .redirect("http://other.example.com/redirect")
-                    .build();
-            bareContext = ApplicationBuilder.newApplication(session)
-                    .client(ClientType.Implicit)
-                    .authenticator("test")
-                    .build();
-            noRoleContext = ApplicationBuilder.newApplication(session)
-                    .client(ClientType.Implicit)
-                    .authenticator("test")
-                    .redirect("http://valid.example.com/redirect")
-                    .build();
-            roleNoScopeContext = ApplicationBuilder.newApplication(session)
-                    .client(ClientType.Implicit)
-                    .authenticator("test")
-                    .scope("debug")
-                    .redirect("http://valid.example.com/redirect")
-                    .role("test", new String[]{})
-                    .build();
-            noauthContext = ApplicationBuilder.newApplication(session)
-                    .scope("debug")
-                    .role("test", new String[]{"debug"})
-                    .client(ClientType.Implicit)
-                    .redirect("http://valid.example.com/redirect")
-                    .build();
-        }
-    };
+    public static final TestRule TEST_DATA_RULE =
+            new TestDataResource(HIBERNATE_RESOURCE) {
+                /**
+                 * Initialize the test data.
+                 */
+                @Override
+                protected void loadTestData(final Session session) {
+                    context = ApplicationBuilder.newApplication(session)
+                            .scope("debug")
+                            .role("test", new String[]{"debug"})
+                            .client(ClientType.Implicit)
+                            .authenticator("test")
+                            .redirect("http://valid.example.com/redirect")
+                            .build();
+                    twoRedirectContext = ApplicationBuilder.newApplication(session)
+                            .scope("debug")
+                            .role("test", new String[]{"debug"})
+                            .client(ClientType.Implicit)
+                            .authenticator("test")
+                            .redirect("http://valid.example.com/redirect")
+                            .redirect("http://other.example.com/redirect")
+                            .build();
+                    bareContext = ApplicationBuilder.newApplication(session)
+                            .client(ClientType.Implicit)
+                            .authenticator("test")
+                            .build();
+                    noRoleContext = ApplicationBuilder.newApplication(session)
+                            .client(ClientType.Implicit)
+                            .authenticator("test")
+                            .redirect("http://valid.example.com/redirect")
+                            .build();
+                    roleNoScopeContext = ApplicationBuilder.newApplication(session)
+                            .client(ClientType.Implicit)
+                            .authenticator("test")
+                            .scope("debug")
+                            .redirect("http://valid.example.com/redirect")
+                            .role("test", new String[]{})
+                            .build();
+                    noauthContext = ApplicationBuilder.newApplication(session)
+                            .scope("debug")
+                            .role("test", new String[]{"debug"})
+                            .client(ClientType.Implicit)
+                            .redirect("http://valid.example.com/redirect")
+                            .build();
+                }
+            };
 
     /**
      * The environment context for the regular client.

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/Section430OwnerPasswordTest.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/Section430OwnerPasswordTest.java
@@ -55,32 +55,33 @@ public final class Section430OwnerPasswordTest
      * Test data loading for this test.
      */
     @ClassRule
-    public static final TestRule TEST_DATA_RULE = new TestDataResource() {
-        /**
-         * Initialize the test data.
-         */
-        protected void loadTestData(final Session session) {
-            builder = ApplicationBuilder.newApplication(session)
-                    .scope("debug")
-                    .role("debug", new String[]{"debug"})
-                    .client(ClientType.OwnerCredentials)
-                    .authenticator("password")
-                    .user()
-                    .login(username, password)
-                    .build();
-            authBuilder = ApplicationBuilder.newApplication(session)
-                    .scope("debug")
-                    .role("debug", new String[]{"debug"})
-                    .client(ClientType.OwnerCredentials, true)
-                    .authenticator("password")
-                    .user()
-                    .login(username, password)
-                    .build();
-            authHeader = HttpUtil.authHeaderBasic(
-                    authBuilder.getClient().getId(),
-                    authBuilder.getClient().getClientSecret());
-        }
-    };
+    public static final TestRule TEST_DATA_RULE =
+            new TestDataResource(HIBERNATE_RESOURCE) {
+                /**
+                 * Initialize the test data.
+                 */
+                protected void loadTestData(final Session session) {
+                    builder = ApplicationBuilder.newApplication(session)
+                            .scope("debug")
+                            .role("debug", new String[]{"debug"})
+                            .client(ClientType.OwnerCredentials)
+                            .authenticator("password")
+                            .user()
+                            .login(username, password)
+                            .build();
+                    authBuilder = ApplicationBuilder.newApplication(session)
+                            .scope("debug")
+                            .role("debug", new String[]{"debug"})
+                            .client(ClientType.OwnerCredentials, true)
+                            .authenticator("password")
+                            .user()
+                            .login(username, password)
+                            .build();
+                    authHeader = HttpUtil.authHeaderBasic(
+                            authBuilder.getClient().getId(),
+                            authBuilder.getClient().getClientSecret());
+                }
+            };
 
     /**
      * User name used for valid requests.

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/Section440ClientCredentialsTest.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/Section440ClientCredentialsTest.java
@@ -55,25 +55,26 @@ public final class Section440ClientCredentialsTest
      * Test data loading for this test.
      */
     @ClassRule
-    public static final TestRule TEST_DATA_RULE = new TestDataResource() {
-        /**
-         * Initialize the test data.
-         */
-        @Override
-        protected void loadTestData(final Session session) {
-            context = ApplicationBuilder.newApplication(session)
-                    .scope("debug")
-                    .client(ClientType.ClientCredentials, false)
-                    .build();
-            authContext = ApplicationBuilder.newApplication(session)
-                    .scope("debug")
-                    .client(ClientType.ClientCredentials, true)
-                    .build();
-            authHeader = HttpUtil.authHeaderBasic(
-                    authContext.getClient().getId(),
-                    authContext.getClient().getClientSecret());
-        }
-    };
+    public static final TestRule TEST_DATA_RULE =
+            new TestDataResource(HIBERNATE_RESOURCE) {
+                /**
+                 * Initialize the test data.
+                 */
+                @Override
+                protected void loadTestData(final Session session) {
+                    context = ApplicationBuilder.newApplication(session)
+                            .scope("debug")
+                            .client(ClientType.ClientCredentials, false)
+                            .build();
+                    authContext = ApplicationBuilder.newApplication(session)
+                            .scope("debug")
+                            .client(ClientType.ClientCredentials, true)
+                            .build();
+                    authHeader = HttpUtil.authHeaderBasic(
+                            authContext.getClient().getId(),
+                            authContext.getClient().getClientSecret());
+                }
+            };
 
     /**
      * Generic context.

--- a/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/Section600RefreshTokenTest.java
+++ b/kangaroo-server-oauth2/src/test/java/net/krotscheck/kangaroo/servlet/oauth2/rfc6749/Section600RefreshTokenTest.java
@@ -54,37 +54,38 @@ public final class Section600RefreshTokenTest
      * Test data loading for this test.
      */
     @ClassRule
-    public static final TestRule TEST_DATA_RULE = new TestDataResource() {
-        /**
-         * Initialize the test data.
-         */
-        @Override
-        protected void loadTestData(final Session session) {
-            context = ApplicationBuilder.newApplication(session)
-                    .scope("debug")
-                    .scope("debug2")
-                    .role("test", new String[]{"debug", "debug2"})
-                    .client(ClientType.AuthorizationGrant)
-                    .authenticator("debug")
-                    .user()
-                    .identity("test_identity_1")
-                    .build();
+    public static final TestRule TEST_DATA_RULE =
+            new TestDataResource(HIBERNATE_RESOURCE) {
+                /**
+                 * Initialize the test data.
+                 */
+                @Override
+                protected void loadTestData(final Session session) {
+                    context = ApplicationBuilder.newApplication(session)
+                            .scope("debug")
+                            .scope("debug2")
+                            .role("test", new String[]{"debug", "debug2"})
+                            .client(ClientType.AuthorizationGrant)
+                            .authenticator("debug")
+                            .user()
+                            .identity("test_identity_1")
+                            .build();
 
-            authContext = ApplicationBuilder.newApplication(session)
-                    .scope("debug")
-                    .scope("debug2")
-                    .role("test", new String[]{"debug", "debug2"})
-                    .client(ClientType.OwnerCredentials, true)
-                    .authenticator("debug")
-                    .user()
-                    .identity("test_identity_2")
-                    .build();
+                    authContext = ApplicationBuilder.newApplication(session)
+                            .scope("debug")
+                            .scope("debug2")
+                            .role("test", new String[]{"debug", "debug2"})
+                            .client(ClientType.OwnerCredentials, true)
+                            .authenticator("debug")
+                            .user()
+                            .identity("test_identity_2")
+                            .build();
 
-            authHeader = HttpUtil.authHeaderBasic(
-                    authContext.getClient().getId(),
-                    authContext.getClient().getClientSecret());
-        }
-    };
+                    authHeader = HttpUtil.authHeaderBasic(
+                            authContext.getClient().getId(),
+                            authContext.getClient().getClientSecret());
+                }
+            };
 
     /**
      * The test context for a public application.


### PR DESCRIPTION
This patch does four things.

- It converts the HibernateResource into a session factory provider only - that
  way we are no longer juggling sessions, nor have to copy the session factory
  boilerplate from test fixture to fixture.
- It creates a new HibernateTestResource, which can be applied at a per-test basis.
  It generates a session that can be used on every test, wrapped in a transaction
  so that it doesn't pollute ActiveSession checks.
- The DatabaseTest now checks for active sessions.
- Many different classes that were leaking database connections have been fixed as
  a result.