### PR TITLE
Migrated Search Tests to new ContainerTest

### DIFF
--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AbstractServiceSearchTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AbstractServiceSearchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Michael Krotscheck
+ * Copyright (c) 2017 Michael Krotscheck
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
@@ -19,14 +19,19 @@
 package net.krotscheck.kangaroo.servlet.admin.v1.resource;
 
 import net.krotscheck.kangaroo.database.entity.AbstractEntity;
+import net.krotscheck.kangaroo.database.entity.Client;
 import net.krotscheck.kangaroo.database.entity.ClientType;
 import net.krotscheck.kangaroo.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.database.entity.User;
-import net.krotscheck.kangaroo.servlet.admin.v1.Scope;
-import net.krotscheck.kangaroo.test.EnvironmentBuilder;
+import net.krotscheck.kangaroo.database.entity.UserIdentity;
+import net.krotscheck.kangaroo.test.ApplicationBuilder.ApplicationContext;
 import org.apache.lucene.search.Query;
+import org.hibernate.Criteria;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -34,11 +39,11 @@ import org.junit.runners.Parameterized;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -48,10 +53,9 @@ import java.util.stream.Collectors;
  * @param <T> The type of entity to execute this test for.
  * @author Michael Krotscheck
  */
-@Deprecated
 @RunWith(Parameterized.class)
-public abstract class DAbstractServiceSearchTest<T extends AbstractEntity>
-        extends DAbstractResourceTest {
+public abstract class AbstractServiceSearchTest<T extends AbstractEntity>
+        extends AbstractResourceTest {
 
     /**
      * Class reference for this class' type, used in casting.
@@ -69,6 +73,11 @@ public abstract class DAbstractServiceSearchTest<T extends AbstractEntity>
     private final ClientType clientType;
 
     /**
+     * The client under test.
+     */
+    private Client client;
+
+    /**
      * Whether to create a user, or fall back on an existing user. In most
      * cases, this will fall back to the owner of the admin scope.
      */
@@ -80,11 +89,6 @@ public abstract class DAbstractServiceSearchTest<T extends AbstractEntity>
     private OAuthToken adminAppToken;
 
     /**
-     * An additional application context used for testing.
-     */
-    private EnvironmentBuilder otherApp;
-
-    /**
      * Create a new instance of this parameterized test.
      *
      * @param typingClass The raw class type, used for type-based parsing.
@@ -92,14 +96,45 @@ public abstract class DAbstractServiceSearchTest<T extends AbstractEntity>
      * @param tokenScope  The client scope to issue.
      * @param createUser  Whether to create a new user.
      */
-    public DAbstractServiceSearchTest(final Class<T> typingClass,
-                                      final ClientType clientType,
-                                      final String tokenScope,
-                                      final Boolean createUser) {
+    public AbstractServiceSearchTest(final Class<T> typingClass,
+                                     final ClientType clientType,
+                                     final String tokenScope,
+                                     final Boolean createUser) {
         this.typingClass = typingClass;
         this.tokenScope = tokenScope;
         this.clientType = clientType;
         this.createUser = createUser;
+    }
+
+    /**
+     * Load data fixtures for each test. Here we're creating two applications
+     * with different owners, using the kangaroo default scopes so we have
+     * some good cross-app name duplication.
+     *
+     * @throws Exception An exception that indicates a failed fixture load.
+     */
+    @Before
+    public final void configureData() throws Exception {
+        // Get the admin app and create users based on the configured
+        // parameters.
+        ApplicationContext context = getAdminContext()
+                .getBuilder()
+                .client(clientType)
+                .build();
+        client = context.getClient();
+
+        User owner = context.getOwner();
+        if (createUser) {
+            // Switch to the other user.
+            owner = getSecondaryContext().getOwner();
+        }
+        UserIdentity identity = owner.getIdentities().iterator().next();
+
+        adminAppToken = context
+                .getBuilder()
+                .bearerToken(client, identity, tokenScope)
+                .build()
+                .getToken();
     }
 
     /**
@@ -139,10 +174,11 @@ public abstract class DAbstractServiceSearchTest<T extends AbstractEntity>
      * @return The list of entities.
      */
     protected final List<T> getOwnedEntities(final OAuthToken token) {
-        if (token.getIdentity() == null) {
+        OAuthToken attachedToken = getAttached(token);
+        if (attachedToken.getIdentity() == null) {
             return Collections.emptyList();
         } else {
-            return getOwnedEntities(getAdminToken().getIdentity().getUser());
+            return getOwnedEntities(attachedToken.getIdentity().getUser());
         }
     }
 
@@ -153,7 +189,31 @@ public abstract class DAbstractServiceSearchTest<T extends AbstractEntity>
      * @param token The oauth token to test against.
      * @return A list of entities (could be empty).
      */
-    protected abstract List<T> getAccessibleEntities(OAuthToken token);
+    protected final List<T> getAccessibleEntities(final OAuthToken token) {
+        Session s = getSession();
+
+        // We know you're an admin. Get all applications in the system.
+        Transaction t = s.beginTransaction();
+        OAuthToken attachedToken = s.get(OAuthToken.class, token.getId());
+        Set<String> scopes = attachedToken.getScopes().keySet();
+        t.commit();
+
+        // If you're an admin, you get to see everything. If you're not, you
+        // only get to see what you own.
+        if (!scopes.contains(getAdminScope())) {
+            return getOwnedEntities(attachedToken);
+        }
+
+        List<T> clients;
+        t = s.beginTransaction();
+        try {
+            Criteria c = getSession().createCriteria(typingClass);
+            clients = c.list();
+        } finally {
+            t.commit();
+        }
+        return clients;
+    }
 
     /**
      * Return the list of entities which are owned by the given oauth token.
@@ -197,15 +257,6 @@ public abstract class DAbstractServiceSearchTest<T extends AbstractEntity>
     }
 
     /**
-     * Return the second application context (not the admin context).
-     *
-     * @return The secondary context in this test.
-     */
-    protected final EnvironmentBuilder getSecondaryContext() {
-        return otherApp;
-    }
-
-    /**
      * Return the oauth token for the primary application.
      *
      * @return The application token.
@@ -220,7 +271,7 @@ public abstract class DAbstractServiceSearchTest<T extends AbstractEntity>
      * @return The application token.
      */
     protected final OAuthToken getSecondaryToken() {
-        return otherApp.getToken();
+        return getSecondaryContext().getToken();
     }
 
     /**
@@ -234,133 +285,6 @@ public abstract class DAbstractServiceSearchTest<T extends AbstractEntity>
     protected final Boolean isLimitedByClientCredentials() {
         return clientType.equals(ClientType.ClientCredentials)
                 && tokenScope.equals(getRegularScope());
-    }
-
-    /**
-     * Load data fixtures for each test. Here we're creating two applications
-     * with different owners, using the kangaroo default scopes so we have
-     * some good cross-app name duplication.
-     *
-     * @return A list of fixtures, which will be cleared after the test.
-     * @throws Exception An exception that indicates a failed fixture load.
-     */
-    @Override
-    public final List<EnvironmentBuilder> fixtures(
-            final EnvironmentBuilder adminApp) throws Exception {
-        List<EnvironmentBuilder> fixtures = new ArrayList<>();
-
-        // Get the admin app and create users based on the configured
-        // parameters.
-        EnvironmentBuilder context = getAdminContext().client(clientType);
-        if (createUser) {
-            context.user().identity();
-        }
-        adminAppToken = context.bearerToken(tokenScope).getToken();
-
-        // Create a second app, owned by another user.
-        otherApp = new EnvironmentBuilder(getSession())
-                .owner(context.getUser())
-                .scopes(Scope.allScopes());
-
-        // Add some data for scopes
-        context.scope("Single Scope");
-        context.scope("Second Scope - many");
-        context.scope("Third Scope - many");
-        context.scope("Fourth Scope - many");
-        otherApp.scope("Single Scope");
-        otherApp.scope("Second Scope - many");
-        otherApp.scope("Third Scope - many");
-        otherApp.scope("Fourth Scope - many");
-
-        // Add some test data for clients
-        context.client(ClientType.ClientCredentials, "Single client");
-        context.authenticator("Single authenticator");
-        context.client(ClientType.ClientCredentials, "Second client - many");
-        context.authenticator("Second authenticator - many");
-        context.client(ClientType.Implicit, "Third client - many");
-        context.authenticator("Third authenticator - many");
-        context.client(ClientType.AuthorizationGrant, "Fourth client - many");
-        context.authenticator("Fourth authenticator - many");
-        otherApp.client(ClientType.ClientCredentials, "Single client");
-        otherApp.authenticator("Single authenticator");
-        otherApp.client(ClientType.ClientCredentials, "Second client - many");
-        otherApp.authenticator("Second authenticator - many");
-        otherApp.client(ClientType.Implicit, "Third client - many");
-        otherApp.authenticator("Third authenticator - many");
-        otherApp.client(ClientType.AuthorizationGrant, "Fourth client - many");
-        otherApp.authenticator("Fourth authenticator - many");
-
-        // Add some data for roles
-        context.role("Single Role");
-        context.role("Second Role - many");
-        context.role("Third Role - many");
-        context.role("Fourth Role - many");
-        otherApp.role("Single Role");
-        otherApp.role("Second Role - many");
-        otherApp.role("Third Role - many");
-        otherApp.role("Fourth Role - many");
-
-        // Create a whole lot of applications to run some tests against.
-        for (int i = 0; i < 10; i++) {
-            String appName = String.format("Application %s- %s", i, i % 2 == 0
-                    ? "many" : "frown");
-            fixtures.add(new EnvironmentBuilder(getSession(), appName)
-                    .owner(adminApp.getOwner()));
-            fixtures.add(new EnvironmentBuilder(getSession(), appName)
-                    .owner(adminApp.getUser()));
-        }
-        fixtures.add(new EnvironmentBuilder(getSession(), "Single")
-                .owner(adminApp.getOwner()));
-        fixtures.add(new EnvironmentBuilder(getSession(), "Single")
-                .owner(adminApp.getUser()));
-
-        // Create some users
-        context.user()
-                .identity()
-                .claim("name", "Single User");
-        context.user()
-                .identity()
-                .claim("name", "Second User - many");
-        context.user()
-                .identity()
-                .claim("name", "Third User - many");
-        context.user()
-                .identity()
-                .claim("name", "Fourth User - many");
-        otherApp.user()
-                .identity()
-                .claim("name", "Single User");
-        otherApp.user()
-                .identity()
-                .claim("name", "Second User - many");
-        otherApp.user()
-                .identity()
-                .claim("name", "Third User - many");
-        otherApp.user()
-                .identity()
-                .claim("name", "Fourth User - many");
-
-        // Create a bunch of tokens
-        context.redirect("http://single.token.example.com/")
-                .authToken();
-        context.redirect("http://second.token.example.com/many")
-                .authToken();
-        context.redirect("http://third.token.example.com/many")
-                .authToken();
-        context.redirect("http://fourth.token.example.com/many")
-                .authToken();
-        otherApp.redirect("http://single.token.example.com/")
-                .authToken();
-        otherApp.redirect("http://second.token.example.com/many")
-                .authToken();
-        otherApp.redirect("http://third.token.example.com/many")
-                .authToken();
-        otherApp.redirect("http://fourth.token.example.com/many")
-                .authToken();
-
-        fixtures.add(otherApp);
-
-        return fixtures;
     }
 
     /**
@@ -528,7 +452,7 @@ public abstract class DAbstractServiceSearchTest<T extends AbstractEntity>
         User secondaryOwner = getSecondaryContext().getOwner();
         Map<String, String> params = new HashMap<>();
         params.put("q", query);
-        params.put("owner", getAdminContext().getOwner().getId().toString());
+        params.put("owner", secondaryOwner.getId().toString());
 
         // Determine result set.
         List<T> searchResults = getSearchResults(query);
@@ -552,11 +476,12 @@ public abstract class DAbstractServiceSearchTest<T extends AbstractEntity>
         if (isLimitedByClientCredentials()) {
             assertErrorResponse(r, Status.BAD_REQUEST.getStatusCode(),
                     "invalid_scope");
-        } else if (!isAccessible(secondaryOwner, adminToken)) {
+        } else if (!getAdminScope().equals(tokenScope)
+                && !adminToken.getIdentity().getUser().equals(secondaryOwner)) {
             assertErrorResponse(r, Status.BAD_REQUEST.getStatusCode(),
                     "invalid_scope");
         } else {
-            Assert.assertTrue(expectedTotal > 1);
+            Assert.assertTrue(expectedTotal > 0);
 
             List<T> results = r.readEntity(getListType());
             Assert.assertEquals(200, r.getStatus());
@@ -622,7 +547,7 @@ public abstract class DAbstractServiceSearchTest<T extends AbstractEntity>
 
         Response r = search(params, token);
 
-        if (token.getScopes().keySet().contains(getAdminScope())) {
+        if (tokenScope.equals(getAdminScope())) {
             assertErrorResponse(r, Status.BAD_REQUEST);
         } else {
             assertErrorResponse(r, Status.BAD_REQUEST.getStatusCode(),

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ApplicationServiceSearchTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ApplicationServiceSearchTest.java
@@ -41,7 +41,7 @@ import java.util.List;
  */
 @RunWith(Parameterized.class)
 public final class ApplicationServiceSearchTest
-        extends DAbstractServiceSearchTest<Application> {
+        extends AbstractServiceSearchTest<Application> {
 
     /**
      * Convenience generic type for response decoding.
@@ -75,28 +75,6 @@ public final class ApplicationServiceSearchTest
     }
 
     /**
-     * Return the list of entities which should be accessible given a
-     * specific token.
-     *
-     * @param token The oauth token to test against.
-     * @return A list of entities (could be empty).
-     */
-    @Override
-    protected List<Application> getAccessibleEntities(final OAuthToken token) {
-        // If you're an admin, you get to see everything. If you're not, you
-        // only get to see what you own.
-        if (!token.getScopes().containsKey(getAdminScope())) {
-            return getOwnedEntities(token);
-        }
-
-        // We know you're an admin. Get all applications in the system.
-        Criteria c = getSession().createCriteria(Application.class);
-
-        // Get all the owned clients.
-        return ((List<Application>) c.list());
-    }
-
-    /**
      * Return the list of entities which are owned by the given user.
      *
      * @param owner The owner of the entities.
@@ -105,7 +83,7 @@ public final class ApplicationServiceSearchTest
     @Override
     protected List<Application> getOwnedEntities(final User owner) {
         // Get all the owned clients.
-        return owner.getApplications();
+        return getAttached(owner).getApplications();
     }
 
     /**

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ScopeServiceSearchTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ScopeServiceSearchTest.java
@@ -24,7 +24,6 @@ import net.krotscheck.kangaroo.database.entity.ClientType;
 import net.krotscheck.kangaroo.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.database.entity.User;
 import net.krotscheck.kangaroo.servlet.admin.v1.Scope;
-import org.hibernate.Criteria;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,7 +49,7 @@ import java.util.stream.Collectors;
  */
 @RunWith(Parameterized.class)
 public final class ScopeServiceSearchTest
-        extends DAbstractServiceSearchTest<ApplicationScope> {
+        extends AbstractServiceSearchTest<ApplicationScope> {
 
     /**
      * Create a new instance of this parameterized test.
@@ -191,7 +190,8 @@ public final class ScopeServiceSearchTest
         if (isLimitedByClientCredentials()) {
             assertErrorResponse(r, Status.BAD_REQUEST.getStatusCode(),
                     "invalid_scope");
-        } else if (token.getScopes().keySet().contains(Scope.SCOPE_ADMIN)) {
+        } else if (getAttached(token).getScopes().keySet()
+                .contains(Scope.SCOPE_ADMIN)) {
             Assert.assertTrue(expectedTotal > 0);
 
             List<ApplicationScope> results = r.readEntity(LIST_TYPE);
@@ -236,32 +236,6 @@ public final class ScopeServiceSearchTest
     }
 
     /**
-     * Return the list of entities which should be accessible given a
-     * specific token.
-     *
-     * @param token The oauth token to test against.
-     * @return A list of entities (could be empty).
-     */
-    @Override
-    protected List<ApplicationScope> getAccessibleEntities(
-            final OAuthToken token) {
-        // If you're an admin, you get to see everything. If you're not, you
-        // only get to see what you own.
-        if (!token.getScopes().containsKey(getAdminScope())) {
-            return getOwnedEntities(token);
-        }
-
-        // We know you're an admin. Get all applications in the system.
-        Criteria c = getSession().createCriteria(Application.class);
-
-        // Get all the owned clients.
-        return ((List<Application>) c.list())
-                .stream()
-                .flatMap(a -> a.getScopes().values().stream())
-                .collect(Collectors.toList());
-    }
-
-    /**
      * Return the list of entities which are owned by the given oauth token.
      *
      * @param owner The owner of these entities.
@@ -270,7 +244,7 @@ public final class ScopeServiceSearchTest
     @Override
     protected List<ApplicationScope> getOwnedEntities(final User owner) {
         // Get all the owned clients.
-        return owner.getApplications()
+        return getAttached(owner).getApplications()
                 .stream()
                 .flatMap(a -> a.getScopes().values().stream())
                 .collect(Collectors.toList());

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/test/rule/TestDataResource.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/test/rule/TestDataResource.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.servlet.admin.v1.test.rule;
+
+import net.krotscheck.kangaroo.database.entity.Application;
+import net.krotscheck.kangaroo.database.entity.ClientType;
+import net.krotscheck.kangaroo.servlet.admin.v1.Scope;
+import net.krotscheck.kangaroo.servlet.admin.v1.servlet.Config;
+import net.krotscheck.kangaroo.servlet.admin.v1.servlet.FirstRunContainerLifecycleListener;
+import net.krotscheck.kangaroo.servlet.admin.v1.servlet.ServletConfigFactory;
+import net.krotscheck.kangaroo.test.ApplicationBuilder;
+import net.krotscheck.kangaroo.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.test.rule.HibernateResource;
+import org.apache.commons.configuration.Configuration;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+
+/**
+ * This JUnit rule bootstraps a common set of data against which we can run
+ * our tests.
+ *
+ * @author Michael Krotscheck
+ */
+public final class TestDataResource
+        extends net.krotscheck.kangaroo.test.rule.TestDataResource {
+
+    /**
+     * The admin application context.
+     */
+    private ApplicationContext adminContext;
+
+    /**
+     * The second application context id.
+     */
+    private ApplicationContext secondContext;
+
+    /**
+     * The system configuration.
+     */
+    private Configuration systemConfig;
+
+    /**
+     * Return the context of the current admin application.
+     *
+     * @return The admin application context.
+     */
+    public ApplicationContext getAdminApplication() {
+        return adminContext;
+    }
+
+    /**
+     * Return the context of the secondary application.
+     *
+     * @return The other application context.
+     */
+    public ApplicationContext getSecondaryApplication() {
+        return secondContext;
+    }
+
+    /**
+     * Get the system configuration.
+     *
+     * @return The system config for this test suite.
+     */
+    public Configuration getSystemConfiguration() {
+        return systemConfig;
+    }
+
+    /**
+     * Create a new instance of the test data resource.
+     *
+     * @param factoryProvider The session factory provider.
+     */
+    public TestDataResource(final HibernateResource factoryProvider) {
+        super(factoryProvider);
+    }
+
+    /**
+     * Create the test application using the FirstRun context listener. This
+     * is to prevent it running when the application starts up.
+     *
+     * @return The UUID of the admin application that was created.
+     */
+    private UUID createAdminApplication() {
+        SessionFactory factory = getSessionFactory();
+
+        // Initialize the servlet configuration.
+        ServletConfigFactory configFactory = new ServletConfigFactory(factory);
+        systemConfig = configFactory.provide();
+
+        // Initialize the application.
+        FirstRunContainerLifecycleListener listener =
+                new FirstRunContainerLifecycleListener(factory, systemConfig);
+        listener.onStartup(null);
+        listener.onShutdown(null);
+
+        // Store the application id.
+        return UUID.fromString(systemConfig.getString(Config.APPLICATION_ID));
+    }
+
+    /**
+     * Load data into the database.
+     */
+    @Override
+    protected void loadTestData(final Session session) {
+        UUID adminAppId = createAdminApplication();
+
+        ApplicationBuilder adminBuilder = ApplicationBuilder
+                .fromApplication(session, adminAppId)
+                .user()
+                .identity();
+        ApplicationContext initialContext = adminBuilder.build();
+        applyUsersToClient(adminBuilder); // Add more users to the admin app.
+        buildApplicationData(adminBuilder);
+        adminContext = adminBuilder.build();
+
+        // Create a second app, owned by another user.
+        ApplicationBuilder secondBuilder = ApplicationBuilder
+                .newApplication(session)
+                .owner(initialContext.getUser())
+                .scopes(Scope.allScopes());
+        buildApplicationData(secondBuilder);
+        secondContext = secondBuilder.build();
+
+        // Create a whole lot of applications to run some tests against.
+        List<Application> applications = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            String appName = String.format("Application %s- %s", i, i % 2 == 0
+                    ? "many" : "frown");
+            Application one = new Application();
+            one.setName(appName);
+            one.setOwner(adminContext.getOwner());
+            applications.add(one);
+
+            Application two = new Application();
+            two.setName(appName);
+            two.setOwner(secondContext.getOwner());
+            applications.add(two);
+        }
+        Application singleOne = new Application();
+        singleOne.setName("Single");
+        singleOne.setOwner(adminContext.getOwner());
+        applications.add(singleOne);
+
+        Application singleTwo = new Application();
+        singleTwo.setName("Single");
+        singleTwo.setOwner(secondContext.getOwner());
+        applications.add(singleTwo);
+
+        Transaction t = session.beginTransaction();
+        applications.forEach(session::save);
+        t.commit();
+    }
+
+    /**
+     * Build test data for this application.
+     *
+     * @param builder The builder to modify.
+     */
+    private void buildApplicationData(final ApplicationBuilder builder) {
+        // Add some data for scopes
+        builder.scope("Single Scope")
+                .scope("Second Scope - many")
+                .scope("Third Scope - many")
+                .scope("Fourth Scope - many");
+        builder.role("Single Role")
+                .role("Second Role - many")
+                .role("Third Role - many")
+                .role("Fourth Role - many");
+
+        builder.client(ClientType.ClientCredentials,
+                "Single client")
+                .authenticator("Single authenticator");
+
+        builder.client(ClientType.OwnerCredentials,
+                "Second client - many")
+                .authenticator("password");
+        applyUsersToClient(builder);
+
+        builder.client(ClientType.Implicit,
+                "Third client - many")
+                .authenticator("Third authenticator - many");
+        applyUsersToClient(builder);
+
+        builder.client(ClientType.AuthorizationGrant,
+                "Fourth client - many")
+                .authenticator("Fourth authenticator - many");
+        applyUsersToClient(builder);
+    }
+
+
+    /**
+     * Helper method: Apply some users and identities to the client in a
+     * provided context.
+     *
+     * @param builder The builder to add these entities to.
+     */
+    private void applyUsersToClient(final ApplicationBuilder builder) {
+        // Create some users
+        builder.user()
+                .identity()
+                .claim("name", "Single User")
+                .redirect("http://single.token.example.com/")
+                .authToken()
+                .bearerToken();
+        builder.user()
+                .identity()
+                .claim("name", "Second User - many")
+                .redirect("http://second.token.example.com/many")
+                .authToken()
+                .bearerToken();
+        builder.user()
+                .identity()
+                .claim("name", "Third User - many")
+                .redirect("http://third.token.example.com/many")
+                .authToken()
+                .bearerToken();
+        builder.user()
+                .identity()
+                .claim("name", "Fourth User - many")
+                .redirect("http://fourth.token.example.com/many")
+                .authToken()
+                .bearerToken();
+    }
+}

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/test/rule/package-info.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/test/rule/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Shared resources required to bootstrap tests.
+ */
+package net.krotscheck.kangaroo.servlet.admin.v1.test.rule;


### PR DESCRIPTION
This patch switches the search tests over to the new
ContainerTest, including the ApplicationBuilder. The search
data will be loaded only once, which should speed things up.