### PR TITLE
Replace redirects and referrer nested resources with subresources.

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/AbstractClientUri.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/AbstractClientUri.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.database.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.hibernate.annotations.Type;
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Index;
+import org.hibernate.search.annotations.Store;
+
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MappedSuperclass;
+import javax.persistence.Transient;
+import java.net.URI;
+
+/**
+ * This represents a redirect URL attached to a specific client.
+ *
+ * @author Michael Krotscheck
+ */
+@MappedSuperclass
+public abstract class AbstractClientUri extends AbstractEntity {
+
+    /**
+     * The client this redirect is associated to.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "client", nullable = false, updatable = false)
+    @JsonIgnore
+    private Client client;
+
+    /**
+     * The redirect URL.
+     */
+    @Basic(optional = false)
+    @Column(name = "uri")
+    @Type(type = "net.krotscheck.kangaroo.database.type.URIType")
+    @Field(index = Index.YES, analyze = Analyze.YES, store = Store.NO)
+    private URI uri;
+
+    /**
+     * Get the Client for this state.
+     *
+     * @return This state's Client.
+     */
+    public final Client getClient() {
+        return client;
+    }
+
+    /**
+     * Set a new Client.
+     *
+     * @param client The new Client.
+     */
+    public final void setClient(final Client client) {
+        this.client = client;
+    }
+
+    /**
+     * Get the validated client redirection URI.
+     *
+     * @return The URI which the client requested a result response to.
+     */
+    public final URI getUri() {
+        return uri;
+    }
+
+    /**
+     * Set a new redirection URI.
+     *
+     * @param redirect The redirection URI.
+     */
+    public final void setUri(final URI redirect) {
+        this.uri = redirect;
+    }
+
+    /**
+     * The owner of this entity.
+     *
+     * @return This entity's owner, if it exists.
+     */
+    @Override
+    @Transient
+    @JsonIgnore
+    public final User getOwner() {
+        if (client != null) {
+            return client.getOwner();
+        }
+        return null;
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/Client.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/Client.java
@@ -25,7 +25,6 @@ import net.krotscheck.kangaroo.database.deserializer.AbstractEntityReferenceDese
 import net.krotscheck.kangaroo.database.filters.UUIDFilter;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
-import org.hibernate.annotations.Type;
 import org.hibernate.search.annotations.Analyze;
 import org.hibernate.search.annotations.ContainedIn;
 import org.hibernate.search.annotations.Field;
@@ -54,14 +53,11 @@ import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
-import java.util.TreeSet;
 
 /**
  * This represents a registered client, as well as it's connection metadata,
@@ -150,22 +146,30 @@ public final class Client extends AbstractEntity {
     /**
      * A collection of referral URL's, used for CORS matching.
      */
-    @ElementCollection(fetch = FetchType.LAZY)
-    @CollectionTable(name = "client_referrers",
-            joinColumns = @JoinColumn(name = "client"))
-    @Column(name = "referrer")
-    @Type(type = "net.krotscheck.kangaroo.database.type.URIType")
-    private Set<URI> referrers = new TreeSet<>();
+    @OneToMany(
+            fetch = FetchType.LAZY,
+            mappedBy = "client",
+            cascade = {CascadeType.ALL},
+            orphanRemoval = true
+    )
+    @JsonIgnore
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @IndexedEmbedded(includePaths = {"id", "uri"})
+    private List<ClientReferrer> referrers = new ArrayList<>();
 
     /**
      * A list of redirect URL's, used for redirection-based flows.
      */
-    @ElementCollection(fetch = FetchType.LAZY)
-    @CollectionTable(name = "client_redirects",
-            joinColumns = @JoinColumn(name = "client"))
-    @Column(name = "redirect")
-    @Type(type = "net.krotscheck.kangaroo.database.type.URIType")
-    private Set<URI> redirects = new TreeSet<>();
+    @OneToMany(
+            fetch = FetchType.LAZY,
+            mappedBy = "client",
+            cascade = {CascadeType.ALL},
+            orphanRemoval = true
+    )
+    @JsonIgnore
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @IndexedEmbedded(includePaths = {"id", "uri"})
+    private List<ClientRedirect> redirects = new ArrayList<>();
 
     /**
      * The configuration settings for this application.
@@ -236,7 +240,7 @@ public final class Client extends AbstractEntity {
      *
      * @return This client's list of valid referrers.
      */
-    public Set<URI> getReferrers() {
+    public List<ClientReferrer> getReferrers() {
         return referrers;
     }
 
@@ -245,8 +249,8 @@ public final class Client extends AbstractEntity {
      *
      * @param referrers A new set of referrers.
      */
-    public void setReferrers(final Set<URI> referrers) {
-        this.referrers = referrers;
+    public void setReferrers(final List<ClientReferrer> referrers) {
+        this.referrers = new ArrayList<>(referrers);
     }
 
     /**
@@ -254,7 +258,7 @@ public final class Client extends AbstractEntity {
      *
      * @return The valid redirect url's.
      */
-    public Set<URI> getRedirects() {
+    public List<ClientRedirect> getRedirects() {
         return redirects;
     }
 
@@ -263,8 +267,8 @@ public final class Client extends AbstractEntity {
      *
      * @param redirects The redirects.
      */
-    public void setRedirects(final Set<URI> redirects) {
-        this.redirects = redirects;
+    public void setRedirects(final List<ClientRedirect> redirects) {
+        this.redirects = new ArrayList<>(redirects);
     }
 
     /**

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/ClientRedirect.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/ClientRedirect.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.database.entity;
+
+import org.hibernate.search.annotations.Indexed;
+
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+/**
+ * This represents a redirect URL attached to a specific client.
+ *
+ * @author Michael Krotscheck
+ */
+@Entity
+@Table(name = "client_redirects")
+@Indexed(index = "client_redirects")
+public final class ClientRedirect extends AbstractClientUri {
+
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/ClientReferrer.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/ClientReferrer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.database.entity;
+
+import org.hibernate.search.annotations.Indexed;
+
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+/**
+ * This represents a referrer URL attached to a specific client.
+ *
+ * @author Michael Krotscheck
+ */
+@Entity
+@Table(name = "client_referrers")
+@Indexed(index = "client_referrers")
+public final class ClientReferrer extends AbstractClientUri {
+
+}

--- a/kangaroo-common/src/main/resources/hibernate.cfg.xml
+++ b/kangaroo-common/src/main/resources/hibernate.cfg.xml
@@ -53,6 +53,8 @@
     <mapping class="net.krotscheck.kangaroo.database.entity.Authenticator"/>
     <mapping class="net.krotscheck.kangaroo.database.entity.AuthenticatorState"/>
     <mapping class="net.krotscheck.kangaroo.database.entity.Client"/>
+    <mapping class="net.krotscheck.kangaroo.database.entity.ClientRedirect"/>
+    <mapping class="net.krotscheck.kangaroo.database.entity.ClientReferrer"/>
     <mapping class="net.krotscheck.kangaroo.database.entity.ConfigurationEntry"/>
     <mapping class="net.krotscheck.kangaroo.database.entity.OAuthToken"/>
     <mapping class="net.krotscheck.kangaroo.database.entity.Role"/>

--- a/kangaroo-common/src/main/resources/liquibase/db.changelog-1.0.0.yaml
+++ b/kangaroo-common/src/main/resources/liquibase/db.changelog-1.0.0.yaml
@@ -336,12 +336,25 @@ databaseChangeLog:
           tableName: client_referrers
           columns:
             - column:
+                name: id
+                type: BINARY(16)
+                constraints:
+                  primaryKey: true
+                  nullable: false
+                  primaryKeyName: pk_client_referrers_id
+            - column:
+                name: createdDate
+                type: datetime
+            - column:
+                name: modifiedDate
+                type: datetime
+            - column:
                 name: client
                 type: BINARY(16)
                 constraints:
                   nullable: false
             - column:
-                name: referrer
+                name: uri
                 type: varchar(255)
                 constraints:
                   nullable: false
@@ -353,8 +366,8 @@ databaseChangeLog:
           indexName: idx_client_referrers_client
           tableName: client_referrers
       - addUniqueConstraint:
-          columnNames: client, referrer
-          constraintName: uq_client_referrers_client_referrer
+          columnNames: client, uri
+          constraintName: uq_client_referrers_client_uri
           tableName: client_referrers
       - addForeignKeyConstraint:
           baseColumnNames: client
@@ -371,12 +384,25 @@ databaseChangeLog:
           tableName: client_redirects
           columns:
             - column:
+                name: id
+                type: BINARY(16)
+                constraints:
+                  primaryKey: true
+                  nullable: false
+                  primaryKeyName: pk_client_redirects_id
+            - column:
+                name: createdDate
+                type: datetime
+            - column:
+                name: modifiedDate
+                type: datetime
+            - column:
                 name: client
                 type: BINARY(16)
                 constraints:
                   nullable: false
             - column:
-                name: redirect
+                name: uri
                 type: varchar(255)
                 constraints:
                   nullable: false
@@ -388,8 +414,8 @@ databaseChangeLog:
           indexName: idx_client_redirects_client
           tableName: client_redirects
       - addUniqueConstraint:
-          columnNames: client, redirect
-          constraintName: uq_client_redirects_client_redirect
+          columnNames: client, uri
+          constraintName: uq_client_redirects_client_uri
           tableName: client_redirects
       - addForeignKeyConstraint:
           baseColumnNames: client

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/ClientRedirectTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/ClientRedirectTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.database.entity;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+import net.krotscheck.kangaroo.database.entity.Client.Deserializer;
+import net.krotscheck.kangaroo.database.util.JacksonUtil;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.net.URI;
+import java.text.DateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test the client redirect entity.
+ *
+ * @author Michael Krotscheck
+ */
+@RunWith(PowerMockRunner.class)
+public final class ClientRedirectTest {
+
+    /**
+     * Assert that we can get and set the redirects's client.
+     */
+    @Test
+    public void testGetSetClient() {
+        ClientRedirect redirect = new ClientRedirect();
+        Client client = new Client();
+
+        Assert.assertNull(redirect.getClient());
+        redirect.setClient(client);
+        Assert.assertEquals(client, redirect.getClient());
+    }
+
+    /**
+     * Assert that we can get and set the redirects's uri.
+     */
+    @Test
+    public void testGetSetUri() {
+        ClientRedirect redirect = new ClientRedirect();
+        URI uri = URI.create("http://example.com/");
+
+        Assert.assertNull(redirect.getUri());
+        redirect.setUri(uri);
+        Assert.assertEquals(uri, redirect.getUri());
+    }
+
+    /**
+     * Assert that we retrieve the owner from the parent client.
+     */
+    @Test
+    @PrepareForTest(Client.class)
+    public void testGetOwner() {
+        ClientRedirect redirect = new ClientRedirect();
+        Client spy = PowerMockito.spy(new Client());
+
+        // Null check
+        Assert.assertNull(redirect.getOwner());
+
+        redirect.setClient(spy);
+        redirect.getOwner();
+
+        Mockito.verify(spy).getOwner();
+    }
+
+    /**
+     * Assert that this entity can be serialized into a JSON object, and
+     * doesn't carry an unexpected payload.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testJacksonSerializable() throws Exception {
+        Client client = new Client();
+        client.setId(UUID.randomUUID());
+
+        ClientRedirect r = new ClientRedirect();
+        r.setClient(client);
+        r.setUri(URI.create("http://example.com/"));
+        r.setId(UUID.randomUUID());
+        r.setCreatedDate(Calendar.getInstance());
+        r.setModifiedDate(Calendar.getInstance());
+
+        // De/serialize to json.
+        ObjectMapper m = JacksonUtil.buildMapper();
+        DateFormat format = new ISO8601DateFormat();
+        String output = m.writeValueAsString(r);
+        JsonNode node = m.readTree(output);
+
+        Assert.assertEquals(
+                r.getId().toString(),
+                node.get("id").asText());
+        Assert.assertEquals(
+                format.format(r.getCreatedDate().getTime()),
+                node.get("createdDate").asText());
+        Assert.assertEquals(
+                format.format(r.getCreatedDate().getTime()),
+                node.get("modifiedDate").asText());
+
+        Assert.assertEquals(
+                r.getUri().toString(),
+                node.get("uri").asText());
+
+        // Enforce a given number of items.
+        List<String> names = new ArrayList<>();
+        Iterator<String> nameIterator = node.fieldNames();
+        while (nameIterator.hasNext()) {
+            names.add(nameIterator.next());
+        }
+        Assert.assertEquals(4, names.size());
+    }
+
+    /**
+     * Assert that this entity can be deserialized from a JSON object.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testJacksonDeserializable() throws Exception {
+        ObjectMapper m = JacksonUtil.buildMapper();
+        DateFormat format = new ISO8601DateFormat();
+        ObjectNode node = m.createObjectNode();
+        node.put("id", UUID.randomUUID().toString());
+        node.put("createdDate",
+                format.format(Calendar.getInstance().getTime()));
+        node.put("modifiedDate",
+                format.format(Calendar.getInstance().getTime()));
+        node.put("client", UUID.randomUUID().toString());
+        node.put("uri", "http://example.com/");
+
+        String output = m.writeValueAsString(node);
+        ClientRedirect r = m.readValue(output, ClientRedirect.class);
+
+        Assert.assertEquals(
+                r.getId().toString(),
+                node.get("id").asText());
+        Assert.assertEquals(
+                format.format(r.getCreatedDate().getTime()),
+                node.get("createdDate").asText());
+        Assert.assertEquals(
+                format.format(r.getModifiedDate().getTime()),
+                node.get("modifiedDate").asText());
+
+        Assert.assertEquals(
+                r.getUri().toString(),
+                node.get("uri").asText());
+
+        // Client is not publicly serialized.
+        Assert.assertNull(r.getClient());
+    }
+
+    /**
+     * Test the deserializer.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testDeserializeSimple() throws Exception {
+        UUID uuid = UUID.randomUUID();
+        String id = String.format("\"%s\"", uuid);
+        JsonFactory f = new JsonFactory();
+        JsonParser preloadedParser = f.createParser(id);
+        preloadedParser.nextToken(); // Advance to the first value.
+
+        Deserializer deserializer = new Deserializer();
+        Client c = deserializer.deserialize(preloadedParser,
+                mock(DeserializationContext.class));
+
+        Assert.assertEquals(uuid, c.getId());
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/ClientReferrerTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/ClientReferrerTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.database.entity;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+import net.krotscheck.kangaroo.database.entity.Client.Deserializer;
+import net.krotscheck.kangaroo.database.util.JacksonUtil;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.net.URI;
+import java.text.DateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test the client referrer entity.
+ *
+ * @author Michael Krotscheck
+ */
+@RunWith(PowerMockRunner.class)
+public final class ClientReferrerTest {
+
+    /**
+     * Assert that we can get and set the referrers's client.
+     */
+    @Test
+    public void testGetSetClient() {
+        ClientReferrer referrer = new ClientReferrer();
+        Client client = new Client();
+
+        Assert.assertNull(referrer.getClient());
+        referrer.setClient(client);
+        Assert.assertEquals(client, referrer.getClient());
+    }
+
+    /**
+     * Assert that we can get and set the referrers's uri.
+     */
+    @Test
+    public void testGetSetUri() {
+        ClientReferrer referrer = new ClientReferrer();
+        URI uri = URI.create("http://example.com/");
+
+        Assert.assertNull(referrer.getUri());
+        referrer.setUri(uri);
+        Assert.assertEquals(uri, referrer.getUri());
+    }
+
+    /**
+     * Assert that we retrieve the owner from the parent client.
+     */
+    @Test
+    @PrepareForTest(Client.class)
+    public void testGetOwner() {
+        ClientReferrer referrer = new ClientReferrer();
+        Client spy = PowerMockito.spy(new Client());
+
+        // Null check
+        Assert.assertNull(referrer.getOwner());
+
+        referrer.setClient(spy);
+        referrer.getOwner();
+
+        Mockito.verify(spy).getOwner();
+    }
+
+    /**
+     * Assert that this entity can be serialized into a JSON object, and
+     * doesn't carry an unexpected payload.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testJacksonSerializable() throws Exception {
+        Client client = new Client();
+        client.setId(UUID.randomUUID());
+
+        ClientReferrer r = new ClientReferrer();
+        r.setClient(client);
+        r.setUri(URI.create("http://example.com/"));
+        r.setId(UUID.randomUUID());
+        r.setCreatedDate(Calendar.getInstance());
+        r.setModifiedDate(Calendar.getInstance());
+
+        // De/serialize to json.
+        ObjectMapper m = JacksonUtil.buildMapper();
+        DateFormat format = new ISO8601DateFormat();
+        String output = m.writeValueAsString(r);
+        JsonNode node = m.readTree(output);
+
+        Assert.assertEquals(
+                r.getId().toString(),
+                node.get("id").asText());
+        Assert.assertEquals(
+                format.format(r.getCreatedDate().getTime()),
+                node.get("createdDate").asText());
+        Assert.assertEquals(
+                format.format(r.getCreatedDate().getTime()),
+                node.get("modifiedDate").asText());
+
+        Assert.assertEquals(
+                r.getUri().toString(),
+                node.get("uri").asText());
+
+        // Enforce a given number of items.
+        List<String> names = new ArrayList<>();
+        Iterator<String> nameIterator = node.fieldNames();
+        while (nameIterator.hasNext()) {
+            names.add(nameIterator.next());
+        }
+        Assert.assertEquals(4, names.size());
+    }
+
+    /**
+     * Assert that this entity can be deserialized from a JSON object.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testJacksonDeserializable() throws Exception {
+        ObjectMapper m = JacksonUtil.buildMapper();
+        DateFormat format = new ISO8601DateFormat();
+        ObjectNode node = m.createObjectNode();
+        node.put("id", UUID.randomUUID().toString());
+        node.put("createdDate",
+                format.format(Calendar.getInstance().getTime()));
+        node.put("modifiedDate",
+                format.format(Calendar.getInstance().getTime()));
+        node.put("client", UUID.randomUUID().toString());
+        node.put("uri", "http://example.com/");
+
+        String output = m.writeValueAsString(node);
+        ClientReferrer r = m.readValue(output, ClientReferrer.class);
+
+        Assert.assertEquals(
+                r.getId().toString(),
+                node.get("id").asText());
+        Assert.assertEquals(
+                format.format(r.getCreatedDate().getTime()),
+                node.get("createdDate").asText());
+        Assert.assertEquals(
+                format.format(r.getModifiedDate().getTime()),
+                node.get("modifiedDate").asText());
+
+        Assert.assertEquals(
+                r.getUri().toString(),
+                node.get("uri").asText());
+
+        // Client is not publicly serialized.
+        Assert.assertNull(r.getClient());
+    }
+
+    /**
+     * Test the deserializer.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testDeserializeSimple() throws Exception {
+        UUID uuid = UUID.randomUUID();
+        String id = String.format("\"%s\"", uuid);
+        JsonFactory f = new JsonFactory();
+        JsonParser preloadedParser = f.createParser(id);
+        preloadedParser.nextToken(); // Advance to the first value.
+
+        Deserializer deserializer = new Deserializer();
+        Client c = deserializer.deserialize(preloadedParser,
+                mock(DeserializationContext.class));
+
+        Assert.assertEquals(uuid, c.getId());
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/util/ValidationUtilTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/util/ValidationUtilTest.java
@@ -24,6 +24,7 @@ import net.krotscheck.kangaroo.common.exception.rfc6749.Rfc6749Exception.Unsuppo
 import net.krotscheck.kangaroo.database.entity.ApplicationScope;
 import net.krotscheck.kangaroo.database.entity.Authenticator;
 import net.krotscheck.kangaroo.database.entity.Client;
+import net.krotscheck.kangaroo.database.entity.ClientRedirect;
 import net.krotscheck.kangaroo.database.entity.ClientType;
 import net.krotscheck.kangaroo.database.entity.Role;
 import org.junit.Assert;
@@ -80,6 +81,96 @@ public final class ValidationUtilTest {
         // Create a new instance for coverage.
         c.setAccessible(true);
         c.newInstance();
+    }
+
+    /**
+     * Check list valid redirect.
+     *
+     * @throws Exception Thrown if validation fails.
+     */
+    @Test
+    public void testValidateClientRedirects() throws Exception {
+        List<ClientRedirect> testRedirects = new ArrayList<>();
+
+        ClientRedirect redirect1 = new ClientRedirect();
+        redirect1.setUri(new URI("http://one.example.com"));
+        testRedirects.add(redirect1);
+
+        ClientRedirect redirect2 = new ClientRedirect();
+        redirect2.setUri(new URI("http://two.example.com"));
+        testRedirects.add(redirect2);
+
+        URI result =
+                ValidationUtil.requireValidRedirect("http://one.example.com",
+                        testRedirects);
+        Assert.assertEquals("http://one.example.com", result.toString());
+    }
+
+    /**
+     * Check list valid redirect.
+     *
+     * @throws Exception Thrown if validation fails.
+     */
+    @Test
+    public void testValidateClientRedirectsWithUri() throws Exception {
+        List<ClientRedirect> testRedirects = new ArrayList<>();
+
+        ClientRedirect redirect1 = new ClientRedirect();
+        redirect1.setUri(new URI("http://one.example.com"));
+        testRedirects.add(redirect1);
+
+        ClientRedirect redirect2 = new ClientRedirect();
+        redirect2.setUri(new URI("http://two.example.com"));
+        testRedirects.add(redirect2);
+
+        URI validUri = URI.create("http://two.example.com");
+
+        URI result =
+                ValidationUtil.requireValidRedirect(validUri,
+                        testRedirects);
+        Assert.assertEquals(validUri, result);
+    }
+
+    /**
+     * Check list valid redirect.
+     *
+     * @throws Exception Thrown if validation fails.
+     */
+    @Test(expected = InvalidRequestException.class)
+    public void testValidateClientRedirectsWithNullUri() throws Exception {
+        List<ClientRedirect> testRedirects = new ArrayList<>();
+
+        ClientRedirect redirect1 = new ClientRedirect();
+        redirect1.setUri(new URI("http://one.example.com"));
+        testRedirects.add(redirect1);
+
+        ClientRedirect redirect2 = new ClientRedirect();
+        redirect2.setUri(new URI("http://two.example.com"));
+        testRedirects.add(redirect2);
+
+        ValidationUtil.requireValidRedirect((URI) null, testRedirects);
+    }
+
+    /**
+     * Check list valid redirect.
+     *
+     * @throws Exception Thrown if validation fails.
+     */
+    @Test(expected = InvalidRequestException.class)
+    public void testValidateClientRedirectsWithNullString() throws Exception {
+        List<ClientRedirect> testRedirects = new ArrayList<>();
+
+        ClientRedirect redirect1 = new ClientRedirect();
+        redirect1.setUri(new URI("http://one.example.com"));
+        testRedirects.add(redirect1);
+
+        ClientRedirect redirect2 = new ClientRedirect();
+        redirect2.setUri(new URI("http://two.example.com"));
+        testRedirects.add(redirect2);
+
+        URI result = ValidationUtil.requireValidRedirect((String) null,
+                testRedirects);
+        Assert.assertNull(result);
     }
 
     /**
@@ -186,6 +277,28 @@ public final class ValidationUtilTest {
 
         ValidationUtil.requireValidRedirect("http://one.example.com/bar",
                 testSet);
+    }
+
+    /**
+     * Check list valid redirect.
+     *
+     * @throws Exception Thrown if validation fails.
+     */
+    @Test
+    public void testInvalidClientRedirects() throws Exception {
+        List<ClientRedirect> testRedirects = new ArrayList<>();
+
+        ClientRedirect redirect1 = new ClientRedirect();
+        redirect1.setUri(new URI("http://one.example.com"));
+        testRedirects.add(redirect1);
+
+        ClientRedirect redirect2 = new ClientRedirect();
+        redirect2.setUri(new URI("http://two.example.com"));
+        testRedirects.add(redirect2);
+
+        URI result = ValidationUtil.validateRedirect("http://three.example.com",
+                testRedirects);
+        Assert.assertNull(result);
     }
 
     /**

--- a/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AbstractService.java
+++ b/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AbstractService.java
@@ -39,6 +39,7 @@ import org.hibernate.search.query.dsl.QueryBuilder;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
@@ -294,6 +295,30 @@ public abstract class AbstractService {
 
         // Not permitted, exit.
         throw new HttpNotFoundException();
+    }
+
+    /**
+     * This method tests whether a particular subresource entity may be
+     * accessed. It defers most of its logic to assertCanAccess, except that
+     * it will rethrow HttpNotFoundExceptions as BadRequestExceptions in the
+     * case where a user does not have permissions to see the parent resource.
+     *
+     * @param entity              The entity to check.
+     * @param requiredParentScope The scope required to access the parent
+     *                            entity.
+     */
+    protected final void assertCanAccessSubresource(
+            final AbstractEntity entity, final String requiredParentScope) {
+        // No null entities permitted.
+        if (entity == null) {
+            throw new HttpNotFoundException();
+        }
+
+        try {
+            assertCanAccess(entity, requiredParentScope);
+        } catch (HttpNotFoundException e) {
+            throw new BadRequestException();
+        }
     }
 
     /**

--- a/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ClientRedirectService.java
+++ b/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ClientRedirectService.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.servlet.admin.v1.resource;
+
+import net.krotscheck.kangaroo.common.exception.exception.HttpNotFoundException;
+import net.krotscheck.kangaroo.common.exception.exception.HttpStatusException;
+import net.krotscheck.kangaroo.common.hibernate.transaction.Transactional;
+import net.krotscheck.kangaroo.common.response.ApiParam;
+import net.krotscheck.kangaroo.common.response.ListResponseBuilder;
+import net.krotscheck.kangaroo.common.response.SortOrder;
+import net.krotscheck.kangaroo.database.entity.AbstractClientUri;
+import net.krotscheck.kangaroo.database.entity.Client;
+import net.krotscheck.kangaroo.database.entity.ClientRedirect;
+import net.krotscheck.kangaroo.database.util.SortUtil;
+import net.krotscheck.kangaroo.servlet.admin.v1.Scope;
+import net.krotscheck.kangaroo.servlet.admin.v1.filter.OAuth2;
+import org.apache.http.HttpStatus;
+import org.hibernate.Criteria;
+import org.hibernate.Session;
+import org.hibernate.criterion.Projections;
+import org.hibernate.criterion.Restrictions;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.net.URI;
+import java.util.UUID;
+
+/**
+ * A RESTful API that permits the management of a client's redirect URI's.
+ *
+ * @author Michael Krotscheck
+ */
+@OAuth2
+@RolesAllowed({Scope.CLIENT, Scope.CLIENT_ADMIN})
+@Transactional
+public final class ClientRedirectService extends AbstractService {
+
+    /**
+     * The client from which the redirects are extracted.
+     */
+    private final UUID clientId;
+
+    /**
+     * Create a new instance of this redirect service.
+     *
+     * @param clientId The client id, provided by the routed path.
+     */
+    @Inject
+    public ClientRedirectService(@PathParam("clientId") final UUID clientId) {
+        this.clientId = clientId;
+    }
+
+    /**
+     * Browse the redirects for this client.
+     *
+     * @param offset The offset of the first scopes to fetch.
+     * @param limit  The number of data sets to fetch.
+     * @param sort   The field on which the records should be sorted.
+     * @param order  The sort order, ASC or DESC.
+     * @return A list of search results.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @SuppressWarnings("CPD-START")
+    public Response browse(
+            @QueryParam(ApiParam.OFFSET_QUERY)
+            @DefaultValue(ApiParam.OFFSET_DEFAULT)
+            final int offset,
+            @QueryParam(ApiParam.LIMIT_QUERY)
+            @DefaultValue(ApiParam.LIMIT_DEFAULT)
+            final int limit,
+            @QueryParam(ApiParam.SORT_QUERY)
+            @DefaultValue(ApiParam.SORT_DEFAULT)
+            final String sort,
+            @QueryParam(ApiParam.ORDER_QUERY)
+            @DefaultValue(ApiParam.ORDER_DEFAULT)
+            final SortOrder order) {
+        Session s = getSession();
+
+        // Make sure we can read the client.
+        Client client = s.get(Client.class, clientId);
+        assertCanAccess(client, getAdminScope());
+
+        // Build a count criteria
+        Criteria countCriteria = getSession()
+                .createCriteria(ClientRedirect.class)
+                .createAlias("client", "c")
+                .add(Restrictions.eq("c.id", client.getId()))
+                .setProjection(Projections.rowCount());
+
+        Criteria browseCriteria = getSession()
+                .createCriteria(ClientRedirect.class)
+                .createAlias("client", "c")
+                .add(Restrictions.eq("c.id", client.getId()))
+                .setFirstResult(offset)
+                .setMaxResults(limit)
+                .setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY)
+                .addOrder(SortUtil.order(order, sort));
+
+        // Always filter by client
+        browseCriteria.add(Restrictions.eq("c.id", client.getId()));
+        countCriteria.add(Restrictions.eq("c.id", client.getId()));
+
+        return ListResponseBuilder.builder()
+                .offset(offset)
+                .limit(limit)
+                .order(order)
+                .sort(sort)
+                .total(countCriteria.uniqueResult())
+                .addResult(browseCriteria.list())
+                .build();
+    }
+
+    /**
+     * Returns a specific redirect.
+     *
+     * @param id The Unique Identifier for the redirect.
+     * @return A response with the redirect that was requested.
+     */
+    @SuppressWarnings("CPD-END")
+    @GET
+    @Path("/{id: [a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getResource(@PathParam("id") final UUID id) {
+        Session s = getSession();
+        Client client = s.get(Client.class, clientId);
+        assertCanAccess(client, getAdminScope());
+
+        ClientRedirect redirect = s.get(ClientRedirect.class, id);
+        if (redirect == null || !redirect.getClient().equals(client)) {
+            throw new HttpNotFoundException();
+        }
+        assertCanAccess(redirect, getAdminScope());
+        return Response.ok(redirect).build();
+    }
+
+    /**
+     * Create a new redirect for this client.
+     *
+     * @param redirect The redirect entity to create.
+     * @return A redirect to the location where the client was created.
+     */
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response createResource(final ClientRedirect redirect) {
+        Session s = getSession();
+
+        // Make sure we're allowed to access the client.
+        Client client = s.get(Client.class, clientId);
+        assertCanAccessSubresource(client, getAdminScope());
+
+        // Input value checks.
+        if (redirect == null) {
+            throw new HttpStatusException(HttpStatus.SC_BAD_REQUEST);
+        }
+        if (redirect.getId() != null) {
+            throw new HttpStatusException(HttpStatus.SC_BAD_REQUEST);
+        }
+        if (redirect.getUri() == null) {
+            throw new HttpStatusException(HttpStatus.SC_BAD_REQUEST);
+        }
+
+        // Check for duplicates
+        Boolean duplicate = client.getRedirects().stream()
+                .map(AbstractClientUri::getUri)
+                .anyMatch(uri -> uri.equals(redirect.getUri()));
+        if (duplicate) {
+            throw new HttpStatusException(HttpStatus.SC_CONFLICT);
+        }
+
+        // Save it all.
+        redirect.setClient(client);
+        client.getRedirects().add(redirect);
+
+        s.update(client);
+        s.save(redirect);
+
+        // Build the URI of the new resources.
+        URI resourceLocation = getUriInfo().getAbsolutePathBuilder()
+                .path(ClientRedirectService.class, "getResource")
+                .build(redirect.getId().toString());
+
+        return Response.created(resourceLocation).build();
+    }
+
+    /**
+     * Update a redirect for this client.
+     *
+     * @param id       The Unique Identifier for the redirect.
+     * @param redirect The redirect to update.
+     * @return A response with the redirect that was updated.
+     */
+    @PUT
+    @Path("/{id: [a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateResource(@PathParam("id") final UUID id,
+                                   final ClientRedirect redirect) {
+        Session s = getSession();
+
+        // Make sure we're allowed to access the client.
+        Client client = s.get(Client.class, clientId);
+        assertCanAccess(client, getAdminScope());
+
+        // Make sure the old instance exists.
+        ClientRedirect currentRedirect = s.get(ClientRedirect.class, id);
+        if (currentRedirect == null) {
+            throw new HttpStatusException(HttpStatus.SC_NOT_FOUND);
+        }
+
+        // Make sure the parent ID's match
+        if (!currentRedirect.getClient().equals(client)) {
+            throw new HttpNotFoundException();
+        }
+        // Make sure the body ID's match
+        if (!currentRedirect.equals(redirect)) {
+            throw new HttpStatusException(HttpStatus.SC_BAD_REQUEST);
+        }
+        // Make sure we're not trying to null the redirect.
+        if (redirect.getUri() == null) {
+            throw new HttpStatusException(HttpStatus.SC_BAD_REQUEST);
+        }
+
+        // Make sure we're not creating a duplicate.
+        Boolean duplicate = client.getRedirects().stream()
+                .filter(r -> !currentRedirect.equals(r))
+                .anyMatch(r -> r.getUri().equals(redirect.getUri()));
+        if (duplicate) {
+            throw new HttpStatusException(HttpStatus.SC_CONFLICT);
+        }
+
+        // Transfer all the values we're allowed to edit.
+        currentRedirect.setUri(redirect.getUri());
+
+        s.update(currentRedirect);
+
+        return Response.ok(redirect).build();
+    }
+
+    /**
+     * Delete a redirect from a client.
+     *
+     * @param redirectId The Unique Identifier for the redirect.
+     * @return A response that indicates the success of this operation.
+     */
+    @DELETE
+    @Path("/{id: [a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}}")
+    public Response deleteResource(@PathParam("id") final UUID redirectId) {
+        Session s = getSession();
+
+        // Make sure we're allowed to access the client.
+        Client client = s.get(Client.class, clientId);
+        assertCanAccess(client, getAdminScope());
+
+        // Hydrate the redirect
+        ClientRedirect redirect = s.get(ClientRedirect.class, redirectId);
+        if (redirect == null) {
+            throw new HttpStatusException(HttpStatus.SC_NOT_FOUND);
+        }
+        // Make sure the parent ID's match
+        if (!redirect.getClient().equals(client)) {
+            throw new HttpNotFoundException();
+        }
+
+        // If we're in the admin app, we can't modify anything.
+        if (getAdminApplication().equals(client.getApplication())) {
+            throw new HttpStatusException(HttpStatus.SC_FORBIDDEN);
+        }
+
+        // Execute the command.
+        client.getRedirects().remove(redirect);
+        s.delete(redirect);
+        s.update(client);
+
+        return Response.noContent().build();
+    }
+
+    /**
+     * Return the redirect required to access ALL resources on this services.
+     *
+     * @return A string naming the redirect.
+     */
+    @Override
+    protected String getAdminScope() {
+        return Scope.CLIENT_ADMIN;
+    }
+
+    /**
+     * Return the redirect required to access resources on this service.
+     *
+     * @return A string naming the redirect.
+     */
+    @Override
+    protected String getAccessScope() {
+        return Scope.CLIENT;
+    }
+}

--- a/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ClientReferrerService.java
+++ b/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ClientReferrerService.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.servlet.admin.v1.resource;
+
+import net.krotscheck.kangaroo.common.exception.exception.HttpNotFoundException;
+import net.krotscheck.kangaroo.common.exception.exception.HttpStatusException;
+import net.krotscheck.kangaroo.common.hibernate.transaction.Transactional;
+import net.krotscheck.kangaroo.common.response.ApiParam;
+import net.krotscheck.kangaroo.common.response.ListResponseBuilder;
+import net.krotscheck.kangaroo.common.response.SortOrder;
+import net.krotscheck.kangaroo.database.entity.AbstractClientUri;
+import net.krotscheck.kangaroo.database.entity.Client;
+import net.krotscheck.kangaroo.database.entity.ClientReferrer;
+import net.krotscheck.kangaroo.database.util.SortUtil;
+import net.krotscheck.kangaroo.servlet.admin.v1.Scope;
+import net.krotscheck.kangaroo.servlet.admin.v1.filter.OAuth2;
+import org.apache.http.HttpStatus;
+import org.hibernate.Criteria;
+import org.hibernate.Session;
+import org.hibernate.criterion.Projections;
+import org.hibernate.criterion.Restrictions;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.net.URI;
+import java.util.UUID;
+
+/**
+ * A RESTful API that permits the management of a client's referrer URI's.
+ *
+ * @author Michael Krotscheck
+ */
+@OAuth2
+@RolesAllowed({Scope.CLIENT, Scope.CLIENT_ADMIN})
+@Transactional
+public final class ClientReferrerService extends AbstractService {
+
+    /**
+     * The client from which the referrers are extracted.
+     */
+    private final UUID clientId;
+
+    /**
+     * Create a new instance of this referrer service.
+     *
+     * @param clientId The client id, provided by the routed path.
+     */
+    @Inject
+    public ClientReferrerService(@PathParam("clientId") final UUID clientId) {
+        this.clientId = clientId;
+    }
+
+    /**
+     * Browse the referrers for this client.
+     *
+     * @param offset The offset of the first scopes to fetch.
+     * @param limit  The number of data sets to fetch.
+     * @param sort   The field on which the records should be sorted.
+     * @param order  The sort order, ASC or DESC.
+     * @return A list of search results.
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @SuppressWarnings("CPD-START")
+    public Response browse(
+            @QueryParam(ApiParam.OFFSET_QUERY)
+            @DefaultValue(ApiParam.OFFSET_DEFAULT)
+            final int offset,
+            @QueryParam(ApiParam.LIMIT_QUERY)
+            @DefaultValue(ApiParam.LIMIT_DEFAULT)
+            final int limit,
+            @QueryParam(ApiParam.SORT_QUERY)
+            @DefaultValue(ApiParam.SORT_DEFAULT)
+            final String sort,
+            @QueryParam(ApiParam.ORDER_QUERY)
+            @DefaultValue(ApiParam.ORDER_DEFAULT)
+            final SortOrder order) {
+        Session s = getSession();
+
+        // Make sure we can read the client.
+        Client client = s.get(Client.class, clientId);
+        assertCanAccess(client, getAdminScope());
+
+        // Build a count criteria
+        Criteria countCriteria = getSession()
+                .createCriteria(ClientReferrer.class)
+                .createAlias("client", "c")
+                .add(Restrictions.eq("c.id", client.getId()))
+                .setProjection(Projections.rowCount());
+
+        Criteria browseCriteria = getSession()
+                .createCriteria(ClientReferrer.class)
+                .createAlias("client", "c")
+                .add(Restrictions.eq("c.id", client.getId()))
+                .setFirstResult(offset)
+                .setMaxResults(limit)
+                .setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY)
+                .addOrder(SortUtil.order(order, sort));
+
+        // Always filter by client
+        browseCriteria.add(Restrictions.eq("c.id", client.getId()));
+        countCriteria.add(Restrictions.eq("c.id", client.getId()));
+
+        return ListResponseBuilder.builder()
+                .offset(offset)
+                .limit(limit)
+                .order(order)
+                .sort(sort)
+                .total(countCriteria.uniqueResult())
+                .addResult(browseCriteria.list())
+                .build();
+    }
+
+    /**
+     * Returns a specific referrer.
+     *
+     * @param id The Unique Identifier for the referrer.
+     * @return A response with the referrer that was requested.
+     */
+    @SuppressWarnings("CPD-END")
+    @GET
+    @Path("/{id: [a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getResource(@PathParam("id") final UUID id) {
+        Session s = getSession();
+        Client client = s.get(Client.class, clientId);
+        assertCanAccess(client, getAdminScope());
+
+        ClientReferrer referrer = s.get(ClientReferrer.class, id);
+        // Make sure the parent ID's match
+        if (referrer == null || !referrer.getClient().equals(client)) {
+            throw new HttpNotFoundException();
+        }
+        assertCanAccess(referrer, getAdminScope());
+        return Response.ok(referrer).build();
+    }
+
+
+    /**
+     * Create a new referrer for this client.
+     *
+     * @param referrer The referrer entity to create.
+     * @return A referrer to the location where the client was created.
+     */
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response createResource(final ClientReferrer referrer) {
+        Session s = getSession();
+
+        // Make sure we're allowed to access the client.
+        Client client = s.get(Client.class, clientId);
+        assertCanAccessSubresource(client, getAdminScope());
+
+        // Input value checks.
+        if (referrer == null) {
+            throw new HttpStatusException(HttpStatus.SC_BAD_REQUEST);
+        }
+        if (referrer.getId() != null) {
+            throw new HttpStatusException(HttpStatus.SC_BAD_REQUEST);
+        }
+        if (referrer.getUri() == null) {
+            throw new HttpStatusException(HttpStatus.SC_BAD_REQUEST);
+        }
+
+        // Check for duplicates
+        Boolean duplicate = client.getReferrers().stream()
+                .map(AbstractClientUri::getUri)
+                .anyMatch(uri -> uri.equals(referrer.getUri()));
+        if (duplicate) {
+            throw new HttpStatusException(HttpStatus.SC_CONFLICT);
+        }
+
+        // Save it all.
+        referrer.setClient(client);
+        client.getReferrers().add(referrer);
+
+        s.update(client);
+        s.save(referrer);
+
+        // Build the URI of the new resources.
+        URI resourceLocation = getUriInfo().getAbsolutePathBuilder()
+                .path(ClientReferrerService.class, "getResource")
+                .build(referrer.getId().toString());
+
+        return Response.created(resourceLocation).build();
+    }
+
+    /**
+     * Update a referrer for this client.
+     *
+     * @param id       The Unique Identifier for the referrer.
+     * @param referrer The referrer to update.
+     * @return A response with the referrer that was updated.
+     */
+    @PUT
+    @Path("/{id: [a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateResource(@PathParam("id") final UUID id,
+                                   final ClientReferrer referrer) {
+        Session s = getSession();
+
+        // Make sure we're allowed to access the client.
+        Client client = s.get(Client.class, clientId);
+        assertCanAccess(client, getAdminScope());
+
+        // Make sure the old instance exists.
+        ClientReferrer currentReferrer = s.get(ClientReferrer.class, id);
+        if (currentReferrer == null) {
+            throw new HttpStatusException(HttpStatus.SC_NOT_FOUND);
+        }
+        // Make sure the parent ID's match
+        if (!currentReferrer.getClient().equals(client)) {
+            throw new HttpNotFoundException();
+        }
+
+        // Make sure the body ID's match
+        if (!currentReferrer.equals(referrer)) {
+            throw new HttpStatusException(HttpStatus.SC_BAD_REQUEST);
+        }
+        // Make sure we're not trying to null the redirect.
+        if (referrer.getUri() == null) {
+            throw new HttpStatusException(HttpStatus.SC_BAD_REQUEST);
+        }
+
+        // Make sure we're not creating a duplicate.
+        Boolean duplicate = client.getReferrers().stream()
+                .filter(r -> !currentReferrer.equals(r))
+                .anyMatch(r -> r.getUri().equals(referrer.getUri()));
+        if (duplicate) {
+            throw new HttpStatusException(HttpStatus.SC_CONFLICT);
+        }
+
+        // Transfer all the values we're allowed to edit.
+        currentReferrer.setUri(referrer.getUri());
+
+        s.update(currentReferrer);
+
+        return Response.ok(referrer).build();
+    }
+
+
+    /**
+     * Delete a referrer from a client.
+     *
+     * @param referrerId The Unique Identifier for the referrer.
+     * @return A response that indicates the success of this operation.
+     */
+    @DELETE
+    @Path("/{id: [a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}}")
+    public Response deleteResource(@PathParam("id") final UUID referrerId) {
+        Session s = getSession();
+
+        // Make sure we're allowed to access the client.
+        Client client = s.get(Client.class, clientId);
+        assertCanAccess(client, getAdminScope());
+
+        // Hydrate the referrer
+        ClientReferrer referrer = s.get(ClientReferrer.class, referrerId);
+        if (referrer == null) {
+            throw new HttpStatusException(HttpStatus.SC_NOT_FOUND);
+        }
+        // Make sure the parent ID's match
+        if (!referrer.getClient().equals(client)) {
+            throw new HttpNotFoundException();
+        }
+
+        // If we're in the admin app, we can't modify anything.
+        if (getAdminApplication().equals(client.getApplication())) {
+            throw new HttpStatusException(HttpStatus.SC_FORBIDDEN);
+        }
+
+        // Execute the command.
+        client.getReferrers().remove(referrer);
+        s.delete(referrer);
+        s.update(client);
+
+        return Response.noContent().build();
+    }
+
+    /**
+     * Return the referrer required to access ALL resources on this services.
+     *
+     * @return A string naming the referrer.
+     */
+    @Override
+    protected String getAdminScope() {
+        return Scope.CLIENT_ADMIN;
+    }
+
+    /**
+     * Return the referrer required to access resources on this service.
+     *
+     * @return A string naming the referrer.
+     */
+    @Override
+    protected String getAccessScope() {
+        return Scope.CLIENT;
+    }
+}

--- a/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ClientService.java
+++ b/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ClientService.java
@@ -126,7 +126,7 @@ public final class ClientService extends AbstractService {
      * @param order         The sort order, ASC or DESC.
      * @param ownerId       An optional user ID to filter by.
      * @param applicationId An optional application ID to filter by.
-     * @param clientType    An optional client type to filter by..
+     * @param clientType    An optional client type to filter by.
      * @return A list of search results.
      */
     @GET
@@ -334,6 +334,36 @@ public final class ClientService extends AbstractService {
         s.delete(client);
 
         return Response.noContent().build();
+    }
+
+    /**
+     * Expose a subresource that manages the redirects on a client. Note that
+     * the OAuth2 flow will not be initialized until the path fully resolves, so
+     * all auth checks have to happen in the child resource.
+     *
+     * @param clientId The ID of the client.
+     * @return The subresource.
+     */
+    @Path("/{clientId: [a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}"
+            + "-[a-f0-9]{4}-[a-f0-9]{12}}/redirect")
+    public Class<ClientRedirectService> getRedirectService(
+            @PathParam("clientId") final UUID clientId) {
+        return ClientRedirectService.class;
+    }
+
+    /**
+     * Expose a subresource that manages the referrers on a client. Note that
+     * the OAuth2 flow will not be initialized until the path fully resolves, so
+     * all auth checks have to happen in the child resource.
+     *
+     * @param clientId The ID of the client.
+     * @return The subresource.
+     */
+    @Path("/{clientId: [a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}"
+            + "-[a-f0-9]{4}-[a-f0-9]{12}}/referrer")
+    public Class<ClientReferrerService> getReferrerService(
+            @PathParam("clientId") final UUID clientId) {
+        return ClientReferrerService.class;
     }
 
     /**

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ClientRedirectServiceBrowseTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ClientRedirectServiceBrowseTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.servlet.admin.v1.resource;
+
+import net.krotscheck.kangaroo.database.entity.AbstractEntity;
+import net.krotscheck.kangaroo.database.entity.Client;
+import net.krotscheck.kangaroo.database.entity.ClientRedirect;
+import net.krotscheck.kangaroo.database.entity.ClientType;
+import net.krotscheck.kangaroo.database.entity.OAuthToken;
+import net.krotscheck.kangaroo.database.entity.User;
+import net.krotscheck.kangaroo.servlet.admin.v1.Scope;
+import net.krotscheck.kangaroo.test.EnvironmentBuilder;
+import org.hibernate.Criteria;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.criterion.Restrictions;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Test the list and filter methods of the ClientRedirect service.
+ *
+ * @author Michael Krotscheck
+ */
+@RunWith(Parameterized.class)
+public final class ClientRedirectServiceBrowseTest
+        extends DAbstractSubserviceBrowseTest<Client, ClientRedirect> {
+
+    /**
+     * Generic type declaration for list decoding.
+     */
+    private static final GenericType<List<ClientRedirect>> LIST_TYPE =
+            new GenericType<List<ClientRedirect>>() {
+
+            };
+
+    /**
+     * Create a new instance of this parameterized test.
+     *
+     * @param clientType The type of client.
+     * @param tokenScope The client scope to issue.
+     * @param createUser Whether to create a new user.
+     */
+    public ClientRedirectServiceBrowseTest(final ClientType clientType,
+                                           final String tokenScope,
+                                           final Boolean createUser) {
+        super(clientType, tokenScope, createUser);
+    }
+
+    /**
+     * Return the token scope required for admin access on this test.
+     *
+     * @return The correct scope string.
+     */
+    @Override
+    protected String getAdminScope() {
+        return Scope.CLIENT_ADMIN;
+    }
+
+    /**
+     * Return the token scope required for generic user access.
+     *
+     * @return The correct scope string.
+     */
+    @Override
+    protected String getRegularScope() {
+        return Scope.CLIENT;
+    }
+
+    /**
+     * Return the list type used to decode browse results.
+     *
+     * @return The list type.
+     */
+    @Override
+    protected GenericType<List<ClientRedirect>> getListType() {
+        return LIST_TYPE;
+    }
+
+    /**
+     * Return the list of entities which should be accessible given a
+     * specific token.
+     *
+     * @param parentEntity The client to filter against.
+     * @param token        The oauth token to test against.
+     * @return A list of entities (could be empty).
+     */
+    @Override
+    protected List<ClientRedirect> getAccessibleEntities(
+            final Client parentEntity,
+            final OAuthToken token) {
+        // If you're an admin, you get to see everything. If you're not, you
+        // only get to see what you own.
+        if (!token.getScopes().containsKey(getAdminScope())) {
+            return getOwnedEntities(parentEntity, token);
+        }
+
+        // We know you're an admin. Get all applications in the system.
+        Criteria criteria = getSession().createCriteria(ClientRedirect.class)
+                .add(Restrictions.eq("client", parentEntity));
+
+        // Get all the owned clients.
+        return ((List<ClientRedirect>) criteria.list());
+    }
+
+    /**
+     * Return the list of entities which are owned by the given oauth token.
+     *
+     * @param parentEntity The client to filter against.
+     * @param owner        The owner of these entities.
+     * @return A list of entities (could be empty).
+     */
+    @Override
+    protected List<ClientRedirect> getOwnedEntities(final Client parentEntity,
+                                                    final User owner) {
+        // Get all the owned clients.
+        return owner.getApplications()
+                .stream()
+                .flatMap(a -> a.getClients().stream())
+                .filter(c -> c.equals(parentEntity))
+                .flatMap(c -> c.getRedirects().stream())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Test parameters.
+     *
+     * @return The list of parameters.
+     */
+    @Parameterized.Parameters
+    public static Collection parameters() {
+        return Arrays.asList(
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT_ADMIN,
+                        false
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT,
+                        false
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT_ADMIN,
+                        true
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT,
+                        true
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.CLIENT_ADMIN,
+                        false
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.CLIENT,
+                        false
+                });
+    }
+
+    /**
+     * Construct the request URL for this test given a specific resource ID.
+     *
+     * @param id The ID to use.
+     * @return The resource URL.
+     */
+    @Override
+    protected URI getUrlForId(final String id) {
+        String parentId = "";
+
+        Session s = getSession();
+        Transaction t = s.beginTransaction();
+        try {
+            ClientRedirect r = s.get(ClientRedirect.class, UUID.fromString(id));
+            parentId = r.getClient().getId().toString();
+        } catch (Exception e) {
+            parentId = getParentEntity(getAdminContext()).getId().toString();
+        } finally {
+            t.rollback();
+        }
+
+        return getUrlForEntity(parentId, id);
+    }
+
+    /**
+     * Construct the request URL for this test given a specific resource ID.
+     *
+     * @param entity The entity to use.
+     * @return The resource URL.
+     */
+    @Override
+    protected URI getUrlForEntity(final AbstractEntity entity) {
+        String parentId = "";
+        String childId = "";
+
+        ClientRedirect referrer = (ClientRedirect) entity;
+        if (referrer == null) {
+            return getUrlForId(null);
+        } else {
+            UUID referrerId = referrer.getId();
+            childId = referrerId == null ? null : referrerId.toString();
+        }
+
+        Client client = referrer.getClient();
+        if (client == null) {
+            return getUrlForId(null);
+        } else {
+            UUID clientId = client.getId();
+            parentId = clientId == null ? null : clientId.toString();
+        }
+        return getUrlForEntity(parentId, childId);
+    }
+
+    /**
+     * Return the correct parent entity type from the provided context.
+     *
+     * @param context The context to extract the value from.
+     * @return The requested entity type under test.
+     */
+    @Override
+    protected Client getParentEntity(final EnvironmentBuilder context) {
+        return context.getReferrer().getClient();
+    }
+
+    /**
+     * Construct the request URL for this test given a specific resource ID.
+     *
+     * @param parentId The parent ID.
+     * @param childId  The Child ID.
+     * @return The resource URL.
+     */
+    private URI getUrlForEntity(final String parentId, final String childId) {
+        UriBuilder builder = UriBuilder
+                .fromPath("/client")
+                .path(parentId)
+                .path("redirect");
+
+        if (childId != null) {
+            builder.path(childId);
+        }
+
+        return builder.build();
+    }
+}

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ClientRedirectServiceCRUDTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ClientRedirectServiceCRUDTest.java
@@ -1,0 +1,414 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.servlet.admin.v1.resource;
+
+import net.krotscheck.kangaroo.database.entity.AbstractEntity;
+import net.krotscheck.kangaroo.database.entity.Client;
+import net.krotscheck.kangaroo.database.entity.ClientRedirect;
+import net.krotscheck.kangaroo.database.entity.ClientType;
+import net.krotscheck.kangaroo.servlet.admin.v1.Scope;
+import net.krotscheck.kangaroo.test.EnvironmentBuilder;
+import org.apache.http.HttpStatus;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.UUID;
+
+/**
+ * Unit test suite for the client redirect subresource.
+ */
+public final class ClientRedirectServiceCRUDTest
+        extends DAbstractSubserviceCRUDTest<Client, ClientRedirect> {
+
+    /**
+     * Create a new instance of this parameterized test.
+     *
+     * @param clientType    The type of  client.
+     * @param tokenScope    The client scope to issue.
+     * @param createUser    Whether to create a new user.
+     * @param shouldSucceed Should this test succeed?
+     */
+    public ClientRedirectServiceCRUDTest(final ClientType clientType,
+                                         final String tokenScope,
+                                         final Boolean createUser,
+                                         final Boolean shouldSucceed) {
+        super(Client.class, ClientRedirect.class, clientType, tokenScope,
+                createUser, shouldSucceed);
+    }
+
+    /**
+     * Test parameters.
+     *
+     * @return List of parameters used to reconstruct this test.
+     */
+    @Parameterized.Parameters
+    public static Collection parameters() {
+        return Arrays.asList(
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT_ADMIN,
+                        false,
+                        true
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT,
+                        false,
+                        true
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT_ADMIN,
+                        true,
+                        true
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT,
+                        true,
+                        false
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.CLIENT_ADMIN,
+                        false,
+                        true
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.CLIENT,
+                        false,
+                        false
+                });
+    }
+
+    /**
+     * Return the token scope required for admin access on this test.
+     *
+     * @return The correct scope string.
+     */
+    @Override
+    protected String getAdminScope() {
+        return Scope.CLIENT_ADMIN;
+    }
+
+    /**
+     * Return the token scope required for generic user access.
+     *
+     * @return The correct scope string.
+     */
+    @Override
+    protected String getRegularScope() {
+        return Scope.CLIENT;
+    }
+
+    /**
+     * Construct the request URL for this test given a specific resource ID.
+     *
+     * @param id The ID to use.
+     * @return The resource URL.
+     */
+    @Override
+    protected URI getUrlForId(final String id) {
+        String parentId = "";
+
+        Session s = getSession();
+        Transaction t = s.beginTransaction();
+        try {
+            ClientRedirect r = s.get(ClientRedirect.class, UUID.fromString(id));
+            parentId = r.getClient().getId().toString();
+        } catch (Exception e) {
+            parentId = getParentEntity(getAdminContext()).getId().toString();
+        } finally {
+            t.rollback();
+        }
+
+        return getUrlForEntity(parentId, id);
+    }
+
+    /**
+     * Construct the request URL for this test given a specific resource ID.
+     *
+     * @param entity The entity to use.
+     * @return The resource URL.
+     */
+    @Override
+    protected URI getUrlForEntity(final AbstractEntity entity) {
+        String parentId = "";
+        String childId = "";
+
+        ClientRedirect redirect = (ClientRedirect) entity;
+        if (redirect == null) {
+            return getUrlForId(null);
+        } else {
+            UUID redirectId = redirect.getId();
+            childId = redirectId == null ? null : redirectId.toString();
+        }
+
+        Client client = redirect.getClient();
+        if (client == null) {
+            return getUrlForId(null);
+        } else {
+            UUID clientId = client.getId();
+            parentId = clientId == null ? null : clientId.toString();
+        }
+        return getUrlForEntity(parentId, childId);
+    }
+
+    /**
+     * Construct the request URL for this test given a specific resource ID.
+     *
+     * @param parentId The parent ID.
+     * @param childId  The Child ID.
+     * @return The resource URL.
+     */
+    private URI getUrlForEntity(final String parentId, final String childId) {
+        UriBuilder builder = UriBuilder
+                .fromPath("/client")
+                .path(parentId)
+                .path("redirect");
+
+        if (childId != null) {
+            builder.path(childId);
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Return the correct parent entity type from the provided context.
+     *
+     * @param context The context to extract the value from.
+     * @return The requested entity type under test.
+     */
+    @Override
+    protected Client getParentEntity(final EnvironmentBuilder context) {
+        return context.getClient();
+    }
+
+    /**
+     * Given a parent entity and a context, create a valid entity.
+     *
+     * @param context The environment context.
+     * @param parent  The parent entity.
+     * @return A valid entity.
+     */
+    @Override
+    protected ClientRedirect createValidEntity(final EnvironmentBuilder context,
+                                               final Client parent) {
+        ClientRedirect r = new ClientRedirect();
+        r.setClient(parent);
+        r.setUri(URI.create(String.format("http://%s.example.com",
+                UUID.randomUUID())));
+        return r;
+    }
+
+    /**
+     * Create a valid parent entity for the given context.
+     *
+     * @param context The environment context.
+     * @return A valid entity.
+     */
+    @Override
+    protected Client createParentEntity(final EnvironmentBuilder context) {
+        Client c = new Client();
+        c.setApplication(context.getApplication());
+        c.setName(UUID.randomUUID().toString());
+        c.setType(ClientType.AuthorizationGrant);
+        return c;
+    }
+
+    /**
+     * Return the correct testingEntity type from the provided context.
+     *
+     * @param context The context to extract the value from.
+     * @return The requested entity type under test.
+     */
+    @Override
+    protected ClientRedirect getEntity(final EnvironmentBuilder context) {
+        return context.getRedirect();
+    }
+
+    /**
+     * Return a new, empty entity.
+     *
+     * @return The requested entity type under test.
+     */
+    @Override
+    protected ClientRedirect getNewEntity() {
+        ClientRedirect newEntity = new ClientRedirect();
+        newEntity.setClient(getAdminContext().getClient());
+        return newEntity;
+    }
+
+    /**
+     * Assert that some users may create entities for other parents.
+     *
+     * @throws Exception Exception encountered during test.
+     */
+    @Test
+    public void testPostNoUri() throws Exception {
+        ClientRedirect testEntity = createValidEntity(getSecondaryContext());
+        testEntity.setUri(null);
+
+        // Issue the request.
+        Response r = postEntity(testEntity, getAdminToken());
+        assertErrorResponse(r, Status.BAD_REQUEST);
+    }
+
+    /**
+     * Assert that some users may create entities for other parents.
+     *
+     * @throws Exception Exception encountered during test.
+     */
+    @Test
+    public void testPostDuplicate() throws Exception {
+        ClientRedirect testEntity = createValidEntity(getSecondaryContext());
+        testEntity.setUri(getSecondaryContext().getRedirect().getUri());
+
+        // Issue the request.
+        Response r = postEntity(testEntity, getAdminToken());
+        if (shouldSucceed()) {
+            assertErrorResponse(r, Status.CONFLICT);
+        } else {
+            assertErrorResponse(r, Status.BAD_REQUEST);
+        }
+    }
+
+    /**
+     * Assert that some users may create entities for other parents.
+     *
+     * @throws Exception Exception encountered during test.
+     */
+    @Test
+    public void testPut() throws Exception {
+        EnvironmentBuilder builder = getAdminContext();
+        ClientRedirect oldEntity = builder.getRedirect();
+
+        // Copy the most recent, then use the redirect from the previous.
+        ClientRedirect cr = new ClientRedirect();
+        cr.setClient(oldEntity.getClient());
+        cr.setId(oldEntity.getId());
+        cr.setUri(URI.create("http://new.example.com/redirect"));
+
+        // Issue the request.
+        Response r = putEntity(cr, getAdminToken());
+        if (shouldSucceed()) {
+            ClientRedirect response = r.readEntity(ClientRedirect.class);
+            Assert.assertEquals(HttpStatus.SC_OK, r.getStatus());
+            Assert.assertEquals(cr, response);
+        } else {
+            assertErrorResponse(r, Status.NOT_FOUND);
+        }
+    }
+
+    /**
+     * Assert that some users may create entities for other parents.
+     *
+     * @throws Exception Exception encountered during test.
+     */
+    @Test
+    public void testPutNoUri() throws Exception {
+        EnvironmentBuilder builder = getAdminContext();
+        ClientRedirect oldEntity = builder.getRedirect();
+
+        // Copy the most recent, then use the redirect from the previous.
+        ClientRedirect duplicateRedirect = new ClientRedirect();
+        duplicateRedirect.setClient(oldEntity.getClient());
+        duplicateRedirect.setId(oldEntity.getId());
+        duplicateRedirect.setUri(null);
+
+        // Issue the request.
+        Response r = putEntity(duplicateRedirect, getAdminToken());
+        if (shouldSucceed()) {
+            assertErrorResponse(r, Status.BAD_REQUEST);
+        } else {
+            assertErrorResponse(r, Status.NOT_FOUND);
+        }
+    }
+
+    /**
+     * Assert that some users may create entities for other parents.
+     *
+     * @throws Exception Exception encountered during test.
+     */
+    @Test
+    public void testPutDuplicate() throws Exception {
+        EnvironmentBuilder builder = getAdminContext()
+                .redirect("http://another.example.com")
+                .redirect("http://yet.another.example.com");
+        ClientRedirect oldEntity = builder.getRedirect();
+
+        // Copy the most recent, then use the redirect from the previous.
+        ClientRedirect duplicateRedirect = new ClientRedirect();
+        duplicateRedirect.setClient(oldEntity.getClient());
+        duplicateRedirect.setId(oldEntity.getId());
+        duplicateRedirect.setUri(URI.create("http://another.example.com"));
+
+        // Issue the request.
+        Response r = putEntity(duplicateRedirect, getAdminToken());
+        if (shouldSucceed()) {
+            assertErrorResponse(r, Status.CONFLICT);
+        } else {
+            assertErrorResponse(r, Status.NOT_FOUND);
+        }
+    }
+
+    /**
+     * Assert that the admin app cannot be deleted, even if we have all the
+     * credentials in the world.
+     *
+     * @throws Exception Exception encountered during test.
+     */
+    @Test
+    public void testDeleteAdminApp() throws Exception {
+        EnvironmentBuilder context = getAdminContext();
+
+        // Issue the request.
+        Response r = deleteEntity(context.getRedirect(), getAdminToken());
+
+        if (shouldSucceed()) {
+            assertErrorResponse(r, Status.FORBIDDEN);
+        } else {
+            assertErrorResponse(r, Status.NOT_FOUND);
+        }
+    }
+
+    /**
+     * Sanity test for coverage on the scope getters.
+     *
+     * @throws Exception Exception encountered during test.
+     */
+    @Test
+    public void testScopes() throws Exception {
+        ClientRedirectService cs = new ClientRedirectService(UUID.randomUUID());
+
+        Assert.assertEquals(Scope.CLIENT_ADMIN, cs.getAdminScope());
+        Assert.assertEquals(Scope.CLIENT, cs.getAccessScope());
+    }
+}

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ClientReferrerServiceBrowseTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ClientReferrerServiceBrowseTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.servlet.admin.v1.resource;
+
+import net.krotscheck.kangaroo.database.entity.AbstractEntity;
+import net.krotscheck.kangaroo.database.entity.Client;
+import net.krotscheck.kangaroo.database.entity.ClientReferrer;
+import net.krotscheck.kangaroo.database.entity.ClientType;
+import net.krotscheck.kangaroo.database.entity.OAuthToken;
+import net.krotscheck.kangaroo.database.entity.User;
+import net.krotscheck.kangaroo.servlet.admin.v1.Scope;
+import net.krotscheck.kangaroo.test.EnvironmentBuilder;
+import org.hibernate.Criteria;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.criterion.Restrictions;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Test the list and filter methods of the ClientReferrer service.
+ *
+ * @author Michael Krotscheck
+ */
+@RunWith(Parameterized.class)
+public final class ClientReferrerServiceBrowseTest
+        extends DAbstractSubserviceBrowseTest<Client, ClientReferrer> {
+
+    /**
+     * Generic type declaration for list decoding.
+     */
+    private static final GenericType<List<ClientReferrer>> LIST_TYPE =
+            new GenericType<List<ClientReferrer>>() {
+
+            };
+
+    /**
+     * Create a new instance of this parameterized test.
+     *
+     * @param clientType The type of client.
+     * @param tokenScope The client scope to issue.
+     * @param createUser Whether to create a new user.
+     */
+    public ClientReferrerServiceBrowseTest(final ClientType clientType,
+                                           final String tokenScope,
+                                           final Boolean createUser) {
+        super(clientType, tokenScope, createUser);
+    }
+
+    /**
+     * Return the token scope required for admin access on this test.
+     *
+     * @return The correct scope string.
+     */
+    @Override
+    protected String getAdminScope() {
+        return Scope.CLIENT_ADMIN;
+    }
+
+    /**
+     * Return the token scope required for generic user access.
+     *
+     * @return The correct scope string.
+     */
+    @Override
+    protected String getRegularScope() {
+        return Scope.CLIENT;
+    }
+
+    /**
+     * Return the list type used to decode browse results.
+     *
+     * @return The list type.
+     */
+    @Override
+    protected GenericType<List<ClientReferrer>> getListType() {
+        return LIST_TYPE;
+    }
+
+    /**
+     * Return the list of entities which should be accessible given a
+     * specific token.
+     *
+     * @param parentEntity The client to filter against.
+     * @param token        The oauth token to test against.
+     * @return A list of entities (could be empty).
+     */
+    @Override
+    protected List<ClientReferrer> getAccessibleEntities(
+            final Client parentEntity,
+            final OAuthToken token) {
+        // If you're an admin, you get to see everything. If you're not, you
+        // only get to see what you own.
+        if (!token.getScopes().containsKey(getAdminScope())) {
+            return getOwnedEntities(parentEntity, token);
+        }
+
+        // We know you're an admin. Get all applications in the system.
+        Criteria criteria = getSession().createCriteria(ClientReferrer.class)
+                .add(Restrictions.eq("client", parentEntity));
+
+        // Get all the owned clients.
+        return ((List<ClientReferrer>) criteria.list());
+    }
+
+    /**
+     * Return the list of entities which are owned by the given oauth token.
+     *
+     * @param parentEntity The client to filter against.
+     * @param owner        The owner of these entities.
+     * @return A list of entities (could be empty).
+     */
+    @Override
+    protected List<ClientReferrer> getOwnedEntities(final Client parentEntity,
+                                                    final User owner) {
+        // Get all the owned clients.
+        return owner.getApplications()
+                .stream()
+                .flatMap(a -> a.getClients().stream())
+                .filter(c -> c.equals(parentEntity))
+                .flatMap(c -> c.getReferrers().stream())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Test parameters.
+     *
+     * @return The list of parameters.
+     */
+    @Parameterized.Parameters
+    public static Collection parameters() {
+        return Arrays.asList(
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT_ADMIN,
+                        false
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT,
+                        false
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT_ADMIN,
+                        true
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT,
+                        true
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.CLIENT_ADMIN,
+                        false
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.CLIENT,
+                        false
+                });
+    }
+
+    /**
+     * Construct the request URL for this test given a specific resource ID.
+     *
+     * @param id The ID to use.
+     * @return The resource URL.
+     */
+    @Override
+    protected URI getUrlForId(final String id) {
+        String parentId = "";
+
+        Session s = getSession();
+        Transaction t = s.beginTransaction();
+        try {
+            ClientReferrer r = s.get(ClientReferrer.class, UUID.fromString(id));
+            parentId = r.getClient().getId().toString();
+        } catch (Exception e) {
+            parentId = getParentEntity(getAdminContext()).getId().toString();
+        } finally {
+            t.rollback();
+        }
+
+        return getUrlForEntity(parentId, id);
+    }
+
+    /**
+     * Construct the request URL for this test given a specific resource ID.
+     *
+     * @param entity The entity to use.
+     * @return The resource URL.
+     */
+    @Override
+    protected URI getUrlForEntity(final AbstractEntity entity) {
+        String parentId = "";
+        String childId = "";
+
+        ClientReferrer referrer = (ClientReferrer) entity;
+        if (referrer == null) {
+            return getUrlForId(null);
+        } else {
+            UUID referrerId = referrer.getId();
+            childId = referrerId == null ? null : referrerId.toString();
+        }
+
+        Client client = referrer.getClient();
+        if (client == null) {
+            return getUrlForId(null);
+        } else {
+            UUID clientId = client.getId();
+            parentId = clientId == null ? null : clientId.toString();
+        }
+        return getUrlForEntity(parentId, childId);
+    }
+
+    /**
+     * Return the correct parent entity type from the provided context.
+     *
+     * @param context The context to extract the value from.
+     * @return The requested entity type under test.
+     */
+    @Override
+    protected Client getParentEntity(final EnvironmentBuilder context) {
+        return context.getReferrer().getClient();
+    }
+
+    /**
+     * Construct the request URL for this test given a specific resource ID.
+     *
+     * @param parentId The parent ID.
+     * @param childId  The Child ID.
+     * @return The resource URL.
+     */
+    private URI getUrlForEntity(final String parentId, final String childId) {
+        UriBuilder builder = UriBuilder
+                .fromPath("/client")
+                .path(parentId)
+                .path("referrer");
+
+        if (childId != null) {
+            builder.path(childId);
+        }
+
+        return builder.build();
+    }
+}

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ClientReferrerServiceCRUDTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ClientReferrerServiceCRUDTest.java
@@ -1,0 +1,415 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.servlet.admin.v1.resource;
+
+import net.krotscheck.kangaroo.database.entity.AbstractEntity;
+import net.krotscheck.kangaroo.database.entity.Client;
+import net.krotscheck.kangaroo.database.entity.ClientReferrer;
+import net.krotscheck.kangaroo.database.entity.ClientType;
+import net.krotscheck.kangaroo.servlet.admin.v1.Scope;
+import net.krotscheck.kangaroo.test.EnvironmentBuilder;
+import org.apache.http.HttpStatus;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.UUID;
+
+/**
+ * Unit test suite for the client redirect subresource.
+ */
+public final class ClientReferrerServiceCRUDTest
+        extends DAbstractSubserviceCRUDTest<Client, ClientReferrer> {
+
+    /**
+     * Create a new instance of this parameterized test.
+     *
+     * @param clientType    The type of  client.
+     * @param tokenScope    The client scope to issue.
+     * @param createUser    Whether to create a new user.
+     * @param shouldSucceed Should this test succeed?
+     */
+    public ClientReferrerServiceCRUDTest(final ClientType clientType,
+                                         final String tokenScope,
+                                         final Boolean createUser,
+                                         final Boolean shouldSucceed) {
+        super(Client.class, ClientReferrer.class, clientType, tokenScope,
+                createUser, shouldSucceed);
+    }
+
+    /**
+     * Test parameters.
+     *
+     * @return List of parameters used to reconstruct this test.
+     */
+    @Parameterized.Parameters
+    public static Collection parameters() {
+        return Arrays.asList(
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT_ADMIN,
+                        false,
+                        true
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT,
+                        false,
+                        true
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT_ADMIN,
+                        true,
+                        true
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT,
+                        true,
+                        false
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.CLIENT_ADMIN,
+                        false,
+                        true
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.CLIENT,
+                        false,
+                        false
+                });
+    }
+
+    /**
+     * Return the token scope required for admin access on this test.
+     *
+     * @return The correct scope string.
+     */
+    @Override
+    protected String getAdminScope() {
+        return Scope.CLIENT_ADMIN;
+    }
+
+    /**
+     * Return the token scope required for generic user access.
+     *
+     * @return The correct scope string.
+     */
+    @Override
+    protected String getRegularScope() {
+        return Scope.CLIENT;
+    }
+
+    /**
+     * Construct the request URL for this test given a specific resource ID.
+     *
+     * @param id The ID to use.
+     * @return The resource URL.
+     */
+    @Override
+    protected URI getUrlForId(final String id) {
+        String parentId = "";
+
+        Session s = getSession();
+        Transaction t = s.beginTransaction();
+        try {
+            ClientReferrer r = s.get(ClientReferrer.class, UUID.fromString(id));
+            parentId = r.getClient().getId().toString();
+        } catch (Exception e) {
+            parentId = getParentEntity(getAdminContext()).getId().toString();
+        } finally {
+            t.rollback();
+        }
+
+        return getUrlForEntity(parentId, id);
+    }
+
+    /**
+     * Construct the request URL for this test given a specific resource ID.
+     *
+     * @param entity The entity to use.
+     * @return The resource URL.
+     */
+    @Override
+    protected URI getUrlForEntity(final AbstractEntity entity) {
+        String parentId = "";
+        String childId = "";
+
+        ClientReferrer referrer = (ClientReferrer) entity;
+        if (referrer == null) {
+            return getUrlForId(null);
+        } else {
+            UUID referrerId = referrer.getId();
+            childId = referrerId == null ? null : referrerId.toString();
+        }
+
+        Client client = referrer.getClient();
+        if (client == null) {
+            return getUrlForId(null);
+        } else {
+            UUID clientId = client.getId();
+            parentId = clientId == null ? null : clientId.toString();
+        }
+        return getUrlForEntity(parentId, childId);
+    }
+
+    /**
+     * Construct the request URL for this test given a specific resource ID.
+     *
+     * @param parentId The parent ID.
+     * @param childId  The Child ID.
+     * @return The resource URL.
+     */
+    private URI getUrlForEntity(final String parentId, final String childId) {
+        UriBuilder builder = UriBuilder
+                .fromPath("/client")
+                .path(parentId)
+                .path("referrer");
+
+        if (childId != null) {
+            builder.path(childId);
+        }
+
+        return builder.build();
+    }
+
+
+    /**
+     * Return the correct parent entity type from the provided context.
+     *
+     * @param context The context to extract the value from.
+     * @return The requested entity type under test.
+     */
+    @Override
+    protected Client getParentEntity(final EnvironmentBuilder context) {
+        return context.getClient();
+    }
+
+    /**
+     * Given a parent entity and a context, create a valid entity.
+     *
+     * @param context The environment context.
+     * @param parent  The parent entity.
+     * @return A valid entity.
+     */
+    @Override
+    protected ClientReferrer createValidEntity(final EnvironmentBuilder context,
+                                               final Client parent) {
+        ClientReferrer r = new ClientReferrer();
+        r.setClient(parent);
+        r.setUri(URI.create(String.format("http://%s.example.com",
+                UUID.randomUUID())));
+        return r;
+    }
+
+    /**
+     * Create a valid parent entity for the given context.
+     *
+     * @param context The environment context.
+     * @return A valid entity.
+     */
+    @Override
+    protected Client createParentEntity(final EnvironmentBuilder context) {
+        Client c = new Client();
+        c.setApplication(context.getApplication());
+        c.setName(UUID.randomUUID().toString());
+        c.setType(ClientType.AuthorizationGrant);
+        return c;
+    }
+
+    /**
+     * Return the correct testingEntity type from the provided context.
+     *
+     * @param context The context to extract the value from.
+     * @return The requested entity type under test.
+     */
+    @Override
+    protected ClientReferrer getEntity(final EnvironmentBuilder context) {
+        return context.getReferrer();
+    }
+
+    /**
+     * Return a new, empty entity.
+     *
+     * @return The requested entity type under test.
+     */
+    @Override
+    protected ClientReferrer getNewEntity() {
+        ClientReferrer newEntity = new ClientReferrer();
+        newEntity.setClient(getAdminContext().getClient());
+        return newEntity;
+    }
+
+    /**
+     * Assert that some users may create entities for other parents.
+     *
+     * @throws Exception Exception encountered during test.
+     */
+    @Test
+    public void testPostNoUri() throws Exception {
+        ClientReferrer testEntity = createValidEntity(getSecondaryContext());
+        testEntity.setUri(null);
+
+        // Issue the request.
+        Response r = postEntity(testEntity, getAdminToken());
+        assertErrorResponse(r, Status.BAD_REQUEST);
+    }
+
+    /**
+     * Assert that some users may create entities for other parents.
+     *
+     * @throws Exception Exception encountered during test.
+     */
+    @Test
+    public void testPostDuplicate() throws Exception {
+        ClientReferrer testEntity = createValidEntity(getSecondaryContext());
+        testEntity.setUri(getSecondaryContext().getReferrer().getUri());
+
+        // Issue the request.
+        Response r = postEntity(testEntity, getAdminToken());
+        if (shouldSucceed()) {
+            assertErrorResponse(r, Status.CONFLICT);
+        } else {
+            assertErrorResponse(r, Status.BAD_REQUEST);
+        }
+    }
+
+    /**
+     * Assert that some users may create entities for other parents.
+     *
+     * @throws Exception Exception encountered during test.
+     */
+    @Test
+    public void testPut() throws Exception {
+        EnvironmentBuilder builder = getAdminContext();
+        ClientReferrer oldEntity = builder.getReferrer();
+
+        // Copy the most recent, then use the referrer from the previous.
+        ClientReferrer cr = new ClientReferrer();
+        cr.setClient(oldEntity.getClient());
+        cr.setId(oldEntity.getId());
+        cr.setUri(URI.create("http://new.example.com/referrer"));
+
+        // Issue the request.
+        Response r = putEntity(cr, getAdminToken());
+        if (shouldSucceed()) {
+            ClientReferrer response = r.readEntity(ClientReferrer.class);
+            Assert.assertEquals(HttpStatus.SC_OK, r.getStatus());
+            Assert.assertEquals(cr, response);
+        } else {
+            assertErrorResponse(r, Status.NOT_FOUND);
+        }
+    }
+
+    /**
+     * Assert that some users may create entities for other parents.
+     *
+     * @throws Exception Exception encountered during test.
+     */
+    @Test
+    public void testPutNoUri() throws Exception {
+        EnvironmentBuilder builder = getAdminContext();
+        ClientReferrer oldEntity = builder.getReferrer();
+
+        // Copy the most recent, then use the referrer from the previous.
+        ClientReferrer duplicateReferrer = new ClientReferrer();
+        duplicateReferrer.setClient(oldEntity.getClient());
+        duplicateReferrer.setId(oldEntity.getId());
+        duplicateReferrer.setUri(null);
+
+        // Issue the request.
+        Response r = putEntity(duplicateReferrer, getAdminToken());
+        if (shouldSucceed()) {
+            assertErrorResponse(r, Status.BAD_REQUEST);
+        } else {
+            assertErrorResponse(r, Status.NOT_FOUND);
+        }
+    }
+
+    /**
+     * Assert that some users may create entities for other parents.
+     *
+     * @throws Exception Exception encountered during test.
+     */
+    @Test
+    public void testPutDuplicate() throws Exception {
+        EnvironmentBuilder builder = getAdminContext()
+                .referrer("http://another.example.com")
+                .referrer("http://yet.another.example.com");
+        ClientReferrer oldEntity = builder.getReferrer();
+
+        // Copy the most recent, then use the referrer from the previous.
+        ClientReferrer duplicateReferrer = new ClientReferrer();
+        duplicateReferrer.setClient(oldEntity.getClient());
+        duplicateReferrer.setId(oldEntity.getId());
+        duplicateReferrer.setUri(URI.create("http://another.example.com"));
+
+        // Issue the request.
+        Response r = putEntity(duplicateReferrer, getAdminToken());
+        if (shouldSucceed()) {
+            assertErrorResponse(r, Status.CONFLICT);
+        } else {
+            assertErrorResponse(r, Status.NOT_FOUND);
+        }
+    }
+
+    /**
+     * Assert that the admin app cannot be deleted, even if we have all the
+     * credentials in the world.
+     *
+     * @throws Exception Exception encountered during test.
+     */
+    @Test
+    public void testDeleteAdminApp() throws Exception {
+        EnvironmentBuilder context = getAdminContext();
+
+        // Issue the request.
+        Response r = deleteEntity(context.getReferrer(), getAdminToken());
+
+        if (shouldSucceed()) {
+            assertErrorResponse(r, Status.FORBIDDEN);
+        } else {
+            assertErrorResponse(r, Status.NOT_FOUND);
+        }
+    }
+
+    /**
+     * Sanity test for coverage on the scope getters.
+     *
+     * @throws Exception Exception encountered during test.
+     */
+    @Test
+    public void testScopes() throws Exception {
+        ClientReferrerService cs = new ClientReferrerService(UUID.randomUUID());
+
+        Assert.assertEquals(Scope.CLIENT_ADMIN, cs.getAdminScope());
+        Assert.assertEquals(Scope.CLIENT, cs.getAccessScope());
+    }
+}

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ClientServiceCRUDTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ClientServiceCRUDTest.java
@@ -21,6 +21,8 @@ package net.krotscheck.kangaroo.servlet.admin.v1.resource;
 import net.krotscheck.kangaroo.database.entity.AbstractEntity;
 import net.krotscheck.kangaroo.database.entity.Application;
 import net.krotscheck.kangaroo.database.entity.Client;
+import net.krotscheck.kangaroo.database.entity.ClientRedirect;
+import net.krotscheck.kangaroo.database.entity.ClientReferrer;
 import net.krotscheck.kangaroo.database.entity.ClientType;
 import net.krotscheck.kangaroo.servlet.admin.v1.Scope;
 import net.krotscheck.kangaroo.test.EnvironmentBuilder;
@@ -190,10 +192,22 @@ public final class ClientServiceCRUDTest
         c.setName(RandomStringUtils.randomAlphanumeric(10));
         c.setClientSecret(RandomStringUtils.randomAlphanumeric(10));
         c.setType(ClientType.ClientCredentials);
-        c.getRedirects().add(URI.create("http://example.com/redirect1"));
-        c.getRedirects().add(URI.create("http://example.com/redirect2"));
-        c.getReferrers().add(URI.create("http://example.com/referrer1"));
-        c.getReferrers().add(URI.create("http://example.com/referrer2"));
+
+        ClientRedirect redirect1 = new ClientRedirect();
+        redirect1.setUri(URI.create("http://example.com/redirect1"));
+        ClientRedirect redirect2 = new ClientRedirect();
+        redirect2.setUri(URI.create("http://example.com/redirect2"));
+
+        ClientReferrer referrer1 = new ClientReferrer();
+        referrer1.setUri(URI.create("http://example.com/redirect1"));
+        ClientReferrer referrer2 = new ClientReferrer();
+        referrer2.setUri(URI.create("http://example.com/redirect2"));
+
+        c.getRedirects().add(redirect1);
+        c.getRedirects().add(redirect2);
+        c.getReferrers().add(referrer1);
+        c.getReferrers().add(referrer2);
+
         c.getConfiguration().put("foo", "bar");
         c.getConfiguration().put("lol", "cat");
         return c;

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/DAbstractSubserviceBrowseTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/DAbstractSubserviceBrowseTest.java
@@ -1,0 +1,622 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.servlet.admin.v1.resource;
+
+import net.krotscheck.kangaroo.common.response.ApiParam;
+import net.krotscheck.kangaroo.database.entity.AbstractEntity;
+import net.krotscheck.kangaroo.database.entity.Client;
+import net.krotscheck.kangaroo.database.entity.ClientType;
+import net.krotscheck.kangaroo.database.entity.OAuthToken;
+import net.krotscheck.kangaroo.database.entity.User;
+import net.krotscheck.kangaroo.servlet.admin.v1.Scope;
+import net.krotscheck.kangaroo.test.EnvironmentBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Abstract class for subresource browsing.
+ *
+ * @param <T> The type of entity to execute this test for.
+ * @author Michael Krotscheck
+ */
+@Deprecated
+@RunWith(Parameterized.class)
+public abstract class DAbstractSubserviceBrowseTest<K extends AbstractEntity,
+        T extends AbstractEntity> extends DAbstractResourceTest {
+
+    /**
+     * The scope to grant the issued token.
+     */
+    private final String tokenScope;
+
+    /**
+     * The type of OAuth2 client to create.
+     */
+    private final ClientType clientType;
+
+    /**
+     * The client under test.
+     */
+    private Client client;
+
+    /**
+     * Whether to create a user, or fall back on an existing user. In most
+     * cases, this will fall back to the owner of the admin scope.
+     */
+    private final Boolean createUser;
+
+    /**
+     * The token issued to the admin app, with appropriate credentials.
+     */
+    private OAuthToken adminAppToken;
+
+    /**
+     * An additional application context used for testing.
+     */
+    private EnvironmentBuilder otherApp;
+
+    /**
+     * Create a new instance of this parameterized test.
+     *
+     * @param clientType The type of  client.
+     * @param tokenScope The client scope to issue.
+     * @param createUser Whether to create a new user.
+     */
+    public DAbstractSubserviceBrowseTest(final ClientType clientType,
+                                         final String tokenScope,
+                                         final Boolean createUser) {
+        this.tokenScope = tokenScope;
+        this.clientType = clientType;
+        this.createUser = createUser;
+    }
+
+    /**
+     * Return the appropriate list type for this test suite.
+     *
+     * @return The list type, used for test decoding.
+     */
+    protected abstract GenericType<List<T>> getListType();
+
+    /**
+     * Return the list of entities which should be accessible given a
+     * specific token and parent entity.
+     *
+     * @param parentEntity The parent entity to filter on.
+     * @param token        The oauth token to test against.
+     * @return A list of entities (could be empty).
+     */
+    protected abstract List<T> getAccessibleEntities(K parentEntity,
+                                                     OAuthToken token);
+
+    /**
+     * Return the list of entities which are owned by the given oauth token.
+     *
+     * @param parentEntity The parent entity to filter on.
+     * @param owner        The owner of these entities.
+     * @return A list of entities (could be empty).
+     */
+    protected abstract List<T> getOwnedEntities(K parentEntity, User owner);
+
+    /**
+     * Return the list of entities which should be accessible given a
+     * specific token.
+     *
+     * @param parentEntity The parent entity to filter on.
+     * @return The list of entities.
+     */
+    protected final List<T> getAccessibleEntities(final K parentEntity) {
+        return getAccessibleEntities(parentEntity, getAdminToken());
+    }
+
+    /**
+     * Return the list of entities which are owned by the current user.
+     *
+     * @param parentEntity The parent entity to filter on.
+     * @return The list of entities.
+     */
+    protected final List<T> getOwnedEntities(final K parentEntity) {
+        if (getAdminToken().getIdentity() == null) {
+            return Collections.emptyList();
+        } else {
+            return getOwnedEntities(parentEntity,
+                    getAdminToken().getIdentity().getUser());
+        }
+    }
+
+    /**
+     * Return the list of entities which are owned by the provided token.
+     *
+     * @param parentEntity The parent entity to filter on.
+     * @param token        The token!
+     * @return The list of entities.
+     */
+    protected final List<T> getOwnedEntities(final K parentEntity,
+                                             final OAuthToken token) {
+        if (token.getIdentity() == null) {
+            return Collections.emptyList();
+        } else {
+            return getOwnedEntities(parentEntity,
+                    getAdminToken().getIdentity().getUser());
+        }
+    }
+
+    /**
+     * Return the second application context (not the admin context).
+     *
+     * @return The secondary context in this test.
+     */
+    protected final EnvironmentBuilder getSecondaryContext() {
+        return otherApp;
+    }
+
+    /**
+     * Return the oauth token for the primary application.
+     *
+     * @return The application token.
+     */
+    protected final OAuthToken getAdminToken() {
+        return adminAppToken;
+    }
+
+    /**
+     * Return the oauth token for the secondary application.
+     *
+     * @return The application token.
+     */
+    protected final OAuthToken getSecondaryToken() {
+        return otherApp.getToken();
+    }
+
+    /**
+     * Return the client under test.
+     *
+     * @return The client under test.
+     */
+    public final Client getAdminClient() {
+        return client;
+    }
+
+    /**
+     * Retrieve the scope under test.
+     *
+     * @return The scope that's being tested.
+     */
+    public final String getTokenScope() {
+        return tokenScope;
+    }
+
+    /**
+     * Return true if the current test parameters indicate a Client
+     * Credentials-based client without any admin credentials. These types of
+     * clients have no identity assigned to them, and therefore cannot 'own'
+     * any resources which they could then access.
+     *
+     * @return True if this is a Client Credentials client without admin scope.
+     */
+    protected final Boolean isLimitedByClientCredentials() {
+        return clientType.equals(ClientType.ClientCredentials)
+                && tokenScope.equals(getRegularScope());
+    }
+
+    /**
+     * Return the correct parent entity type from the provided context.
+     *
+     * @param context The context to extract the value from.
+     * @return The requested entity type under test.
+     */
+    protected abstract K getParentEntity(EnvironmentBuilder context);
+
+    /**
+     * Load data fixtures for each test. Here we're creating two applications
+     * with different owners, using the kangaroo default scopes so we have
+     * some good cross-app name duplication.
+     *
+     * @return A list of fixtures, which will be cleared after the test.
+     * @throws Exception An exception that indicates a failed fixture load.
+     */
+    @Override
+    public final List<EnvironmentBuilder> fixtures(
+            final EnvironmentBuilder adminApp) throws Exception {
+        List<EnvironmentBuilder> fixtures = new ArrayList<>();
+
+        // Get the admin app and create users based on the configured
+        // parameters.
+        EnvironmentBuilder context = getAdminContext()
+                .client(clientType);
+
+        client = context.getClient();
+
+        // Create a whole lot of applications to run some tests against.
+        for (int i = 0; i < 10; i++) {
+            String appName = String.format("Application %s- %s", i, i % 2 == 0
+                    ? "many" : "frown");
+            fixtures.add(new EnvironmentBuilder(getSession(), appName)
+                    .owner(adminApp.getUser()));
+        }
+        fixtures.add(new EnvironmentBuilder(getSession(), "Single")
+                .owner(adminApp.getUser()));
+
+
+        if (createUser) {
+            context.user().identity();
+        }
+        adminAppToken = context.bearerToken(tokenScope).getToken();
+
+        // Create a whole lot more applications to run some tests against.
+        for (int i = 0; i < 10; i++) {
+            String appName = String.format("Application %s- %s", i, i % 2 == 0
+                    ? "many" : "frown");
+            fixtures.add(new EnvironmentBuilder(getSession(), appName)
+                    .owner(adminApp.getUser()));
+        }
+        fixtures.add(new EnvironmentBuilder(getSession(), "Single")
+                .owner(adminApp.getUser()));
+
+        // Create a second app, owned by another user.
+        otherApp = new EnvironmentBuilder(getSession())
+                .owner(context.getUser())
+                .scopes(Scope.allScopes());
+
+        // Add some data for scopes
+        context.scope("Single Scope");
+        context.scope("Second Scope - many");
+        context.scope("Third Scope - many");
+        context.scope("Fourth Scope - many");
+        otherApp.scope("Single Scope");
+        otherApp.scope("Second Scope - many");
+        otherApp.scope("Third Scope - many");
+        otherApp.scope("Fourth Scope - many");
+
+        // Add some test data for clients
+        context.client(ClientType.ClientCredentials, "Single client");
+        context.authenticator("Single authenticator");
+        context.client(ClientType.ClientCredentials, "Second client - many");
+        context.authenticator("Second authenticator - many");
+        context.client(ClientType.Implicit, "Third client - many");
+        context.authenticator("Third authenticator - many");
+        context.client(ClientType.AuthorizationGrant, "Fourth client - many");
+        context.authenticator("Fourth authenticator - many");
+        otherApp.client(ClientType.ClientCredentials, "Single client");
+        otherApp.authenticator("Single authenticator");
+        otherApp.client(ClientType.ClientCredentials, "Second client - many");
+        otherApp.authenticator("Second authenticator - many");
+        otherApp.client(ClientType.Implicit, "Third client - many");
+        otherApp.authenticator("Third authenticator - many");
+        otherApp.client(ClientType.AuthorizationGrant, "Fourth client - many");
+        otherApp.authenticator("Fourth authenticator - many");
+
+        // Add some data for roles
+        context.role("Single Role");
+        context.role("Second Role - many");
+        context.role("Third Role - many");
+        context.role("Fourth Role - many");
+        otherApp.role("Single Role");
+        otherApp.role("Second Role - many");
+        otherApp.role("Third Role - many");
+        otherApp.role("Fourth Role - many");
+
+        // Create some users
+        context.user()
+                .identity()
+                .claim("name", "Single User");
+        context.user()
+                .identity()
+                .claim("name", "Second User - many");
+        context.user()
+                .identity()
+                .claim("name", "Third User - many");
+        context.user()
+                .identity()
+                .claim("name", "Fourth User - many");
+        otherApp.user()
+                .identity()
+                .claim("name", "Single User");
+        otherApp.user()
+                .identity()
+                .claim("name", "Second User - many");
+        otherApp.user()
+                .identity()
+                .claim("name", "Third User - many");
+        otherApp.user()
+                .identity()
+                .claim("name", "Fourth User - many");
+
+        // Create a bunch of tokens
+        context.redirect("http://single.token.example.com/")
+                .authToken();
+        context.redirect("http://second.token.example.com/many")
+                .authToken();
+        context.redirect("http://third.token.example.com/many")
+                .authToken();
+        context.redirect("http://fourth.token.example.com/many")
+                .authToken();
+        otherApp.redirect("http://single.token.example.com/")
+                .authToken();
+        otherApp.redirect("http://second.token.example.com/many")
+                .authToken();
+        otherApp.redirect("http://third.token.example.com/many")
+                .authToken();
+        otherApp.redirect("http://fourth.token.example.com/many")
+                .authToken();
+
+        // Create a bunch of referrers
+        context.referrer("http://single.referrer.example.com/");
+        context.referrer("http://second.referrer.example.com/many");
+        context.referrer("http://third.referrer.example.com/many");
+        context.referrer("http://fourth.referrer.example.com/many");
+        otherApp.referrer("http://single.referrer.example.com/");
+        otherApp.referrer("http://second.referrer.example.com/many");
+        otherApp.referrer("http://third.referrer.example.com/many");
+        otherApp.referrer("http://fourth.referrer.example.com/many");
+
+        fixtures.add(otherApp);
+        return fixtures;
+    }
+
+    /**
+     * Assert that you can browse applications.
+     */
+    @Test
+    public final void testBrowse() {
+        Map<String, String> params = new HashMap<>();
+        Response r = browse(params, adminAppToken);
+
+        K parentEntity = getParentEntity(getAdminContext());
+        Integer expectedResults = getAccessibleEntities(parentEntity,
+                adminAppToken).size();
+
+        if (isLimitedByClientCredentials()) {
+            assertErrorResponse(r, Status.NOT_FOUND.getStatusCode(),
+                    "not_found");
+        } else if (!isAccessible(parentEntity, adminAppToken)) {
+            assertErrorResponse(r, Status.NOT_FOUND.getStatusCode(),
+                    "not_found");
+        } else {
+            List<T> results = r.readEntity(getListType());
+            Assert.assertEquals("0", r.getHeaderString("Offset"));
+            Assert.assertEquals("10", r.getHeaderString("Limit"));
+            Assert.assertEquals(expectedResults.toString(),
+                    r.getHeaderString("Total"));
+            Assert.assertEquals(Math.min(expectedResults, 10), results.size());
+        }
+    }
+
+    /**
+     * Assert that you can browse with a limit set.
+     */
+    @Test
+    public final void testBrowseLimit() {
+        Integer limit = 2;
+        Map<String, String> params = new HashMap<>();
+        params.put("limit", limit.toString());
+
+        K parentEntity = getParentEntity(getAdminContext());
+        Response r = browse(params, adminAppToken);
+        Integer expectedResults =
+                getAccessibleEntities(parentEntity, adminAppToken).size();
+
+        if (isLimitedByClientCredentials()) {
+            assertErrorResponse(r, Status.NOT_FOUND.getStatusCode(),
+                    "not_found");
+        } else if (!isAccessible(parentEntity, adminAppToken)) {
+            assertErrorResponse(r, Status.NOT_FOUND.getStatusCode(),
+                    "not_found");
+        } else {
+            List<T> results = r.readEntity(getListType());
+            Assert.assertEquals("0", r.getHeaderString("Offset"));
+            Assert.assertEquals(limit.toString(), r.getHeaderString("Limit"));
+            Assert.assertEquals(expectedResults.toString(),
+                    r.getHeaderString("Total"));
+            Assert.assertEquals(Math.min(expectedResults, limit),
+                    results.size());
+        }
+    }
+
+    /**
+     * Assert that you can browse with an offset.
+     */
+    @Test
+    public final void testBrowseOffset() {
+        Integer offset = 1;
+        Map<String, String> params = new HashMap<>();
+        params.put("offset", offset.toString());
+
+        K parentEntity = getParentEntity(getAdminContext());
+        Response r = browse(params, adminAppToken);
+        Integer expectedResults = getAccessibleEntities(parentEntity,
+                adminAppToken).size();
+
+        if (isLimitedByClientCredentials()) {
+            assertErrorResponse(r, Status.NOT_FOUND.getStatusCode(),
+                    "not_found");
+        } else if (!isAccessible(parentEntity, adminAppToken)) {
+            assertErrorResponse(r, Status.NOT_FOUND.getStatusCode(),
+                    "not_found");
+        } else {
+            List<T> results = r.readEntity(getListType());
+            Assert.assertEquals(offset.toString(),
+                    r.getHeaderString("Offset"));
+            Assert.assertEquals("10", r.getHeaderString("Limit"));
+            Assert.assertEquals(expectedResults.toString(),
+                    r.getHeaderString("Total"));
+            Assert.assertEquals(Math.min(expectedResults - offset, 10),
+                    results.size());
+        }
+    }
+
+    /**
+     * Assert that you can browse and sort default ascending.
+     */
+    @Test
+    public final void testBrowseSortDefault() {
+        Map<String, String> params = new HashMap<>();
+        params.put(ApiParam.SORT_QUERY, "createdDate");
+
+        K parentEntity = getParentEntity(getAdminContext());
+        Response r = browse(params, adminAppToken);
+        Integer expectedResults = getAccessibleEntities(parentEntity,
+                adminAppToken).size();
+
+        if (isLimitedByClientCredentials()) {
+            assertErrorResponse(r, Status.NOT_FOUND.getStatusCode(),
+                    "not_found");
+        } else if (!isAccessible(parentEntity, adminAppToken)) {
+            assertErrorResponse(r, Status.NOT_FOUND.getStatusCode(),
+                    "not_found");
+        } else {
+            List<T> results = r.readEntity(getListType());
+            Assert.assertEquals("0", r.getHeaderString("Offset"));
+            Assert.assertEquals("10", r.getHeaderString("Limit"));
+            Assert.assertEquals(expectedResults.toString(),
+                    r.getHeaderString("Total"));
+            Assert.assertEquals(Math.min(expectedResults, 10),
+                    results.size());
+
+            results.stream().sorted((e1, e2) -> e1.getCreatedDate()
+                    .compareTo(e2.getCreatedDate()));
+        }
+    }
+
+    /**
+     * Assert that you can browse and sort ascending.
+     */
+    @Test
+    public final void testBrowseSortAscending() {
+        Map<String, String> params = new HashMap<>();
+        params.put(ApiParam.SORT_QUERY, "createdDate");
+        params.put(ApiParam.ORDER_QUERY, "ASC");
+
+        K parentEntity = getParentEntity(getAdminContext());
+        Response r = browse(params, adminAppToken);
+        Integer expectedResults = getAccessibleEntities(parentEntity,
+                adminAppToken).size();
+
+        if (isLimitedByClientCredentials()) {
+            assertErrorResponse(r, Status.NOT_FOUND.getStatusCode(),
+                    "not_found");
+        } else if (!isAccessible(parentEntity, adminAppToken)) {
+            assertErrorResponse(r, Status.NOT_FOUND.getStatusCode(),
+                    "not_found");
+        } else {
+            List<T> results = r.readEntity(getListType());
+            Assert.assertEquals("0", r.getHeaderString("Offset"));
+            Assert.assertEquals("10", r.getHeaderString("Limit"));
+            Assert.assertEquals(expectedResults.toString(),
+                    r.getHeaderString("Total"));
+            Assert.assertEquals(Math.min(expectedResults, 10),
+                    results.size());
+
+            results.stream().sorted(
+                    Comparator.comparing(AbstractEntity::getCreatedDate));
+        }
+    }
+
+    /**
+     * Assert that you can browse and sort descending.
+     */
+    @Test
+    public final void testBrowseSortDescending() {
+        Map<String, String> params = new HashMap<>();
+        params.put(ApiParam.SORT_QUERY, "createdDate");
+        params.put(ApiParam.ORDER_QUERY, "DESC");
+
+        Response r = browse(params, adminAppToken);
+        K parentEntity = getParentEntity(getAdminContext());
+        Integer expectedResults = getAccessibleEntities(parentEntity,
+                adminAppToken).size();
+
+        if (clientType.equals(ClientType.ClientCredentials)
+                && tokenScope.equals(getRegularScope())) {
+            assertErrorResponse(r, Status.NOT_FOUND.getStatusCode(),
+                    "not_found");
+        } else if (!isAccessible(parentEntity, adminAppToken)) {
+            assertErrorResponse(r, Status.NOT_FOUND.getStatusCode(),
+                    "not_found");
+        } else {
+            List<T> results = r.readEntity(getListType());
+            Assert.assertEquals("0", r.getHeaderString("Offset"));
+            Assert.assertEquals("10", r.getHeaderString("Limit"));
+            Assert.assertEquals(expectedResults.toString(),
+                    r.getHeaderString("Total"));
+            Assert.assertEquals(Math.min(expectedResults, 10),
+                    results.size());
+
+            results.stream().sorted((e1, e2) -> e2.getCreatedDate()
+                    .compareTo(e1.getCreatedDate()));
+        }
+    }
+
+    /**
+     * Assert that an invalid sort parameter defaults to ASC.
+     */
+    @Test
+    public final void testBrowseSortInvalid() {
+        Map<String, String> params = new HashMap<>();
+        params.put(ApiParam.SORT_QUERY, "createdDate");
+        params.put(ApiParam.ORDER_QUERY, "invalid_sort");
+
+        Response r = browse(params, adminAppToken);
+        K parentEntity = getParentEntity(getAdminContext());
+        Integer expectedResults = getAccessibleEntities(parentEntity,
+                adminAppToken).size();
+
+        if (isLimitedByClientCredentials()) {
+            assertErrorResponse(r, Status.NOT_FOUND.getStatusCode(),
+                    "not_found");
+        } else if (!isAccessible(parentEntity, adminAppToken)) {
+            assertErrorResponse(r, Status.NOT_FOUND.getStatusCode(),
+                    "not_found");
+        } else {
+            List<T> results = r.readEntity(getListType());
+            Assert.assertEquals("0", r.getHeaderString("Offset"));
+            Assert.assertEquals("10", r.getHeaderString("Limit"));
+            Assert.assertEquals(expectedResults.toString(),
+                    r.getHeaderString("Total"));
+            Assert.assertEquals(Math.min(expectedResults, 10),
+                    results.size());
+
+            results.stream().sorted((e1, e2) -> e1.getCreatedDate()
+                    .compareTo(e2.getCreatedDate()));
+        }
+    }
+
+    /**
+     * Assert that we can only browse the resource if we're logged in.
+     */
+    @Test
+    public final void testBrowseNoAuth() {
+        Response response = target(getBrowseUrl().getPath())
+                .request()
+                .get();
+
+        assertErrorResponse(response, Status.FORBIDDEN);
+    }
+}

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/DAbstractSubserviceCRUDTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/DAbstractSubserviceCRUDTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.servlet.admin.v1.resource;
+
+import net.krotscheck.kangaroo.database.entity.AbstractEntity;
+import net.krotscheck.kangaroo.database.entity.ClientType;
+import net.krotscheck.kangaroo.test.EnvironmentBuilder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import java.util.UUID;
+
+/**
+ * Test the CRUD methods of the scope service.
+ *
+ * @param <T> The type of entity to execute this test for.
+ * @author Michael Krotscheck
+ */
+@Deprecated
+@RunWith(Parameterized.class)
+public abstract class DAbstractSubserviceCRUDTest<K extends AbstractEntity,
+        T extends AbstractEntity> extends DAbstractServiceCRUDTest<T> {
+
+    /**
+     * Class reference for this class' parent type, used in casting.
+     */
+    private final Class<K> parentClass;
+
+    /**
+     * Create a new instance of this parameterized test.
+     *
+     * @param parentClass   The raw parent type, used for type-based parsing.
+     * @param childClass    The raw child type, used for type-based parsing.
+     * @param clientType    The type of  client.
+     * @param tokenScope    The client scope to issue.
+     * @param createUser    Whether to create a new user.
+     * @param shouldSucceed Should this test succeed?
+     */
+    public DAbstractSubserviceCRUDTest(final Class<K> parentClass,
+                                       final Class<T> childClass,
+                                       final ClientType clientType,
+                                       final String tokenScope,
+                                       final Boolean createUser,
+                                       final Boolean shouldSucceed) {
+        super(childClass, clientType, tokenScope, createUser, shouldSucceed);
+        this.parentClass = parentClass;
+    }
+
+    /**
+     * Return the correct parent entity type from the provided context.
+     *
+     * @param context The context to extract the value from.
+     * @return The requested entity type under test.
+     */
+    protected abstract K getParentEntity(EnvironmentBuilder context);
+
+    /**
+     * Create a new valid entity to test the creation endpoint.
+     *
+     * @param context The context within which to create the entity.
+     * @return A valid, but unsaved, entity.
+     */
+    @Override
+    protected final T createValidEntity(final EnvironmentBuilder context) {
+        K parent = getParentEntity(context);
+        return createValidEntity(context, parent);
+    }
+
+    /**
+     * Given a parent entity and a context, create a valid entity.
+     *
+     * @param context The environment context.
+     * @param parent  The parent entity.
+     * @return A valid entity.
+     */
+    protected abstract T createValidEntity(EnvironmentBuilder context,
+                                           K parent);
+
+    /**
+     * Create a valid parent entity for the given context.
+     *
+     * @param context The environment context.
+     * @return A valid entity.
+     */
+    protected abstract K createParentEntity(EnvironmentBuilder context);
+
+    /**
+     * Assert that we cannot read from an different parent entity
+     *
+     * @throws Exception Exception encountered during test.
+     */
+    @Test
+    public void testGetDifferentParent() throws Exception {
+        T originalEntity = getEntity(getAdminContext());
+        K testParent = (K) getParentEntity(getSecondaryContext()).clone();
+
+        T testEntity = createValidEntity(getAdminContext(), testParent);
+        testEntity.setId(originalEntity.getId());
+
+        // Issue the request.
+        Response r = getEntity(testEntity, getAdminToken());
+        assertErrorResponse(r, Status.NOT_FOUND);
+    }
+
+    /**
+     * Assert that we cannot read from an invalid parent entity
+     *
+     * @throws Exception Exception encountered during test.
+     */
+    @Test
+    public void testGetInvalidParent() throws Exception {
+        T originalEntity = (T) getEntity(getAdminContext()).clone();
+        K testParent = createParentEntity(getAdminContext());
+        testParent.setId(UUID.randomUUID());
+
+        T testEntity = createValidEntity(getAdminContext(), testParent);
+        testEntity.setId(originalEntity.getId());
+
+        // Issue the request.
+        Response r = getEntity(testEntity, getAdminToken());
+        assertErrorResponse(r, Status.NOT_FOUND);
+    }
+
+    /**
+     * Assert that an entity cannot be created for a nonexistent parent.
+     *
+     * @throws Exception Exception encountered during test.
+     */
+    @Test
+    public final void testPostInvalidParent() throws Exception {
+        K testParent = createParentEntity(getAdminContext());
+        testParent.setId(UUID.randomUUID());
+        T testEntity = createValidEntity(getAdminContext(), testParent);
+
+        // Issue the request.
+        Response r = postEntity(testEntity, getAdminToken());
+        assertErrorResponse(r, Status.NOT_FOUND);
+    }
+
+    /**
+     * Assert that an entity can only be modified if linked to its actual
+     * parent.
+     *
+     * @throws Exception Exception encountered during test.
+     */
+    @Test
+    public final void testPutDifferentParent() throws Exception {
+        K testParent = getParentEntity(getSecondaryContext());
+        T testEntity = createValidEntity(getAdminContext(), testParent);
+        T validEntity = getEntity(getAdminContext());
+        testEntity.setId(validEntity.getId());
+
+        // Issue the request.
+        Response r = putEntity(testEntity, getAdminToken());
+        assertErrorResponse(r, Status.NOT_FOUND);
+    }
+
+    /**
+     * Assert that an entity cannot be updated for a nonexistent parent.
+     *
+     * @throws Exception Exception encountered during test.
+     */
+    @Test
+    public final void testPutInvalidParent() throws Exception {
+        K testParent = createParentEntity(getAdminContext());
+        testParent.setId(UUID.randomUUID());
+        T testEntity = createValidEntity(getAdminContext(), testParent);
+        T validEntity = getEntity(getAdminContext());
+        testEntity.setId(validEntity.getId());
+
+        // Issue the request.
+        Response r = putEntity(testEntity, getAdminToken());
+        assertErrorResponse(r, Status.NOT_FOUND);
+    }
+
+    /**
+     * Assert that an entity cannot be deleted for a different parent.
+     *
+     * @throws Exception Exception encountered during test.
+     */
+    @Test
+    public final void testDeleteDifferentParent() throws Exception {
+        K testParent = getParentEntity(getSecondaryContext());
+        T testEntity = createValidEntity(getAdminContext(), testParent);
+        T validEntity = getEntity(getAdminContext());
+        testEntity.setId(validEntity.getId());
+
+        // Issue the request.
+        Response r = deleteEntity(testEntity, getAdminToken());
+        assertErrorResponse(r, Status.NOT_FOUND);
+    }
+
+    /**
+     * Assert that an entity cannot be deleted for a nonexistent parent.
+     *
+     * @throws Exception Exception encountered during test.
+     */
+    @Test
+    public final void testDeleteInvalidParent() throws Exception {
+        K testParent = createParentEntity(getAdminContext());
+        testParent.setId(UUID.randomUUID());
+        T testEntity = createValidEntity(getAdminContext(), testParent);
+        T validEntity = getEntity(getAdminContext());
+        testEntity.setId(validEntity.getId());
+
+        // Issue the request.
+        Response r = deleteEntity(testEntity, getAdminToken());
+        assertErrorResponse(r, Status.NOT_FOUND);
+    }
+}

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/OAuthTokenServiceCRUDTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/OAuthTokenServiceCRUDTest.java
@@ -300,7 +300,7 @@ public final class OAuthTokenServiceCRUDTest
         URI redirect = UriBuilder.fromPath("http://invalid.example.com/")
                 .build();
         if (client.getRedirects().size() > 0) {
-            redirect = client.getRedirects().iterator().next();
+            redirect = client.getRedirects().iterator().next().getUri();
         }
 
         OAuthToken t = new OAuthToken();
@@ -597,7 +597,7 @@ public final class OAuthTokenServiceCRUDTest
         testEntity.setAuthToken(bearerToken);
         if (testEntity.getRedirect() == null) {
             testEntity.setRedirect(getAdminClient().getRedirects()
-                    .iterator().next());
+                    .iterator().next().getUri());
         }
 
         // Issue the request.
@@ -616,7 +616,7 @@ public final class OAuthTokenServiceCRUDTest
         testEntity.setTokenType(OAuthTokenType.Bearer);
         if (testEntity.getRedirect() == null) {
             testEntity.setRedirect(getAdminClient().getRedirects()
-                    .iterator().next());
+                    .iterator().next().getUri());
         }
 
         // Issue the request.
@@ -667,7 +667,11 @@ public final class OAuthTokenServiceCRUDTest
      */
     @Test
     public void testPostAuthNoRedirect() throws Exception {
-        OAuthToken testEntity = createValidEntity(getAdminContext());
+        // Make sure there's more than one redirect in this context.
+        EnvironmentBuilder builder = getAdminContext()
+                .redirect("http://one.example.com/redirect")
+                .redirect("http://two.example.com/redirect");
+        OAuthToken testEntity = createValidEntity(builder);
         testEntity.setTokenType(OAuthTokenType.Authorization);
         testEntity.setRedirect(null);
 
@@ -957,7 +961,7 @@ public final class OAuthTokenServiceCRUDTest
                 OAuthTokenType.Refresh);
         if (testEntity.getRedirect() == null) {
             testEntity.setRedirect(getAdminClient().getRedirects()
-                    .iterator().next());
+                    .iterator().next().getUri());
         }
 
         // Issue the request.
@@ -980,7 +984,7 @@ public final class OAuthTokenServiceCRUDTest
                 OAuthTokenType.Bearer);
         if (testEntity.getRedirect() == null) {
             testEntity.setRedirect(getAdminClient().getRedirects()
-                    .iterator().next());
+                    .iterator().next().getUri());
         }
 
         // Issue the request.
@@ -1021,7 +1025,10 @@ public final class OAuthTokenServiceCRUDTest
      */
     @Test
     public void testPutAuthNoRedirect() throws Exception {
-        OAuthToken testEntity = createValidToken(getAdminContext(),
+        EnvironmentBuilder builder = getAdminContext()
+                .redirect("http://one.example.com/redirect")
+                .redirect("http://two.example.com/redirect");
+        OAuthToken testEntity = createValidToken(builder,
                 OAuthTokenType.Authorization);
         testEntity.setRedirect(null);
 

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
     <hibernate.version>5.0.11.Final</hibernate.version>
     <hibernate-validator.version>5.3.4.Final</hibernate-validator.version>
     <hibernate-search.version>5.5.5.Final</hibernate-search.version>
-    <jersey.version>2.25</jersey.version>
+    <jersey.version>2.25.1</jersey.version>
     <jersey2-toolkit.version>2.1.1</jersey2-toolkit.version>
     <slf4j.version>1.7.13</slf4j.version>
     <powermock.version>1.6.6</powermock.version>


### PR DESCRIPTION
It turns out that the hydration of lazy loaded entities reopens transactions
after the TransactionFilter has already closed them, resulting in a significant
database connection leak. To avoid this, we are reclassifying redirects and
referrers as their own entities, and providing each with a subresource underneath
the /client/ path.