### PR TITLE
Migrade Subservice Browse tests to new ContainerTest

### DIFF
--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AbstractResourceTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AbstractResourceTest.java
@@ -31,6 +31,7 @@ import net.krotscheck.kangaroo.test.ApplicationBuilder.ApplicationContext;
 import net.krotscheck.kangaroo.test.ContainerTest;
 import net.krotscheck.kangaroo.test.HttpUtil;
 import net.krotscheck.kangaroo.test.TestAuthenticator;
+import org.apache.commons.configuration.Configuration;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.hibernate.Session;
 import org.hibernate.collection.internal.PersistentSortedMap;
@@ -106,6 +107,15 @@ public abstract class AbstractResourceTest extends ContainerTest {
      */
     protected final ApplicationContext getSecondaryContext() {
         return TEST_DATA_RESOURCE.getSecondaryApplication();
+    }
+
+    /**
+     * Return the system configuration.
+     *
+     * @return The secondary context in this test.
+     */
+    protected final Configuration getSystemConfig() {
+        return TEST_DATA_RESOURCE.getSystemConfiguration();
     }
 
     /**

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ClientRedirectServiceBrowseTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/ClientRedirectServiceBrowseTest.java
@@ -25,7 +25,7 @@ import net.krotscheck.kangaroo.database.entity.ClientType;
 import net.krotscheck.kangaroo.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.database.entity.User;
 import net.krotscheck.kangaroo.servlet.admin.v1.Scope;
-import net.krotscheck.kangaroo.test.EnvironmentBuilder;
+import net.krotscheck.kangaroo.test.ApplicationBuilder.ApplicationContext;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
@@ -49,7 +49,7 @@ import java.util.stream.Collectors;
  */
 @RunWith(Parameterized.class)
 public final class ClientRedirectServiceBrowseTest
-        extends DAbstractSubserviceBrowseTest<Client, ClientRedirect> {
+        extends AbstractSubserviceBrowseTest<Client, ClientRedirect> {
 
     /**
      * Generic type declaration for list decoding.
@@ -103,6 +103,17 @@ public final class ClientRedirectServiceBrowseTest
     }
 
     /**
+     * Return the correct parent entity type from the provided context.
+     *
+     * @param context The context to extract the value from.
+     * @return The requested entity type under test.
+     */
+    @Override
+    protected Client getParentEntity(final ApplicationContext context) {
+        return context.getClient();
+    }
+
+    /**
      * Return the list of entities which should be accessible given a
      * specific token.
      *
@@ -116,8 +127,9 @@ public final class ClientRedirectServiceBrowseTest
             final OAuthToken token) {
         // If you're an admin, you get to see everything. If you're not, you
         // only get to see what you own.
-        if (!token.getScopes().containsKey(getAdminScope())) {
-            return getOwnedEntities(parentEntity, token);
+        OAuthToken attachedToken = getAttached(token);
+        if (!attachedToken.getScopes().containsKey(getAdminScope())) {
+            return getOwnedEntities(parentEntity, attachedToken);
         }
 
         // We know you're an admin. Get all applications in the system.
@@ -139,7 +151,7 @@ public final class ClientRedirectServiceBrowseTest
     protected List<ClientRedirect> getOwnedEntities(final Client parentEntity,
                                                     final User owner) {
         // Get all the owned clients.
-        return owner.getApplications()
+        return getAttached(owner).getApplications()
                 .stream()
                 .flatMap(a -> a.getClients().stream())
                 .filter(c -> c.equals(parentEntity))
@@ -238,17 +250,6 @@ public final class ClientRedirectServiceBrowseTest
             parentId = clientId == null ? null : clientId.toString();
         }
         return getUrlForEntity(parentId, childId);
-    }
-
-    /**
-     * Return the correct parent entity type from the provided context.
-     *
-     * @param context The context to extract the value from.
-     * @return The requested entity type under test.
-     */
-    @Override
-    protected Client getParentEntity(final EnvironmentBuilder context) {
-        return context.getReferrer().getClient();
     }
 
     /**

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/test/rule/TestDataResource.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/test/rule/TestDataResource.java
@@ -223,24 +223,28 @@ public final class TestDataResource
                 .identity()
                 .claim("name", "Single User")
                 .redirect("http://single.token.example.com/")
+                .referrer("http://single.token.example.com/")
                 .authToken()
                 .bearerToken();
         builder.user()
                 .identity()
                 .claim("name", "Second User - many")
                 .redirect("http://second.token.example.com/many")
+                .referrer("http://second.token.example.com/many")
                 .authToken()
                 .bearerToken();
         builder.user()
                 .identity()
                 .claim("name", "Third User - many")
                 .redirect("http://third.token.example.com/many")
+                .referrer("http://third.token.example.com/many")
                 .authToken()
                 .bearerToken();
         builder.user()
                 .identity()
                 .claim("name", "Fourth User - many")
                 .redirect("http://fourth.token.example.com/many")
+                .referrer("http://fourth.token.example.com/many")
                 .authToken()
                 .bearerToken();
     }


### PR DESCRIPTION
This migrates the subservice browse test to the new rule-based
testing harness.