### PR TITLE
User Identity is now persisted with reverse reference.

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/User.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/User.java
@@ -101,7 +101,7 @@ public final class User extends AbstractEntity {
     @OneToMany(
             fetch = FetchType.LAZY,
             mappedBy = "user",
-            cascade = {CascadeType.REMOVE, CascadeType.MERGE},
+            cascade = {CascadeType.ALL},
             orphanRemoval = true
     )
     @JsonIgnore

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/ApplicationBuilder.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/ApplicationBuilder.java
@@ -449,6 +449,9 @@ public final class ApplicationBuilder {
         context.userIdentity.setUser(context.user);
         context.userIdentity.setAuthenticator(context.authenticator);
 
+        context.user.getIdentities().add(context.userIdentity);
+
+        persist(context.user);
         persist(context.userIdentity);
 
         return this;
@@ -466,6 +469,9 @@ public final class ApplicationBuilder {
         context.userIdentity.setUser(context.user);
         context.userIdentity.setAuthenticator(context.authenticator);
 
+        context.user.getIdentities().add(context.userIdentity);
+
+        persist(context.user);
         persist(context.userIdentity);
 
         return this;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/EnvironmentBuilder.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/EnvironmentBuilder.java
@@ -627,6 +627,10 @@ public final class EnvironmentBuilder {
         userIdentity.setPassword(PasswordUtil.hash(password,
                 userIdentity.getSalt()));
         userIdentity.setAuthenticator(getAuthenticator());
+
+        user.getIdentities().add(userIdentity);
+
+        persist(user);
         persist(userIdentity);
 
         return this;
@@ -643,6 +647,10 @@ public final class EnvironmentBuilder {
         userIdentity.setUser(getUser());
         userIdentity.setRemoteId(remoteIdentity);
         userIdentity.setAuthenticator(getAuthenticator());
+
+        user.getIdentities().add(userIdentity);
+
+        persist(user);
         persist(userIdentity);
         return this;
     }
@@ -870,7 +878,7 @@ public final class EnvironmentBuilder {
      */
     public void clear() {
 
-        // Clear everything...
+        // Clear everything, then...
         session.clear();
 
         // Delete the entities in reverse order.


### PR DESCRIPTION
Something in the Hibernate Search SDK has issues when an
entity, with child search index paths, that does not have its
parent association set, is persisted. In this case, the
parent's search index is not updated with the child's child
indexes. This is fixed by explicitly creating the parent-child
link from both the parent's and the child's perspective.