### PR TITLE
Fix two bugs in the ApplicationBuilder

### DIFF
--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/ApplicationBuilder.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/ApplicationBuilder.java
@@ -626,7 +626,7 @@ public final class ApplicationBuilder {
         // Only non-client-credentials clients are associated with users.
         if (!context.token.getClient()
                 .getType().equals(ClientType.ClientCredentials)) {
-            context.token.setIdentity(context.userIdentity);
+            context.token.setIdentity(identity);
         }
 
         if (!StringUtils.isEmpty(redirect)) {
@@ -738,7 +738,7 @@ public final class ApplicationBuilder {
         }
         t2.commit();
 
-        return this.context;
+        return this.context.copy();
     }
 
     /**


### PR DESCRIPTION
This patch fixes two bugs. First, we copy any context that is returned
from the application builder, so that the ApplicationBuilder may be
reused without poisoning an already-built context.

The second bug uses the user identity passed into the method, rather
than the one from the context, to create a new token.