### PR TITLE
Only create one single jersey container per search/browse suite.

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/migration/LiquibaseMigrationContainerListener.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/migration/LiquibaseMigrationContainerListener.java
@@ -126,7 +126,7 @@ public final class LiquibaseMigrationContainerListener
 
         @Override
         protected void configure() {
-            bind(SearchIndexContainerLifecycleListener.class)
+            bind(LiquibaseMigrationContainerListener.class)
                     .to(ContainerLifecycleListener.class)
                     .in(Singleton.class);
         }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/runner/ParameterizedSingleInstanceTestRunner.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/runner/ParameterizedSingleInstanceTestRunner.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.test.runner;
+
+import org.junit.runner.Runner;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
+import org.junit.runners.parameterized.ParametersRunnerFactory;
+import org.junit.runners.parameterized.TestWithParameters;
+
+import java.util.List;
+
+/**
+ * A parameterized test runner which only creates a single instance of the test
+ * class for all executions, rather than an instance per execution.
+ * <p>
+ * This is a straight copy/paste of the BlockJUnit4ClassRunnerWithParameters
+ * class, which unfortunately isn't that extensible. If something breaks
+ * here, copy/paste the originating class and see if that does it.
+ *
+ * @author Michael Krotscheck
+ */
+public final class ParameterizedSingleInstanceTestRunner
+        extends BlockJUnit4ClassRunner {
+
+    /**
+     * The test parameters.
+     */
+    private final Object[] parameters;
+
+    /**
+     * The name of the test.
+     */
+    private final String name;
+
+    /**
+     * Create a new instance of this test runner.
+     *
+     * @param test The test to run.
+     * @throws InitializationError Thrown if the test class is malformed.
+     */
+    public ParameterizedSingleInstanceTestRunner(final TestWithParameters test)
+            throws InitializationError {
+        super(test.getTestClass().getJavaClass());
+        parameters = test.getParameters().toArray(
+                new Object[test.getParameters().size()]);
+        name = test.getName();
+    }
+
+    /**
+     * Create a new test, with the parameters captured.
+     *
+     * @return A new test instance.
+     * @throws Exception Thrown if we cannot instantiate the test.
+     */
+    @Override
+    public Object createTest() throws Exception {
+        return TestInstanceManager.getInstance(getTestClass(),
+                getChildren().size(), parameters);
+    }
+
+    @Override
+    protected void validateConstructor(final List<Throwable> errors) {
+        validateOnlyOneConstructor(errors);
+    }
+
+    /**
+     * Return the test name.
+     *
+     * @return The test name.
+     */
+    @Override
+    protected String getName() {
+        return name;
+    }
+
+    /**
+     * Return the method name.
+     *
+     * @param method The method to name.
+     * @return The method test name.
+     */
+    @Override
+    protected String testName(final FrameworkMethod method) {
+        return method.getName() + getName();
+    }
+
+    /**
+     * Return the class block.
+     *
+     * @param notifier The run notifier for this class block.
+     * @return The run block.
+     */
+    @Override
+    protected Statement classBlock(final RunNotifier notifier) {
+        return childrenInvoker(notifier);
+    }
+
+    public static final class ParameterizedSingleInstanceTestRunnerFactory
+            implements ParametersRunnerFactory {
+        /**
+         * Returns a runner for the specified {@link TestWithParameters}.
+         *
+         * @param test
+         * @throws InitializationError if the runner could not be created.
+         */
+        @Override
+        public Runner createRunnerForTestWithParameters(
+                final TestWithParameters test) throws InitializationError {
+            return new ParameterizedSingleInstanceTestRunner(test);
+        }
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/runner/SingleInstanceTestRunner.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/runner/SingleInstanceTestRunner.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.test.runner;
+
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.InitializationError;
+
+/**
+ * A test runner which only creates a single instance of the test class for
+ * all executions, rather than an instance per execution.
+ *
+ * @author Michael Krotscheck
+ */
+public class SingleInstanceTestRunner
+        extends BlockJUnit4ClassRunner {
+
+    /**
+     * Creates a BlockJUnit4ClassRunner to run {@code klass}
+     *
+     * @param klass The test class to execute.
+     * @throws InitializationError If the test class is malformed.
+     */
+    public SingleInstanceTestRunner(final Class<?> klass)
+            throws InitializationError {
+        super(klass);
+    }
+
+    /**
+     * Returns a new fixture for running a test. Default implementation executes
+     * the test class's no-argument constructor (validation should have ensured
+     * one exists).
+     */
+    @Override
+    protected Object createTest() throws Exception {
+        return TestInstanceManager.getInstance(getTestClass(),
+                getChildren().size());
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/runner/TestInstanceManager.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/runner/TestInstanceManager.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.test.runner;
+
+import org.junit.runners.model.TestClass;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Small internal helper pojo, which keeps track of how often this
+ * instance was requested.
+ *
+ * @author Michael Krotscheck
+ */
+public final class TestInstanceManager {
+
+    /**
+     * A static cache of all test classes that have been created.
+     */
+    private static Map<String, ManagedInstance> instanceCache =
+            new HashMap<>();
+
+    /**
+     * Return a managed test instance for the specified test class.
+     *
+     * @param tClass     The test class.
+     * @param totalCount The total number of expected invocations.
+     * @return A managed test instance.
+     * @throws Exception Thrown if the test is malformed.
+     */
+    public static Object getInstance(final TestClass tClass,
+                                     final int totalCount)
+            throws Exception {
+        return getInstance(tClass, totalCount, (Object[]) null);
+    }
+
+    /**
+     * Return a managed test instance for the specified test class.
+     *
+     * @param tClass     The test class.
+     * @param totalCount The total number of expected invocations.
+     * @param initArgs   Initialization arguments.
+     * @return A managed test instance.
+     * @throws Exception Thrown if the test is malformed.
+     */
+    public static Object getInstance(final TestClass tClass,
+                                     final int totalCount,
+                                     final Object... initArgs)
+            throws Exception {
+
+        // Build a unique key for this test class & init args.
+        String hashCode = "";
+        if (initArgs != null) {
+            hashCode = "_" + String.valueOf(Arrays.hashCode(initArgs));
+        }
+        String key = String.format("%s%s", tClass.getName(), hashCode);
+
+        if (!instanceCache.containsKey(key)) {
+            instanceCache.put(key, new ManagedInstance(totalCount,
+                    tClass.getOnlyConstructor().newInstance(initArgs)));
+        }
+        ManagedInstance marker = instanceCache.get(key);
+        Object instance = marker.get();
+        if (marker.isExhausted()) {
+            instanceCache.remove(key);
+        }
+        return instance;
+    }
+
+    /**
+     * Utility class, private constructor.
+     */
+    private TestInstanceManager() {
+
+    }
+
+
+    /**
+     * Small internal helper pojo, which keeps track of how often this
+     * instance was requested.
+     */
+    private static class ManagedInstance {
+
+        /**
+         * The total number of test executions we're expecting.
+         */
+        private final int totalCount;
+
+        /**
+         * The total number of times this instance has been requested.
+         */
+        private int currentCount = 0;
+
+        /**
+         * The test instance.
+         */
+        private final Object instance;
+
+        /**
+         * Create a new instance of this marker.
+         *
+         * @param totalCount The total number of executions we're expecting.
+         * @param instance   The instance to manage
+         */
+        ManagedInstance(final int totalCount,
+                        final Object instance) {
+            this.totalCount = totalCount;
+            this.instance = instance;
+        }
+
+        /**
+         * Retrieve the instance, but only 'totalCount' times.
+         *
+         * @return The instance.
+         */
+        public Object get() {
+            currentCount++;
+            return instance;
+        }
+
+        /**
+         * Return true if we've requested the instance totalCount # of times.
+         *
+         * @return True if we've exhausted this resource, otherwise false.
+         */
+        public boolean isExhausted() {
+            return currentCount >= totalCount;
+        }
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/runner/package-info.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/runner/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Custom test runners.
+ */
+package net.krotscheck.kangaroo.test.runner;

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AbstractResourceTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AbstractResourceTest.java
@@ -80,15 +80,22 @@ public abstract class AbstractResourceTest extends ContainerTest {
             new TestDataResource(HIBERNATE_RESOURCE);
 
     /**
+     * The current running test application.
+     */
+    private ResourceConfig testApplication;
+
+    /**
      * Create the application under test.
      *
      * @return A configured api servlet.
      */
     @Override
     protected final ResourceConfig createApplication() {
-        ResourceConfig v1Api = new AdminV1API();
-        v1Api.register(new TestAuthenticator.Binder());
-        return v1Api;
+        if (testApplication == null) {
+            testApplication = new AdminV1API();
+            testApplication.register(new TestAuthenticator.Binder());
+        }
+        return testApplication;
     }
 
     /**

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AbstractServiceBrowseTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AbstractServiceBrowseTest.java
@@ -25,13 +25,18 @@ import net.krotscheck.kangaroo.database.entity.ClientType;
 import net.krotscheck.kangaroo.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.database.entity.User;
 import net.krotscheck.kangaroo.database.entity.UserIdentity;
+import net.krotscheck.kangaroo.servlet.admin.v1.test.SingletonTestContainerFactory;
 import net.krotscheck.kangaroo.test.ApplicationBuilder.ApplicationContext;
 import net.krotscheck.kangaroo.test.HttpUtil;
+import net.krotscheck.kangaroo.test.runner.ParameterizedSingleInstanceTestRunner.ParameterizedSingleInstanceTestRunnerFactory;
+import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.HttpHeaders;
@@ -50,6 +55,7 @@ import java.util.stream.Collectors;
  * @author Michael Krotscheck
  */
 @RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedSingleInstanceTestRunnerFactory.class)
 public abstract class AbstractServiceBrowseTest<T extends AbstractEntity>
         extends AbstractResourceTest {
 
@@ -80,6 +86,11 @@ public abstract class AbstractServiceBrowseTest<T extends AbstractEntity>
     private OAuthToken adminAppToken;
 
     /**
+     * Test container factory.
+     */
+    private SingletonTestContainerFactory testContainerFactory;
+
+    /**
      * Create a new instance of this parameterized test.
      *
      * @param clientType The type of  client.
@@ -92,6 +103,28 @@ public abstract class AbstractServiceBrowseTest<T extends AbstractEntity>
         this.tokenScope = tokenScope;
         this.clientType = clientType;
         this.createUser = createUser;
+    }
+
+    /**
+     * This method overrides the underlying default test container provider,
+     * with one that provides a singleton instance. This allows us to
+     * circumvent the often expensive initialization routines that come from
+     * bootstrapping our services.
+     *
+     * @return an instance of {@link TestContainerFactory} class.
+     * @throws TestContainerException if the initialization of
+     *                                {@link TestContainerFactory} instance
+     *                                is not successful.
+     */
+    protected TestContainerFactory getTestContainerFactory()
+            throws TestContainerException {
+        if (this.testContainerFactory == null) {
+            this.testContainerFactory =
+                    new SingletonTestContainerFactory(
+                            super.getTestContainerFactory(),
+                            this.getClass());
+        }
+        return testContainerFactory;
     }
 
     /**

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AbstractSubserviceBrowseTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AbstractSubserviceBrowseTest.java
@@ -25,12 +25,17 @@ import net.krotscheck.kangaroo.database.entity.ClientType;
 import net.krotscheck.kangaroo.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.database.entity.User;
 import net.krotscheck.kangaroo.database.entity.UserIdentity;
+import net.krotscheck.kangaroo.servlet.admin.v1.test.SingletonTestContainerFactory;
 import net.krotscheck.kangaroo.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.test.runner.ParameterizedSingleInstanceTestRunner.ParameterizedSingleInstanceTestRunnerFactory;
+import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
@@ -49,6 +54,7 @@ import java.util.Map;
  * @author Michael Krotscheck
  */
 @RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedSingleInstanceTestRunnerFactory.class)
 public abstract class AbstractSubserviceBrowseTest<K extends AbstractEntity,
         T extends AbstractEntity> extends AbstractResourceTest {
 
@@ -84,6 +90,11 @@ public abstract class AbstractSubserviceBrowseTest<K extends AbstractEntity,
     private ApplicationContext otherApp;
 
     /**
+     * Test container factory.
+     */
+    private SingletonTestContainerFactory testContainerFactory;
+
+    /**
      * Create a new instance of this parameterized test.
      *
      * @param clientType The type of  client.
@@ -96,6 +107,28 @@ public abstract class AbstractSubserviceBrowseTest<K extends AbstractEntity,
         this.tokenScope = tokenScope;
         this.clientType = clientType;
         this.createUser = createUser;
+    }
+
+    /**
+     * This method overrides the underlying default test container provider,
+     * with one that provides a singleton instance. This allows us to
+     * circumvent the often expensive initialization routines that come from
+     * bootstrapping our services.
+     *
+     * @return an instance of {@link TestContainerFactory} class.
+     * @throws TestContainerException if the initialization of
+     *                                {@link TestContainerFactory} instance
+     *                                is not successful.
+     */
+    protected TestContainerFactory getTestContainerFactory()
+            throws TestContainerException {
+        if (this.testContainerFactory == null) {
+            this.testContainerFactory =
+                    new SingletonTestContainerFactory(
+                            super.getTestContainerFactory(),
+                            this.getClass());
+        }
+        return testContainerFactory;
     }
 
     /**

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/test/SingletonTestContainerFactory.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/test/SingletonTestContainerFactory.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.servlet.admin.v1.test;
+
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.spi.TestContainer;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
+import org.junit.Test;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This class provides a singleton test container for a jersey test.
+ *
+ * @author Michael Krotscheck
+ */
+public class SingletonTestContainerFactory implements TestContainerFactory {
+
+    /**
+     * The number of expected tests.
+     */
+    private int testCount = 0;
+
+    /**
+     * Wrapped factory, used to generate instances if we don't have one yet.
+     */
+    private final TestContainerFactory defaultFactory;
+
+    /**
+     * List of test containers that have been generated during this run.
+     */
+    private TestContainer currentContainer;
+
+    /**
+     * Create a new singleton test container factory, wrapped around an
+     * existing factory type.
+     *
+     * @param defaultFactory The factory to wrap.
+     * @param testClass      The test class this instance
+     *                       has been created for. Used to find the expected
+     *                       # of tests.
+     */
+    public SingletonTestContainerFactory(
+            final TestContainerFactory defaultFactory,
+            final Class testClass) {
+        this.defaultFactory = defaultFactory;
+
+        List<Method> methods = getMethodsAnnotatedWith(testClass,
+                Test.class);
+        testCount = methods.size();
+    }
+
+    /**
+     * Create a test container instance.
+     *
+     * @param baseUri           base URI for the test container to run at.
+     * @param deploymentContext deployment context of the tested JAX-RS / Jersey application .
+     * @return new test container configured to run the tested application.
+     * @throws IllegalArgumentException if {@code deploymentContext} is not supported
+     *                                  by this test container factory.
+     */
+    @Override
+    public TestContainer create(final URI baseUri,
+                                final DeploymentContext deploymentContext) {
+        if (currentContainer == null) {
+            TestContainer created = defaultFactory.create(baseUri,
+                    deploymentContext);
+            currentContainer = new SingletonTestContainer(created, testCount);
+        }
+
+        return currentContainer;
+    }
+
+    public static List<Method> getMethodsAnnotatedWith(
+            final Class<?> type,
+            final Class<? extends Annotation> annotation) {
+        final List<Method> methods = new ArrayList<Method>();
+        Class<?> klass = type;
+        while (klass != Object.class) {
+
+            final List<Method> allMethods =
+                    new ArrayList<>(Arrays.asList(klass.getDeclaredMethods()));
+            for (final Method method : allMethods) {
+                if (method.isAnnotationPresent(annotation)) {
+                    methods.add(method);
+                }
+            }
+            // move to the upper class in the hierarchy in search for more methods
+            klass = klass.getSuperclass();
+        }
+        return methods;
+    }
+
+    /**
+     * Wrapper test container, ensures that a container is only started once.
+     */
+    private static class SingletonTestContainer implements TestContainer {
+
+        /**
+         * How often are we expecting this container to be started?
+         */
+        private final int totalStartsExpected;
+
+        /**
+         * How often has this container been started?
+         */
+        private int startRequests = 0;
+
+        /**
+         * Have we already started this container?
+         */
+        private boolean started = false;
+
+        /**
+         * The wrapped testcontainer.
+         */
+        private final TestContainer wrapped;
+
+        /**
+         * Create a new SingletonTestContainer, wrapping an existing one.
+         *
+         * @param wrapped             The container to wrap.
+         * @param totalStartsExpected The total number of
+         *                            start() requests we're
+         *                            expecting.
+         */
+        SingletonTestContainer(final TestContainer wrapped,
+                               final int totalStartsExpected) {
+            this.wrapped = wrapped;
+            this.totalStartsExpected = totalStartsExpected;
+        }
+
+        /**
+         * Get a client configuration specific to the test container.
+         *
+         * @return a client configuration specific to the test container, otherwise {@code null} if there
+         * is no specific client configuration required.
+         */
+        @Override
+        public ClientConfig getClientConfig() {
+            return wrapped.getClientConfig();
+        }
+
+        /**
+         * Get the base URI of the application.
+         *
+         * @return the base URI of the application.
+         */
+        @Override
+        public URI getBaseUri() {
+            return wrapped.getBaseUri();
+        }
+
+        /**
+         * Start the container.
+         */
+        @Override
+        public void start() {
+            startRequests++;
+            if (!started) {
+                wrapped.start();
+                started = true;
+            }
+        }
+
+        /**
+         * Stop the container, but only if it's been started the expected
+         * number of times.
+         */
+        @Override
+        public void stop() {
+            if (startRequests == totalStartsExpected) {
+                wrapped.stop();
+                started = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This patch extends the Parallel Test Runner, as well as the standard
Jersey TestContainerFactory, in order to ensure that only one single
jersey2 container is started for an entire suite of browse/search tests.