### PR TITLE
Replace mysql with mariadb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,14 @@ jdk:
 dist: trusty
 sudo: required
 env:
-  - PROFILE=mysql PROJECT=kangaroo-common
-  - PROFILE=mysql PROJECT=kangaroo-server-authz
+  - PROFILE=mariadb PROJECT=kangaroo-common
+  - PROFILE=mariadb PROJECT=kangaroo-server-authz
   - PROFILE=h2 PROJECT=kangaroo-common
   - PROFILE=h2 PROJECT=kangaroo-server-authz
 services:
-  - mysql
   - docker
+addons:
+  mariadb: '10.0'
 branches:
   only:
   - master

--- a/kangaroo-common/pom.xml
+++ b/kangaroo-common/pom.xml
@@ -207,19 +207,16 @@
     <dependency>
       <groupId>com.mchange</groupId>
       <artifactId>c3p0</artifactId>
-      <version>0.9.5.2</version>
     </dependency>
 
     <!-- H2 database, used for testing. -->
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.4.190</version>
     </dependency>
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.31</version>
+      <groupId>org.mariadb.jdbc</groupId>
+      <artifactId>mariadb-java-client</artifactId>
     </dependency>
 
     <!-- Apache Commons -->

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateServiceRegistryFactoryTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateServiceRegistryFactoryTest.java
@@ -26,7 +26,7 @@ import org.glassfish.jersey.server.ResourceConfig;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.H2Dialect;
-import org.hibernate.dialect.MySQLDialect;
+import org.hibernate.dialect.MariaDBDialect;
 import org.hibernate.service.ServiceRegistry;
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -69,8 +69,8 @@ public final class HibernateServiceRegistryFactoryTest {
             case "org.h2.Driver":
                 Assert.assertTrue(d instanceof H2Dialect);
                 break;
-            case "com.mysql.jdbc.Driver":
-                Assert.assertTrue(d instanceof MySQLDialect);
+            case "org.mariadb.jdbc.Driver":
+                Assert.assertTrue(d instanceof MariaDBDialect);
                 break;
             default:
                 Assert.fail(String.format("Unrecognized driver: %s", dbDriver));
@@ -109,8 +109,8 @@ public final class HibernateServiceRegistryFactoryTest {
             case "org.h2.Driver":
                 Assert.assertTrue(d instanceof H2Dialect);
                 break;
-            case "com.mysql.jdbc.Driver":
-                Assert.assertTrue(d instanceof MySQLDialect);
+            case "org.mariadb.jdbc.Driver":
+                Assert.assertTrue(d instanceof MariaDBDialect);
                 break;
             default:
                 Assert.fail(String.format("Unrecognized driver: %s", dbDriver));

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/type/URITypeTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/type/URITypeTest.java
@@ -18,7 +18,7 @@
 
 package net.krotscheck.kangaroo.common.hibernate.type;
 
-import org.hibernate.dialect.MySQL5Dialect;
+import org.hibernate.dialect.MariaDBDialect;
 import org.hibernate.type.DiscriminatorType;
 import org.junit.Assert;
 import org.junit.Test;
@@ -90,7 +90,7 @@ public final class URITypeTest {
     @Test
     public void testObjectToSQLString() throws Exception {
         URIType t = new URIType();
-        String sql = t.objectToSQLString(testUri, new MySQL5Dialect());
+        String sql = t.objectToSQLString(testUri, new MariaDBDialect());
         Assert.assertEquals("'http://example.com'", sql);
     }
 

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/DatabaseResource.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/DatabaseResource.java
@@ -27,7 +27,7 @@ import liquibase.resource.ClassLoaderResourceAccessor;
 import net.krotscheck.kangaroo.test.TestConfig;
 import net.krotscheck.kangaroo.test.rule.database.H2TestDatabase;
 import net.krotscheck.kangaroo.test.rule.database.ITestDatabase;
-import net.krotscheck.kangaroo.test.rule.database.MySQLTestDatabase;
+import net.krotscheck.kangaroo.test.rule.database.MariaDBTestDatabase;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -62,8 +62,8 @@ public final class DatabaseResource implements TestRule {
      */
     public ITestDatabase createDatabase() {
         switch (TestConfig.getDatabase()) {
-            case MYSQL:
-                database = new MySQLTestDatabase("");
+            case MARIADB:
+                database = new MariaDBTestDatabase("");
                 break;
             case H2:
             default:

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/HibernateResource.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/HibernateResource.java
@@ -106,12 +106,8 @@ public class HibernateResource implements TestRule {
                 name);
         System.setProperty("hibernate.search.default.exclusive_index_use",
                 "false");
-
-        // C3P0 Overrides for testing only
-        System.setProperty("initialPoolSize", "0");
-        System.setProperty("maxIdleTime", "0");
-        System.setProperty("maxPoolSize", "5");
-        System.setProperty("minPoolSize", "0");
+        System.setProperty("hibernate.c3p0.min_size", "0");
+        System.setProperty("hibernate.c3p0.max_size", "5");
     }
 
     /**
@@ -121,10 +117,8 @@ public class HibernateResource implements TestRule {
         System.clearProperty("hibernate.search.default.directory_provider");
         System.clearProperty("hibernate.search.default.exclusive_index_use");
 
-        System.clearProperty("initialPoolSize");
-        System.clearProperty("maxIdleTime");
-        System.clearProperty("maxPoolSize");
-        System.clearProperty("minPoolSize");
+        System.clearProperty("hibernate.c3p0.min_size");
+        System.clearProperty("hibernate.c3p0.max_size");
     }
 
     /**

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/database/MariaDBTestDatabase.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/database/MariaDBTestDatabase.java
@@ -27,14 +27,17 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 /**
- * Create a new test database using the mysql driver. We assume that the
+ * Create a new test database using the mariadb driver. We assume that the
  * database is available on 127.0.0.1:3306, and that the root password is
  * blank. If this is not the case, your testing environment is likely not
  * ephemeral enough to be secure.
  *
+ * The reason we're using MariaDB instead of MySQL is because the mysql
+ * driver is GPL'd. Tough cookies, Oracle.
+ *
  * @author Michael Krotscheck
  */
-public final class MySQLTestDatabase extends AbstractTestDatabase
+public final class MariaDBTestDatabase extends AbstractTestDatabase
         implements ITestDatabase {
 
     /**
@@ -47,7 +50,7 @@ public final class MySQLTestDatabase extends AbstractTestDatabase
      *
      * @param rootPassword The root password for the database.
      */
-    public MySQLTestDatabase(final String rootPassword) {
+    public MariaDBTestDatabase(final String rootPassword) {
         this.rootPassword = rootPassword;
     }
 
@@ -86,7 +89,7 @@ public final class MySQLTestDatabase extends AbstractTestDatabase
                 stmt.executeBatch();
             }
         } catch (SQLException e) {
-            throw new RuntimeException("cannot delete mysql database", e);
+            throw new RuntimeException("cannot delete maria database", e);
         }
     }
 
@@ -110,7 +113,7 @@ public final class MySQLTestDatabase extends AbstractTestDatabase
                 stmt.executeBatch();
             }
         } catch (SQLException e) {
-            throw new RuntimeException("cannot create mysql database", e);
+            throw new RuntimeException("cannot create maria database", e);
         }
 
         return this;
@@ -130,7 +133,7 @@ public final class MySQLTestDatabase extends AbstractTestDatabase
                     getUser(),
                     getPassword());
         } catch (SQLException e) {
-            throw new RuntimeException("cannot connect to mysql database", e);
+            throw new RuntimeException("cannot connect to maria database", e);
         }
     }
 
@@ -154,7 +157,7 @@ public final class MySQLTestDatabase extends AbstractTestDatabase
             return DriverManager.getConnection(rootJdbc, "root",
                     rootPassword);
         } catch (SQLException e) {
-            throw new RuntimeException("cannot connect to mysql database",
+            throw new RuntimeException("cannot connect to maria database",
                     e);
         }
     }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/database/TestDB.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/database/TestDB.java
@@ -20,10 +20,8 @@ package net.krotscheck.kangaroo.test.rule.database;
 
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.H2Dialect;
-import org.hibernate.dialect.MySQL55Dialect;
-import org.hibernate.dialect.MySQL57Dialect;
-import org.hibernate.dialect.MySQL5Dialect;
-import org.hibernate.dialect.MySQLDialect;
+import org.hibernate.dialect.MariaDB53Dialect;
+import org.hibernate.dialect.MariaDBDialect;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -37,10 +35,9 @@ import java.util.Set;
 public enum TestDB {
 
     /**
-     * A Mysql database.
+     * A MariaDB database (Also usable for mysql).
      */
-    MYSQL(MySQLDialect.class, MySQL55Dialect.class, MySQL5Dialect.class,
-            MySQL57Dialect.class),
+    MARIADB(MariaDBDialect.class, MariaDB53Dialect.class),
 
     /**
      * An H2 database.

--- a/kangaroo-common/src/test/resources/liquibase/db.changelog-master.yaml
+++ b/kangaroo-common/src/test/resources/liquibase/db.changelog-master.yaml
@@ -4,6 +4,7 @@ databaseChangeLog:
       - dbms:
           type: h2
       - dbms:
+          # Actually MariaDB.
           type: mysql
   - include:
       file: liquibase/db.changelog-common-1.0.0.yaml

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractSubserviceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractSubserviceCRUDTest.java
@@ -52,11 +52,6 @@ public abstract class AbstractSubserviceCRUDTest<K extends AbstractAuthzEntity,
     private final Class<K> parentClass;
 
     /**
-     * Test container factory.
-     */
-    private SingletonTestContainerFactory testContainerFactory;
-
-    /**
      * Create a new instance of this parameterized test.
      *
      * @param parentClass   The raw parent type, used for type-based parsing.
@@ -74,28 +69,6 @@ public abstract class AbstractSubserviceCRUDTest<K extends AbstractAuthzEntity,
                                       final Boolean shouldSucceed) {
         super(childClass, clientType, tokenScope, createUser, shouldSucceed);
         this.parentClass = parentClass;
-    }
-
-    /**
-     * This method overrides the underlying default test container provider,
-     * with one that provides a singleton instance. This allows us to
-     * circumvent the often expensive initialization routines that come from
-     * bootstrapping our services.
-     *
-     * @return an instance of {@link TestContainerFactory} class.
-     * @throws TestContainerException if the initialization of
-     *                                {@link TestContainerFactory} instance
-     *                                is not successful.
-     */
-    protected TestContainerFactory getTestContainerFactory()
-            throws TestContainerException {
-        if (this.testContainerFactory == null) {
-            this.testContainerFactory =
-                    new SingletonTestContainerFactory(
-                            super.getTestContainerFactory(),
-                            this.getClass());
-        }
-        return testContainerFactory;
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientRedirectServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientRedirectServiceCRUDTest.java
@@ -18,11 +18,12 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
+import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
+import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientRedirect;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
-import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hibernate.Session;
@@ -207,7 +208,7 @@ public final class ClientRedirectServiceCRUDTest
      */
     @Override
     protected Client getParentEntity(final ApplicationContext context) {
-        return context.getClient();
+        return getAttached(context.getClient());
     }
 
     /**
@@ -235,8 +236,9 @@ public final class ClientRedirectServiceCRUDTest
      */
     @Override
     protected Client createParentEntity(final ApplicationContext context) {
+        Application a = getAttached(context.getApplication());
         Client c = new Client();
-        c.setApplication(context.getApplication());
+        c.setApplication(a);
         c.setName(UUID.randomUUID().toString());
         c.setType(ClientType.AuthorizationGrant);
         return c;
@@ -250,7 +252,7 @@ public final class ClientRedirectServiceCRUDTest
      */
     @Override
     protected ClientRedirect getEntity(final ApplicationContext context) {
-        return context.getRedirect();
+        return getAttached(context.getRedirect());
     }
 
     /**
@@ -261,7 +263,7 @@ public final class ClientRedirectServiceCRUDTest
     @Override
     protected ClientRedirect getNewEntity() {
         ClientRedirect newEntity = new ClientRedirect();
-        newEntity.setClient(getAdminContext().getClient());
+        newEntity.setClient(getAttached(getAdminContext().getClient()));
         return newEntity;
     }
 

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientReferrerServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientReferrerServiceCRUDTest.java
@@ -208,7 +208,7 @@ public final class ClientReferrerServiceCRUDTest
      */
     @Override
     protected Client getParentEntity(final ApplicationContext context) {
-        return context.getClient();
+        return getAttached(context.getClient());
     }
 
     /**
@@ -237,7 +237,7 @@ public final class ClientReferrerServiceCRUDTest
     @Override
     protected Client createParentEntity(final ApplicationContext context) {
         Client c = new Client();
-        c.setApplication(context.getApplication());
+        c.setApplication(getAttached(context.getApplication()));
         c.setName(UUID.randomUUID().toString());
         c.setType(ClientType.AuthorizationGrant);
         return c;
@@ -251,7 +251,7 @@ public final class ClientReferrerServiceCRUDTest
      */
     @Override
     protected ClientReferrer getEntity(final ApplicationContext context) {
-        return context.getReferrer();
+        return getAttached(context.getReferrer());
     }
 
     /**
@@ -262,7 +262,7 @@ public final class ClientReferrerServiceCRUDTest
     @Override
     protected ClientReferrer getNewEntity() {
         ClientReferrer newEntity = new ClientReferrer();
-        newEntity.setClient(getAdminContext().getClient());
+        newEntity.setClient(getAttached(getAdminContext().getClient()));
         return newEntity;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,11 +62,11 @@
       </properties>
     </profile>
     <profile>
-      <id>mysql</id>
+      <id>mariadb</id>
       <properties>
-        <hibernate.connection.url>jdbc:mysql://127.0.0.1:3306/oid?useUnicode=yes</hibernate.connection.url>
-        <hibernate.connection.driver_class>com.mysql.jdbc.Driver</hibernate.connection.driver_class>
-        <hibernate.dialect>org.hibernate.dialect.MySQL55Dialect</hibernate.dialect>
+        <hibernate.connection.url>jdbc:mariadb://127.0.0.1:3306/oid?useUnicode=yes</hibernate.connection.url>
+        <hibernate.connection.driver_class>org.mariadb.jdbc.Driver</hibernate.connection.driver_class>
+        <hibernate.dialect>org.hibernate.dialect.MariaDBDialect</hibernate.dialect>
       </properties>
     </profile>
   </profiles>
@@ -805,16 +805,16 @@
         <version>2.0.0</version>
       </dependency>
 
-      <!-- H2 database, used for testing. -->
+      <!-- Database drivers. -->
       <dependency>
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
         <version>1.4.195</version>
       </dependency>
       <dependency>
-        <groupId>mysql</groupId>
-        <artifactId>mysql-connector-java</artifactId>
-        <version>5.1.31</version>
+        <groupId>org.mariadb.jdbc</groupId>
+        <artifactId>mariadb-java-client</artifactId>
+        <version>1.5.9</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
MariaDB's drivers are, thankfully, LGPL licensed. MySQL, unfortunately,
is not. This means we can't ship the latter, so we're switching to the
former.