### PR TITLE
CRUDTests are now also singleton instance.

### DIFF
--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AbstractServiceCRUDTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/AbstractServiceCRUDTest.java
@@ -26,15 +26,20 @@ import net.krotscheck.kangaroo.database.entity.ClientType;
 import net.krotscheck.kangaroo.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.database.entity.User;
 import net.krotscheck.kangaroo.database.entity.UserIdentity;
+import net.krotscheck.kangaroo.servlet.admin.v1.test.SingletonTestContainerFactory;
 import net.krotscheck.kangaroo.test.ApplicationBuilder;
 import net.krotscheck.kangaroo.test.ApplicationBuilder.ApplicationContext;
 import net.krotscheck.kangaroo.test.HttpUtil;
+import net.krotscheck.kangaroo.test.runner.ParameterizedSingleInstanceTestRunner.ParameterizedSingleInstanceTestRunnerFactory;
+import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
 import org.hibernate.Session;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -47,6 +52,7 @@ import java.util.UUID;
  * @author Michael Krotscheck
  */
 @RunWith(Parameterized.class)
+@UseParametersRunnerFactory(ParameterizedSingleInstanceTestRunnerFactory.class)
 public abstract class AbstractServiceCRUDTest<T extends AbstractEntity>
         extends AbstractResourceTest {
 
@@ -85,6 +91,33 @@ public abstract class AbstractServiceCRUDTest<T extends AbstractEntity>
      * The token issued to the admin app, with appropriate credentials.
      */
     private OAuthToken adminAppToken;
+
+    /**
+     * Test container factory.
+     */
+    private SingletonTestContainerFactory testContainerFactory;
+
+    /**
+     * This method overrides the underlying default test container provider,
+     * with one that provides a singleton instance. This allows us to
+     * circumvent the often expensive initialization routines that come from
+     * bootstrapping our services.
+     *
+     * @return an instance of {@link TestContainerFactory} class.
+     * @throws TestContainerException if the initialization of
+     *                                {@link TestContainerFactory} instance
+     *                                is not successful.
+     */
+    protected TestContainerFactory getTestContainerFactory()
+            throws TestContainerException {
+        if (this.testContainerFactory == null) {
+            this.testContainerFactory =
+                    new SingletonTestContainerFactory(
+                            super.getTestContainerFactory(),
+                            this.getClass());
+        }
+        return testContainerFactory;
+    }
 
     /**
      * Create a new instance of this parameterized test.


### PR DESCRIPTION
This patch applies the singleton-style testing harness used in the
browse and search tests, to the crud tests as well. It should
dramatically increase build performance.