### PR TITLE
Switched datetime columns to timestamp

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/AbstractEntity.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/AbstractEntity.java
@@ -93,12 +93,14 @@ public abstract class AbstractEntity implements Cloneable {
      * The date this record was created.
      */
     @Column(name = "createdDate")
+    @Type(type = "net.krotscheck.kangaroo.database.type.CalendarTimestampType")
     private Calendar createdDate;
 
     /**
      * The date this record was last modified.
      */
     @Column(name = "modifiedDate")
+    @Type(type = "net.krotscheck.kangaroo.database.type.CalendarTimestampType")
     private Calendar modifiedDate;
 
     /**

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/listener/CreatedUpdatedListener.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/listener/CreatedUpdatedListener.java
@@ -57,10 +57,7 @@ public final class CreatedUpdatedListener
                     .getPropertyNames();
             Object[] state = event.getState();
 
-            // Not all databases support milliseconds, let's just drop them.
             Calendar now = Calendar.getInstance(timeZone);
-            now.set(Calendar.MILLISECOND, 0);
-
             AbstractEntity persistingEntity = (AbstractEntity) entity;
             persistingEntity.setCreatedDate(now);
             persistingEntity.setModifiedDate(now);
@@ -88,10 +85,7 @@ public final class CreatedUpdatedListener
                     .getPropertyNames();
             Object[] state = event.getState();
 
-            // Not all databases support milliseconds, let's just drop them.
             Calendar now = Calendar.getInstance(timeZone);
-            now.set(Calendar.MILLISECOND, 0);
-
             AbstractEntity persistingEntity = (AbstractEntity) entity;
             persistingEntity.setModifiedDate(now);
 

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/type/CalendarTimestampType.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/type/CalendarTimestampType.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.database.type;
+
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.usertype.UserType;
+
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Calendar;
+
+
+/**
+ * Custom hibernate type that permits storing Calendar's into varchar columns.
+ *
+ * @author Michael Krotscheck
+ */
+public final class CalendarTimestampType implements UserType {
+
+    /**
+     * Return the SQL type codes for the columns mapped by this type. The
+     * codes are defined on <tt>java.sql.Types</tt>.
+     *
+     * @return int[] the typecodes
+     * @see Types
+     */
+    @Override
+    public int[] sqlTypes() {
+        return new int[]{Types.BIGINT};
+    }
+
+    /**
+     * The class returned by <tt>nullSafeGet()</tt>.
+     *
+     * @return Class
+     */
+    @Override
+    public Class returnedClass() {
+        return Calendar.class;
+    }
+
+    /**
+     * Compare two instances of the class mapped by this type for persistence
+     * "equality". Equality of the persistent state.
+     *
+     * @param x Left
+     * @param y Right
+     * @return boolean True if they are equal.
+     */
+    @Override
+    public boolean equals(final Object x,
+                          final Object y) throws HibernateException {
+        if (x == null) {
+            return y == null;
+        }
+        return x.equals(y);
+    }
+
+    /**
+     * Get a hashcode for the instance, consistent with persistence "equality".
+     *
+     * @param x The object to hash.
+     */
+    @Override
+    public int hashCode(final Object x) throws HibernateException {
+        return x.hashCode();
+    }
+
+    /**
+     * Retrieve an instance of the mapped class from a JDBC resultset.
+     * Implementors should handle possibility of null values.
+     *
+     * @param rs      A JDBC result set
+     * @param names   The column names
+     * @param session The session implementation.
+     * @param owner   the containing entity  @return Object
+     * @throws HibernateException Thrown if hibernate throws up.
+     * @throws SQLException       Thrown if the type is not mapped properly.
+     */
+    @Override
+    public Object nullSafeGet(final ResultSet rs,
+                              final String[] names,
+                              final SharedSessionContractImplementor session,
+                              final Object owner)
+            throws HibernateException, SQLException {
+        // Read the value as a string, so we can check for null.
+        String timeInMillisStr = rs.getString(names[0]);
+        if (timeInMillisStr == null) {
+            return null;
+        }
+        Long timeInMillis = Long.valueOf(timeInMillisStr);
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTimeInMillis(timeInMillis);
+        return calendar;
+    }
+
+    /**
+     * Write an instance of the mapped class to a prepared statement.
+     * Implementors should handle possibility of null values. A multi-column
+     * type should be written to parameters starting from <tt>index</tt>.
+     *
+     * @param st      A JDBC prepared statement.
+     * @param value   The object to write.
+     * @param index   Statement parameter index.
+     * @param session The session implementation.
+     * @throws HibernateException Thrown if hibernate throws up.
+     * @throws SQLException       Thrown if the type is not mapped properly.
+     */
+    @Override
+    public void nullSafeSet(final PreparedStatement st,
+                            final Object value,
+                            final int index,
+                            final SharedSessionContractImplementor session)
+            throws HibernateException, SQLException {
+        if (value != null) {
+            Calendar calendar = (Calendar) value;
+            st.setLong(index, calendar.getTimeInMillis());
+        } else {
+            st.setNull(index, Types.BIGINT);
+        }
+    }
+
+    /**
+     * Return a deep copy of the persistent state, stopping at entities and at
+     * collections. It is not necessary to copy immutable objects, or null
+     * values, in which case it is safe to simply return the argument.
+     *
+     * @param value the object to be cloned, which may be null
+     * @return Object a copy
+     */
+    @Override
+    public Object deepCopy(final Object value) throws HibernateException {
+        return value;
+    }
+
+    /**
+     * Are objects of this type mutable?
+     *
+     * @return boolean
+     */
+    @Override
+    public boolean isMutable() {
+        return false;
+    }
+
+    /**
+     * Transform the object into its cacheable representation. At the very
+     * least this method should perform a deep copy if the type is mutable.
+     * That may not be enough for some implementations, however; for example,
+     * associations must be cached as identifier values. (optional operation)
+     *
+     * @param value The object to be cached
+     * @return A cachable representation of the object
+     * @throws HibernateException Thrown if hibernate throws up.
+     */
+    @Override
+    public Serializable disassemble(final Object value)
+            throws HibernateException {
+        Calendar calendar = (Calendar) value;
+        return calendar.getTimeInMillis();
+    }
+
+    /**
+     * Reconstruct an object from the cacheable representation. At the very
+     * least this method should perform a deep copy if the type is mutable.
+     * (optional operation)
+     *
+     * @param cached The object to be cached.
+     * @param owner  The owner of the cached object.
+     * @return A reconstructed object from the cachable representation.
+     * @throws HibernateException Thrown if hibernate throws up.
+     */
+    @Override
+    public Object assemble(final Serializable cached,
+                           final Object owner) throws HibernateException {
+        Long timeInMillis = (Long) cached;
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTimeInMillis(timeInMillis);
+        return calendar;
+    }
+
+    /**
+     * During merge, replace the existing (target) value in the entity we are
+     * merging to with a new (original) value from the detached entity we are
+     * merging. For immutable objects, or null values, it is safe to simply
+     * return the first parameter. For mutable objects, it is safe to return
+     * a copy of the first parameter. For objects with component values, it
+     * might make sense to recursively replace component values.
+     *
+     * @param original the value from the detached entity being merged.
+     * @param target   the value in the managed entity.
+     * @param owner    The owning entity.
+     * @return the value to be merged
+     */
+    @Override
+    public Object replace(final Object original,
+                          final Object target,
+                          final Object owner)
+            throws HibernateException {
+        return original;
+    }
+}

--- a/kangaroo-common/src/main/resources/liquibase/db.changelog-1.0.0.yaml
+++ b/kangaroo-common/src/main/resources/liquibase/db.changelog-1.0.0.yaml
@@ -17,10 +17,10 @@ databaseChangeLog:
                   primaryKeyName: pk_configuration_id
             - column:
                 name: createdDate
-                type: datetime
+                type: bigint
             - column:
                 name: modifiedDate
-                type: datetime
+                type: bigint
             - column:
                 name: section
                 type: varchar(255)
@@ -69,10 +69,10 @@ databaseChangeLog:
                   primaryKeyName: pk_applications_id
             - column:
                 name: createdDate
-                type: datetime
+                type: bigint
             - column:
                 name: modifiedDate
-                type: datetime
+                type: bigint
             - column:
                 name: owner
                 type: BINARY(16)
@@ -95,10 +95,10 @@ databaseChangeLog:
                   primaryKeyName: pk_application_scopes_id
             - column:
                 name: createdDate
-                type: datetime
+                type: bigint
             - column:
                 name: modifiedDate
-                type: datetime
+                type: bigint
             - column:
                 name: application
                 type: BINARY(16)
@@ -151,10 +151,10 @@ databaseChangeLog:
                   primaryKeyName: pk_roles_id
             - column:
                 name: createdDate
-                type: datetime
+                type: bigint
             - column:
                 name: modifiedDate
-                type: datetime
+                type: bigint
             - column:
                 name: application
                 type: BINARY(16)
@@ -240,10 +240,10 @@ databaseChangeLog:
                   primaryKeyName: pk_users_id
             - column:
                 name: createdDate
-                type: datetime
+                type: bigint
             - column:
                 name: modifiedDate
-                type: datetime
+                type: bigint
             - column:
                 name: application
                 type: BINARY(16)
@@ -295,10 +295,10 @@ databaseChangeLog:
                   primaryKeyName: pk_clients_id
             - column:
                 name: createdDate
-                type: datetime
+                type: bigint
             - column:
                 name: modifiedDate
-                type: datetime
+                type: bigint
             - column:
                 name: application
                 type: BINARY(16)
@@ -344,10 +344,10 @@ databaseChangeLog:
                   primaryKeyName: pk_client_referrers_id
             - column:
                 name: createdDate
-                type: datetime
+                type: bigint
             - column:
                 name: modifiedDate
-                type: datetime
+                type: bigint
             - column:
                 name: client
                 type: BINARY(16)
@@ -392,10 +392,10 @@ databaseChangeLog:
                   primaryKeyName: pk_client_redirects_id
             - column:
                 name: createdDate
-                type: datetime
+                type: bigint
             - column:
                 name: modifiedDate
-                type: datetime
+                type: bigint
             - column:
                 name: client
                 type: BINARY(16)
@@ -489,10 +489,10 @@ databaseChangeLog:
                   primaryKeyName: pk_authenticators_id
             - column:
                 name: createdDate
-                type: datetime
+                type: bigint
             - column:
                 name: modifiedDate
-                type: datetime
+                type: bigint
             - column:
                 name: client
                 type: BINARY(16)
@@ -576,10 +576,10 @@ databaseChangeLog:
                   primaryKeyName: pk_authenticator_states_id
             - column:
                 name: createdDate
-                type: datetime
+                type: bigint
             - column:
                 name: modifiedDate
-                type: datetime
+                type: bigint
             - column:
                 name: authenticator
                 type: BINARY(16)
@@ -677,10 +677,10 @@ databaseChangeLog:
                   primaryKeyName: pk_user_identities_id
             - column:
                 name: createdDate
-                type: datetime
+                type: bigint
             - column:
                 name: modifiedDate
-                type: datetime
+                type: bigint
             - column:
                 name: user
                 type: BINARY(16)
@@ -795,10 +795,10 @@ databaseChangeLog:
                   primaryKeyName: pk_oauth_tokens_id
             - column:
                 name: createdDate
-                type: datetime
+                type: bigint
             - column:
                 name: modifiedDate
-                type: datetime
+                type: bigint
             - column:
                 name: identity
                 type: BINARY(16)

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/type/CalendarTimestampTypeTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/type/CalendarTimestampTypeTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.database.type;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Types;
+import java.util.Calendar;
+
+import static org.mockito.Mockito.times;
+
+/**
+ * Unit test for the calendar-to-timestamp converter.
+ *
+ * @author Michael Krotscheck
+ */
+public final class CalendarTimestampTypeTest {
+
+    /**
+     * Assert that we map to the correct types.
+     */
+    @Test
+    public void sqlTypes() {
+        CalendarTimestampType type = new CalendarTimestampType();
+
+        int[] types = type.sqlTypes();
+        Assert.assertEquals(1, types.length);
+        Assert.assertEquals(Types.BIGINT, types[0]);
+    }
+
+    /**
+     * Assert that the converted type is a calendar.
+     */
+    @Test
+    public void returnedClass() {
+        CalendarTimestampType type = new CalendarTimestampType();
+
+        Assert.assertEquals(Calendar.class, type.returnedClass());
+    }
+
+    /**
+     * Assert that comparison works.
+     */
+    @Test
+    public void equals() {
+        CalendarTimestampType type = new CalendarTimestampType();
+
+        Calendar one = Calendar.getInstance();
+        Calendar two = (Calendar) one.clone();
+        Calendar three = Calendar.getInstance();
+        three.add(Calendar.MINUTE, 1);
+
+        // Basic comparison
+        Assert.assertTrue(type.equals(one, two));
+        Assert.assertFalse(type.equals(three, two));
+        Assert.assertFalse(type.equals(two, three));
+        Assert.assertTrue(type.equals(null, null));
+        Assert.assertFalse(type.equals(null, two));
+        Assert.assertFalse(type.equals(two, null));
+    }
+
+    /**
+     * Assert that hashcode is passed through to the underlying instance.
+     */
+    @Test
+    public void testHashCode() {
+        CalendarTimestampType type = new CalendarTimestampType();
+
+        Calendar one = Calendar.getInstance();
+        Assert.assertEquals(one.hashCode(), type.hashCode(one));
+    }
+
+    /**
+     * Assert that we can retrieve the calendar.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void nullSafeGet() throws Exception {
+        CalendarTimestampType type = new CalendarTimestampType();
+        String[] names = new String[]{"test"};
+        ResultSet rs = Mockito.mock(ResultSet.class);
+        Calendar one = Calendar.getInstance();
+        Mockito.doReturn(String.valueOf(one.getTimeInMillis()))
+                .when(rs).getString(names[0]);
+        Calendar result = (Calendar)
+                type.nullSafeGet(rs, names, null, null);
+
+        Assert.assertEquals(one, result);
+    }
+
+    /**
+     * Assert that a null value returns null.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void nullSafeGetNull() throws Exception {
+        CalendarTimestampType type = new CalendarTimestampType();
+        String[] names = new String[]{"test"};
+        ResultSet rs = Mockito.mock(ResultSet.class);
+        Mockito.doReturn(null).when(rs).getString(names[0]);
+        Calendar result = (Calendar)
+                type.nullSafeGet(rs, names, null, null);
+
+        Assert.assertNull(result);
+    }
+
+    /**
+     * Assert that we can set a value.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void nullSafeSet() throws Exception {
+        CalendarTimestampType type = new CalendarTimestampType();
+        PreparedStatement st = Mockito.mock(PreparedStatement.class);
+        Calendar one = Calendar.getInstance();
+        type.nullSafeSet(st, one, 0, null);
+        Mockito.verify(st, times(1))
+                .setLong(0, one.getTimeInMillis());
+    }
+
+    /**
+     * Assert that setting with a null value sets null.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void nullSafeSetNull() throws Exception {
+        CalendarTimestampType type = new CalendarTimestampType();
+        PreparedStatement st = Mockito.mock(PreparedStatement.class);
+        type.nullSafeSet(st, null, 0, null);
+        Mockito.verify(st, times(1)).setNull(0, Types.BIGINT);
+    }
+
+    /**
+     * Assert that deepCopy returns the same (immutable) instance.
+     */
+    @Test
+    public void deepCopy() {
+        CalendarTimestampType type = new CalendarTimestampType();
+        Calendar one = Calendar.getInstance();
+        Assert.assertSame(one, type.deepCopy(one));
+    }
+
+    /**
+     * Assert that ismutable is false.
+     */
+    @Test
+    public void isMutable() {
+        CalendarTimestampType type = new CalendarTimestampType();
+        Assert.assertFalse(type.isMutable());
+    }
+
+    /**
+     * Assert that a calendar is disassembled into a long.
+     */
+    @Test
+    public void disassemble() {
+        CalendarTimestampType type = new CalendarTimestampType();
+
+        Calendar one = Calendar.getInstance();
+        long result = (long) type.disassemble(one);
+        Assert.assertEquals(one.getTimeInMillis(), result);
+    }
+
+    /**
+     * Assert that a long can be converted into a calendar.
+     */
+    @Test
+    public void assemble() {
+        CalendarTimestampType type = new CalendarTimestampType();
+
+        Calendar one = Calendar.getInstance();
+        Calendar result = (Calendar) type.assemble(one.getTimeInMillis(), null);
+        Assert.assertTrue(one.equals(result));
+    }
+
+    /**
+     * This type is immutable, replace should only return the first response.
+     */
+    @Test
+    public void replace() {
+        CalendarTimestampType type = new CalendarTimestampType();
+
+        Calendar one = Calendar.getInstance();
+        Calendar two = Calendar.getInstance();
+        Calendar result = (Calendar) type.replace(one, two, null);
+
+        Assert.assertSame(one, result);
+    }
+}


### PR DESCRIPTION
After mysql 5.6.1, this is permitted, and makes HQL queries a bit
easier when manipulating datetimes.