### PR TITLE
Use getAdminScope() instead of explicit scope.

### DIFF
--- a/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ApplicationService.java
+++ b/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ApplicationService.java
@@ -168,7 +168,7 @@ public final class ApplicationService extends AbstractService {
     @Produces(MediaType.APPLICATION_JSON)
     public Response getResource(@PathParam("id") final UUID id) {
         Application application = getSession().get(Application.class, id);
-        assertCanAccess(application, Scope.APPLICATION_ADMIN);
+        assertCanAccess(application, getAdminScope());
         return Response.ok(application).build();
     }
 
@@ -191,7 +191,7 @@ public final class ApplicationService extends AbstractService {
 
         // Only admins can change the owner.
         if (application.getOwner() != null) {
-            if (!getSecurityContext().isUserInRole(Scope.APPLICATION_ADMIN)
+            if (!getSecurityContext().isUserInRole(getAdminScope())
                     && !application.getOwner().equals(getCurrentUser())) {
                 throw new HttpStatusException(HttpStatus.SC_BAD_REQUEST);
             }
@@ -231,7 +231,7 @@ public final class ApplicationService extends AbstractService {
         // Load the old instance.
         Application currentApp = s.get(Application.class, id);
 
-        assertCanAccess(currentApp, Scope.APPLICATION_ADMIN);
+        assertCanAccess(currentApp, getAdminScope());
 
         // Additional special case - we cannot modify the kangaroo app itself.
         if (currentApp.equals(getAdminApplication())) {
@@ -268,7 +268,7 @@ public final class ApplicationService extends AbstractService {
         Session s = getSession();
         Application a = s.get(Application.class, id);
 
-        assertCanAccess(a, Scope.APPLICATION_ADMIN);
+        assertCanAccess(a, getAdminScope());
 
         // Additional special case - we cannot delete the kangaroo app itself.
         if (a.equals(getAdminApplication())) {

--- a/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ScopeService.java
+++ b/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ScopeService.java
@@ -221,7 +221,7 @@ public final class ScopeService extends AbstractService {
     @Produces(MediaType.APPLICATION_JSON)
     public Response getResource(@PathParam("id") final UUID id) {
         ApplicationScope scope = getSession().get(ApplicationScope.class, id);
-        assertCanAccess(scope, Scope.SCOPE_ADMIN);
+        assertCanAccess(scope, getAdminScope());
         return Response.ok(scope).build();
     }
 
@@ -247,7 +247,7 @@ public final class ScopeService extends AbstractService {
         }
 
         // Assert that we can create a scope in this application.
-        if (!getSecurityContext().isUserInRole(Scope.SCOPE_ADMIN)) {
+        if (!getSecurityContext().isUserInRole(getAdminScope())) {
             Application scopeApp =
                     getSession().get(Application.class,
                             scope.getApplication().getId());
@@ -290,7 +290,7 @@ public final class ScopeService extends AbstractService {
         // Load the old instance.
         ApplicationScope currentScope = s.get(ApplicationScope.class, id);
 
-        assertCanAccess(currentScope, Scope.SCOPE_ADMIN);
+        assertCanAccess(currentScope, getAdminScope());
 
         // Additional special case - we cannot modify the kangaroo app's scopes.
         if (currentScope.getApplication().equals(getAdminApplication())) {
@@ -327,7 +327,7 @@ public final class ScopeService extends AbstractService {
         Session s = getSession();
         ApplicationScope a = s.get(ApplicationScope.class, id);
 
-        assertCanAccess(a, Scope.SCOPE_ADMIN);
+        assertCanAccess(a, getAdminScope());
 
         // Additional special case - we cannot delete the kangaroo app itself.
         if (a.getApplication().equals(getAdminApplication())) {


### PR DESCRIPTION
Replace places where the admin scope was directly referenced,
instead of via the abstract getAdminScope() method.