### PR TITLE
Support MySQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ jdk:
 - oraclejdk8
 dist: trusty
 sudo: required
+env:
+  - PROFILE=mysql
+  - PROFILE=h2
+services:
+  - mysql
 branches:
   only:
   - master
@@ -10,7 +15,10 @@ branches:
   - /^feature\/.*$/
   - /^hotfix\/.*$/
   - /^release\/.*$/
+before_install:
+  - mysql -e 'CREATE DATABASE IF NOT EXISTS oid;'
+  - mysql -e 'GRANT ALL ON oid.* TO oid@localhost identified by "oid";'
 script:
-  - mvn clean install -Ptravis
+  - mvn clean install -Ptravis -P$PROFILE
 after_success:
   - mvn coveralls:report -Ptravis

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/listener/CreatedUpdatedListener.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/listener/CreatedUpdatedListener.java
@@ -57,9 +57,13 @@ public final class CreatedUpdatedListener
                     .getPropertyNames();
             Object[] state = event.getState();
 
+            // Not all databases support milliseconds, let's just drop them.
+            Calendar now = Calendar.getInstance(timeZone);
+            now.set(Calendar.MILLISECOND, 0);
+
             AbstractEntity persistingEntity = (AbstractEntity) entity;
-            persistingEntity.setCreatedDate(Calendar.getInstance(timeZone));
-            persistingEntity.setModifiedDate(Calendar.getInstance(timeZone));
+            persistingEntity.setCreatedDate(now);
+            persistingEntity.setModifiedDate(now);
 
             setValue(state, propertyNames, "createdDate",
                     persistingEntity.getCreatedDate());
@@ -84,8 +88,12 @@ public final class CreatedUpdatedListener
                     .getPropertyNames();
             Object[] state = event.getState();
 
+            // Not all databases support milliseconds, let's just drop them.
+            Calendar now = Calendar.getInstance(timeZone);
+            now.set(Calendar.MILLISECOND, 0);
+
             AbstractEntity persistingEntity = (AbstractEntity) entity;
-            persistingEntity.setModifiedDate(Calendar.getInstance(timeZone));
+            persistingEntity.setModifiedDate(now);
 
             setValue(state, propertyNames, "modifiedDate",
                     persistingEntity.getModifiedDate());

--- a/kangaroo-common/src/main/resources/logback.xml
+++ b/kangaroo-common/src/main/resources/logback.xml
@@ -34,6 +34,7 @@
   <logger name="org.apache.http" level="WARN"/>
   <logger name="com.mchange" level="WARN"/>
   <logger name="org.hibernate" level="WARN"/>
+  <logger name="org.hibernate.orm.deprecation" level="OFF"/>
   <logger name="org.jboss" level="WARN"/>
   <logger name="net.sourceforge.cobertura" level="WARN"/>
   <logger name="liquibase" level="WARN"/>

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/ApplicationBuilder.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/ApplicationBuilder.java
@@ -250,7 +250,6 @@ public final class ApplicationBuilder {
         context.role.setApplication(context.application);
 
         // Attach all the scopes.
-        SortedMap<String, ApplicationScope> roleScopes = new TreeMap<>();
         for (String scopeName : scopeNames) {
             if (context.scopes.containsKey(scopeName)) {
                 ApplicationScope scope = context.scopes.get(scopeName);
@@ -731,7 +730,6 @@ public final class ApplicationBuilder {
      * @return The constructed context, detached from the hibernate session.
      */
     public ApplicationContext build() {
-
         Session session = context.session;
 
         // Persist/update
@@ -978,41 +976,6 @@ public final class ApplicationBuilder {
             snapshot.referrer = referrer;
 
             return snapshot;
-        }
-
-        /**
-         * Return a list of all entities for easy iteration.
-         *
-         * @return A list of all entities associated with this builder.
-         */
-        private List<AbstractEntity> getAllEntities() {
-            List<AbstractEntity> entities = new ArrayList<>();
-            nullSafeAdd(entities, application);
-            nullSafeAdd(entities, client);
-            nullSafeAdd(entities, authenticator);
-            nullSafeAdd(entities, authenticatorState);
-            nullSafeAdd(entities, role);
-            nullSafeAdd(entities, user);
-            nullSafeAdd(entities, userIdentity);
-            nullSafeAdd(entities, token);
-            nullSafeAdd(entities, redirect);
-            nullSafeAdd(entities, referrer);
-            entities.addAll(scopes.values());
-
-            return entities;
-        }
-
-        /**
-         * Check for null on an instance, and if not null add it to the list.
-         *
-         * @param list The list to add to.
-         * @param item The item to check for null.
-         * @param <T>  The type.
-         */
-        private <T> void nullSafeAdd(final List<T> list, final T item) {
-            if (item != null) {
-                list.add(item);
-            }
         }
     }
 }

--- a/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/OAuthTokenService.java
+++ b/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/OAuthTokenService.java
@@ -285,6 +285,7 @@ public final class OAuthTokenService extends AbstractService {
         // Yay, we're valid! Save it.
         Session s = getSession();
         s.save(validToken);
+        s.getTransaction().commit();
 
         // Build the URI of the new resources.
         URI resourceLocation = getUriInfo().getAbsolutePathBuilder()


### PR DESCRIPTION
This patch enables mysql in the gate, and makes a few modifications to our
classes in order to support it. In particular:

- The Hibernate Service Registry Factory test can now test for the h2 and
  the mysql dialect.
- CreatedUpdatedListener scrubs out milliseconds, as that granularity
  is not supported on mysql-style databases.
- All searches now ignore field bridges, so that we can search on enum
  values as well.