### PR TITLE
Expose SessionFactory in TestDataResource

### DIFF
--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/TestDataResource.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/TestDataResource.java
@@ -87,6 +87,15 @@ public abstract class TestDataResource implements TestRule {
     protected abstract void loadTestData(Session session);
 
     /**
+     * Return the session factory associated with this resource.
+     *
+     * @return The driving session factory, provided by the constructor.
+     */
+    protected final SessionFactory getSessionFactory() {
+        return factoryProvider.getSessionFactory();
+    }
+
+    /**
      * Wipe the database clean.
      *
      * @param session The hibernate session to use to persist our data.


### PR DESCRIPTION
This should simplify bootstrapping of factories that depend on
the session provider, not the session itself.