### PR TITLE
Use impl-based logger in ContainerTest

### DIFF
--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/ContainerTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/ContainerTest.java
@@ -59,7 +59,7 @@ public abstract class ContainerTest extends KangarooJerseyTest {
     /**
      * Logger instance.
      */
-    private static Logger logger = LoggerFactory.getLogger(ContainerTest.class);
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
 
     /**
      * A list of HTTP status codes that are valid for redirects.


### PR DESCRIPTION
This patch creates a new logger for each instance of the ContainerTest.
The most immediate improvement here is that log statements sent by the
ContainerTest itself will be properly annotated.