### PR TITLE
Migrated Browse Tests to new ContainerTest

### DIFF
--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AbstractServiceBrowseTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AbstractServiceBrowseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Michael Krotscheck
+ * Copyright (c) 2017 Michael Krotscheck
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
@@ -24,10 +24,12 @@ import net.krotscheck.kangaroo.database.entity.Client;
 import net.krotscheck.kangaroo.database.entity.ClientType;
 import net.krotscheck.kangaroo.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.database.entity.User;
-import net.krotscheck.kangaroo.servlet.admin.v1.Scope;
+import net.krotscheck.kangaroo.database.entity.UserIdentity;
+import net.krotscheck.kangaroo.test.ApplicationBuilder.ApplicationContext;
 import net.krotscheck.kangaroo.test.EnvironmentBuilder;
 import net.krotscheck.kangaroo.test.HttpUtil;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -36,7 +38,6 @@ import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -49,10 +50,9 @@ import java.util.stream.Collectors;
  * @param <T> The type of entity to execute this test for.
  * @author Michael Krotscheck
  */
-@Deprecated
 @RunWith(Parameterized.class)
-public abstract class DAbstractServiceBrowseTest<T extends AbstractEntity>
-        extends DAbstractResourceTest {
+public abstract class AbstractServiceBrowseTest<T extends AbstractEntity>
+        extends AbstractResourceTest {
 
     /**
      * The scope to grant the issued token.
@@ -92,12 +92,43 @@ public abstract class DAbstractServiceBrowseTest<T extends AbstractEntity>
      * @param tokenScope The client scope to issue.
      * @param createUser Whether to create a new user.
      */
-    public DAbstractServiceBrowseTest(final ClientType clientType,
-                                      final String tokenScope,
-                                      final Boolean createUser) {
+    public AbstractServiceBrowseTest(final ClientType clientType,
+                                     final String tokenScope,
+                                     final Boolean createUser) {
         this.tokenScope = tokenScope;
         this.clientType = clientType;
         this.createUser = createUser;
+    }
+
+    /**
+     * Load data fixtures for each test. Here we're creating two applications
+     * with different owners, using the kangaroo default scopes so we have
+     * some good cross-app name duplication.
+     *
+     * @throws Exception An exception that indicates a failed fixture load.
+     */
+    @Before
+    public final void configureData() throws Exception {
+        // Get the admin app and create users based on the configured
+        // parameters.
+        ApplicationContext context = getAdminContext()
+                .getBuilder()
+                .client(clientType)
+                .build();
+        client = context.getClient();
+
+        User owner = context.getOwner();
+        if (createUser) {
+            // Switch to the other user.
+            owner = getSecondaryContext().getOwner();
+        }
+        UserIdentity identity = owner.getIdentities().iterator().next();
+
+        adminAppToken = context
+                .getBuilder()
+                .bearerToken(client, identity, tokenScope)
+                .build()
+                .getToken();
     }
 
     /**
@@ -154,20 +185,12 @@ public abstract class DAbstractServiceBrowseTest<T extends AbstractEntity>
      * @return The list of entities.
      */
     protected final List<T> getOwnedEntities(final OAuthToken token) {
+        OAuthToken attachedToken = getAttached(token);
         if (token.getIdentity() == null) {
             return Collections.emptyList();
         } else {
-            return getOwnedEntities(getAdminToken().getIdentity().getUser());
+            return getOwnedEntities(attachedToken.getIdentity().getUser());
         }
-    }
-
-    /**
-     * Return the second application context (not the admin context).
-     *
-     * @return The secondary context in this test.
-     */
-    protected final EnvironmentBuilder getSecondaryContext() {
-        return otherApp;
     }
 
     /**
@@ -217,143 +240,6 @@ public abstract class DAbstractServiceBrowseTest<T extends AbstractEntity>
     protected final Boolean isLimitedByClientCredentials() {
         return clientType.equals(ClientType.ClientCredentials)
                 && tokenScope.equals(getRegularScope());
-    }
-
-    /**
-     * Load data fixtures for each test. Here we're creating two applications
-     * with different owners, using the kangaroo default scopes so we have
-     * some good cross-app name duplication.
-     *
-     * @return A list of fixtures, which will be cleared after the test.
-     * @throws Exception An exception that indicates a failed fixture load.
-     */
-    @Override
-    public final List<EnvironmentBuilder> fixtures(
-            final EnvironmentBuilder adminApp) throws Exception {
-        List<EnvironmentBuilder> fixtures = new ArrayList<>();
-
-        // Get the admin app and create users based on the configured
-        // parameters.
-        EnvironmentBuilder context = getAdminContext()
-                .client(clientType);
-
-        client = context.getClient();
-
-        // Create a whole lot of applications to run some tests against.
-        for (int i = 0; i < 10; i++) {
-            String appName = String.format("Application %s- %s", i, i % 2 == 0
-                    ? "many" : "frown");
-            fixtures.add(new EnvironmentBuilder(getSession(), appName)
-                    .owner(adminApp.getUser()));
-        }
-        fixtures.add(new EnvironmentBuilder(getSession(), "Single")
-                .owner(adminApp.getUser()));
-
-
-        if (createUser) {
-            context.user().identity();
-        }
-        adminAppToken = context.bearerToken(tokenScope).getToken();
-
-        // Create a whole lot more applications to run some tests against.
-        for (int i = 0; i < 10; i++) {
-            String appName = String.format("Application %s- %s", i, i % 2 == 0
-                    ? "many" : "frown");
-            fixtures.add(new EnvironmentBuilder(getSession(), appName)
-                    .owner(adminApp.getUser()));
-        }
-        fixtures.add(new EnvironmentBuilder(getSession(), "Single")
-                .owner(adminApp.getUser()));
-
-        // Create a second app, owned by another user.
-        otherApp = new EnvironmentBuilder(getSession())
-                .owner(context.getUser())
-                .scopes(Scope.allScopes());
-
-        // Add some data for scopes
-        context.scope("Single Scope");
-        context.scope("Second Scope - many");
-        context.scope("Third Scope - many");
-        context.scope("Fourth Scope - many");
-        otherApp.scope("Single Scope");
-        otherApp.scope("Second Scope - many");
-        otherApp.scope("Third Scope - many");
-        otherApp.scope("Fourth Scope - many");
-
-        // Add some test data for clients
-        context.client(ClientType.ClientCredentials, "Single client");
-        context.authenticator("Single authenticator");
-        context.client(ClientType.ClientCredentials, "Second client - many");
-        context.authenticator("Second authenticator - many");
-        context.client(ClientType.Implicit, "Third client - many");
-        context.authenticator("Third authenticator - many");
-        context.client(ClientType.AuthorizationGrant, "Fourth client - many");
-        context.authenticator("Fourth authenticator - many");
-        otherApp.client(ClientType.ClientCredentials, "Single client");
-        otherApp.authenticator("Single authenticator");
-        otherApp.client(ClientType.ClientCredentials, "Second client - many");
-        otherApp.authenticator("Second authenticator - many");
-        otherApp.client(ClientType.Implicit, "Third client - many");
-        otherApp.authenticator("Third authenticator - many");
-        otherApp.client(ClientType.AuthorizationGrant, "Fourth client - many");
-        otherApp.authenticator("Fourth authenticator - many");
-
-        // Add some data for roles
-        context.role("Single Role");
-        context.role("Second Role - many");
-        context.role("Third Role - many");
-        context.role("Fourth Role - many");
-        otherApp.role("Single Role");
-        otherApp.role("Second Role - many");
-        otherApp.role("Third Role - many");
-        otherApp.role("Fourth Role - many");
-
-        // Create some users
-        context.user()
-                .identity()
-                .claim("name", "Single User");
-        context.user()
-                .identity()
-                .claim("name", "Second User - many");
-        context.user()
-                .identity()
-                .claim("name", "Third User - many");
-        context.user()
-                .identity()
-                .claim("name", "Fourth User - many");
-        otherApp.user()
-                .identity()
-                .claim("name", "Single User");
-        otherApp.user()
-                .identity()
-                .claim("name", "Second User - many");
-        otherApp.user()
-                .identity()
-                .claim("name", "Third User - many");
-        otherApp.user()
-                .identity()
-                .claim("name", "Fourth User - many");
-
-        // Create a bunch of tokens
-        context.redirect("http://single.token.example.com/")
-                .authToken();
-        context.redirect("http://second.token.example.com/many")
-                .authToken();
-        context.redirect("http://third.token.example.com/many")
-                .authToken();
-        context.redirect("http://fourth.token.example.com/many")
-                .authToken();
-        otherApp.redirect("http://single.token.example.com/")
-                .authToken();
-        otherApp.redirect("http://second.token.example.com/many")
-                .authToken();
-        otherApp.redirect("http://third.token.example.com/many")
-                .authToken();
-        otherApp.redirect("http://fourth.token.example.com/many")
-                .authToken();
-
-        fixtures.add(otherApp);
-        return fixtures;
     }
 
     /**
@@ -619,8 +505,7 @@ public abstract class DAbstractServiceBrowseTest<T extends AbstractEntity>
                             HttpUtil.authHeaderBearer(adminAppToken.getId()))
                     .get();
 
-            Integer expectedResults = getOwnedEntities(adminAppToken)
-                    .size();
+            Integer expectedResults = getOwnedEntities(adminAppToken).size();
 
             List<T> results = response.readEntity(getListType());
             Assert.assertEquals(200, response.getStatus());

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ApplicationServiceBrowseTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ApplicationServiceBrowseTest.java
@@ -42,7 +42,7 @@ import java.util.List;
  */
 @RunWith(Parameterized.class)
 public final class ApplicationServiceBrowseTest
-        extends DAbstractServiceBrowseTest<Application> {
+        extends AbstractServiceBrowseTest<Application> {
 
     /**
      * Convenience generic type for response decoding.
@@ -86,8 +86,9 @@ public final class ApplicationServiceBrowseTest
     protected List<Application> getAccessibleEntities(final OAuthToken token) {
         // If you're an admin, you get to see everything. If you're not, you
         // only get to see what you own.
-        if (!token.getScopes().containsKey(getAdminScope())) {
-            return getOwnedEntities(token);
+        OAuthToken attachedToken = getAttached(token);
+        if (!attachedToken.getScopes().containsKey(getAdminScope())) {
+            return getOwnedEntities(attachedToken);
         }
 
         // We know you're an admin. Get all applications in the system.
@@ -105,7 +106,7 @@ public final class ApplicationServiceBrowseTest
      */
     @Override
     protected List<Application> getOwnedEntities(final User owner) {
-        return owner.getApplications();
+        return getAttached(owner).getApplications();
     }
 
     /**

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AuthenticatorServiceBrowseTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AuthenticatorServiceBrowseTest.java
@@ -51,7 +51,7 @@ import java.util.stream.Collectors;
  */
 @RunWith(Parameterized.class)
 public final class AuthenticatorServiceBrowseTest
-        extends DAbstractServiceBrowseTest<Authenticator> {
+        extends AbstractServiceBrowseTest<Authenticator> {
 
     /**
      * Generic type declaration for list decoding.
@@ -116,8 +116,9 @@ public final class AuthenticatorServiceBrowseTest
             final OAuthToken token) {
         // If you're an admin, you get to see everything. If you're not, you
         // only get to see what you own.
-        if (!token.getScopes().containsKey(getAdminScope())) {
-            return getOwnedEntities(token);
+        OAuthToken attachedToken = getAttached(token);
+        if (!attachedToken.getScopes().containsKey(getAdminScope())) {
+            return getOwnedEntities(attachedToken);
         }
 
         // We know you're an admin. Get all applications in the system.
@@ -139,13 +140,13 @@ public final class AuthenticatorServiceBrowseTest
      */
     @Override
     protected List<Authenticator> getOwnedEntities(final User owner) {
-
         // Get all the owned clients.
-        return owner.getApplications()
+        List<Authenticator> aList = owner.getApplications()
                 .stream()
                 .flatMap(a -> a.getClients().stream())
                 .flatMap(c -> c.getAuthenticators().stream())
                 .collect(Collectors.toList());
+        return aList;
     }
 
     /**

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ClientServiceBrowseTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ClientServiceBrowseTest.java
@@ -50,7 +50,7 @@ import java.util.stream.Collectors;
  */
 @RunWith(Parameterized.class)
 public final class ClientServiceBrowseTest
-        extends DAbstractServiceBrowseTest<Client> {
+        extends AbstractServiceBrowseTest<Client> {
 
     /**
      * Generic type declaration for list decoding.
@@ -114,8 +114,9 @@ public final class ClientServiceBrowseTest
     protected List<Client> getAccessibleEntities(final OAuthToken token) {
         // If you're an admin, you get to see everything. If you're not, you
         // only get to see what you own.
-        if (!token.getScopes().containsKey(getAdminScope())) {
-            return getOwnedEntities(token);
+        OAuthToken attachedToken = getAttached(token);
+        if (!attachedToken.getScopes().containsKey(getAdminScope())) {
+            return getOwnedEntities(attachedToken);
         }
 
         // We know you're an admin. Get all applications in the system.

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/OAuthTokenServiceBrowseTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/OAuthTokenServiceBrowseTest.java
@@ -50,7 +50,7 @@ import java.util.stream.Collectors;
  */
 @RunWith(Parameterized.class)
 public final class OAuthTokenServiceBrowseTest
-        extends DAbstractServiceBrowseTest<OAuthToken> {
+        extends AbstractServiceBrowseTest<OAuthToken> {
 
     /**
      * Generic type declaration for list decoding.
@@ -114,8 +114,9 @@ public final class OAuthTokenServiceBrowseTest
     protected List<OAuthToken> getAccessibleEntities(final OAuthToken token) {
         // If you're an admin, you get to see everything. If you're not, you
         // only get to see what you own.
-        if (!token.getScopes().containsKey(getAdminScope())) {
-            return getOwnedEntities(token);
+        OAuthToken attachedToken = getAttached(token);
+        if (!attachedToken.getScopes().containsKey(getAdminScope())) {
+            return getOwnedEntities(attachedToken);
         }
 
         // We know you're an admin. Get all applications in the system.

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/RoleServiceBrowseTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/RoleServiceBrowseTest.java
@@ -51,7 +51,7 @@ import java.util.stream.Collectors;
  */
 @RunWith(Parameterized.class)
 public final class RoleServiceBrowseTest
-        extends DAbstractServiceBrowseTest<Role> {
+        extends AbstractServiceBrowseTest<Role> {
 
     /**
      * Generic type declaration for list decoding.
@@ -123,8 +123,9 @@ public final class RoleServiceBrowseTest
     protected List<Role> getAccessibleEntities(final OAuthToken token) {
         // If you're an admin, you get to see everything. If you're not, you
         // only get to see what you own.
-        if (!token.getScopes().containsKey(getAdminScope())) {
-            return getOwnedEntities(token);
+        OAuthToken attachedToken = getAttached(token);
+        if (!attachedToken.getScopes().containsKey(getAdminScope())) {
+            return getOwnedEntities(attachedToken);
         }
 
         // We know you're an admin. Get all applications in the system.

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ScopeServiceBrowseTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ScopeServiceBrowseTest.java
@@ -50,7 +50,7 @@ import java.util.stream.Collectors;
  */
 @RunWith(Parameterized.class)
 public final class ScopeServiceBrowseTest
-        extends DAbstractServiceBrowseTest<ApplicationScope> {
+        extends AbstractServiceBrowseTest<ApplicationScope> {
 
     /**
      * Create a new instance of this parameterized test.
@@ -108,8 +108,9 @@ public final class ScopeServiceBrowseTest
             final OAuthToken token) {
         // If you're an admin, you get to see everything. If you're not, you
         // only get to see what you own.
-        if (!token.getScopes().containsKey(getAdminScope())) {
-            return getOwnedEntities(token);
+        OAuthToken attachedToken = getAttached(token);
+        if (!attachedToken.getScopes().containsKey(getAdminScope())) {
+            return getOwnedEntities(attachedToken);
         }
 
         // We know you're an admin. Get all applications in the system.

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/UserIdentityServiceBrowseTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/UserIdentityServiceBrowseTest.java
@@ -52,7 +52,7 @@ import java.util.stream.Collectors;
  */
 @RunWith(Parameterized.class)
 public final class UserIdentityServiceBrowseTest
-        extends DAbstractServiceBrowseTest<UserIdentity> {
+        extends AbstractServiceBrowseTest<UserIdentity> {
 
     /**
      * Generic type declaration for list decoding.
@@ -116,8 +116,9 @@ public final class UserIdentityServiceBrowseTest
     protected List<UserIdentity> getAccessibleEntities(final OAuthToken token) {
         // If you're an admin, you get to see everything. If you're not, you
         // only get to see what you own.
-        if (!token.getScopes().containsKey(getAdminScope())) {
-            return getOwnedEntities(token);
+        OAuthToken attachedToken = getAttached(token);
+        if (!attachedToken.getScopes().containsKey(getAdminScope())) {
+            return getOwnedEntities(attachedToken);
         }
 
         // We know you're an admin. Get all applications in the system.

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/UserServiceBrowseTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/UserServiceBrowseTest.java
@@ -51,7 +51,7 @@ import java.util.stream.Collectors;
  */
 @RunWith(Parameterized.class)
 public final class UserServiceBrowseTest
-        extends DAbstractServiceBrowseTest<User> {
+        extends AbstractServiceBrowseTest<User> {
 
     /**
      * Generic type declaration for list decoding.
@@ -115,8 +115,9 @@ public final class UserServiceBrowseTest
     protected List<User> getAccessibleEntities(final OAuthToken token) {
         // If you're an admin, you get to see everything. If you're not, you
         // only get to see what you own.
-        if (!token.getScopes().containsKey(getAdminScope())) {
-            return getOwnedEntities(token);
+        OAuthToken attachedToken = getAttached(token);
+        if (!attachedToken.getScopes().containsKey(getAdminScope())) {
+            return getOwnedEntities(attachedToken);
         }
 
         // We know you're an admin. Get all applications in the system.


### PR DESCRIPTION
This patch switches the browse tests over to the new
ContainerTest, including the ApplicationBuilder. The search
data will be loaded only once, which should speed things up.