### PR TITLE
Added application default role

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/Application.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/database/entity/Application.java
@@ -130,6 +130,16 @@ public final class Application extends AbstractEntity {
     private User owner;
 
     /**
+     * The default role for this application.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "defaultRole", nullable = true, updatable = true)
+    @JsonIdentityReference(alwaysAsId = true)
+    @JsonDeserialize(using = Role.Deserializer.class)
+    @IndexedEmbedded(includePaths = "id")
+    private Role defaultRole;
+
+    /**
      * The name of the application.
      */
     @Basic(optional = false)
@@ -245,6 +255,24 @@ public final class Application extends AbstractEntity {
      */
     public void setOwner(final User owner) {
         this.owner = owner;
+    }
+
+    /**
+     * Get the default role for this application.
+     *
+     * @return The default role.
+     */
+    public Role getDefaultRole() {
+        return defaultRole;
+    }
+
+    /**
+     * Set the default role for this application.
+     *
+     * @param defaultRole The default role.
+     */
+    public void setDefaultRole(final Role defaultRole) {
+        this.defaultRole = defaultRole;
     }
 
     /**

--- a/kangaroo-common/src/main/resources/liquibase/db.changelog-1.0.0.yaml
+++ b/kangaroo-common/src/main/resources/liquibase/db.changelog-1.0.0.yaml
@@ -77,6 +77,9 @@ databaseChangeLog:
                 name: owner
                 type: BINARY(16)
             - column:
+                name: defaultRole
+                type: BINARY(16)
+            - column:
                 name: name
                 type: varchar(255)
                 constraints:

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/ApplicationTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/database/entity/ApplicationTest.java
@@ -61,6 +61,19 @@ public final class ApplicationTest {
     }
 
     /**
+     * Test getting/setting the default role.
+     */
+    @Test
+    public void testGetSetDefaultRole() {
+        Application application = new Application();
+        Role role = new Role();
+
+        Assert.assertNull(application.getDefaultRole());
+        application.setDefaultRole(role);
+        Assert.assertEquals(role, application.getDefaultRole());
+    }
+
+    /**
      * Test get/set name.
      */
     @Test
@@ -145,6 +158,9 @@ public final class ApplicationTest {
         User owner = new User();
         owner.setId(UUID.randomUUID());
 
+        Role defaultRole = new Role();
+        defaultRole.setId(UUID.randomUUID());
+
         List<User> users = new ArrayList<>();
         User user = new User();
         user.setId(UUID.randomUUID());
@@ -168,6 +184,7 @@ public final class ApplicationTest {
         a.setName("name");
 
         // These four should not show up in the deserialized version.
+        a.setDefaultRole(defaultRole);
         a.setClients(clients);
         a.setRoles(roles);
         a.setUsers(users);
@@ -191,6 +208,9 @@ public final class ApplicationTest {
                 a.getOwner().getId().toString(),
                 node.get("owner").asText());
         Assert.assertEquals(
+                a.getDefaultRole().getId().toString(),
+                node.get("defaultRole").asText());
+        Assert.assertEquals(
                 a.getName(),
                 node.get("name").asText());
         Assert.assertFalse(node.has("clients"));
@@ -203,7 +223,7 @@ public final class ApplicationTest {
         while (nameIterator.hasNext()) {
             names.add(nameIterator.next());
         }
-        Assert.assertEquals(5, names.size());
+        Assert.assertEquals(6, names.size());
     }
 
     /**

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/ApplicationBuilder.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/ApplicationBuilder.java
@@ -260,6 +260,12 @@ public final class ApplicationBuilder {
 
         persist(context.role);
 
+        // If the application doesn't have a default role, create it.
+        if (context.application.getDefaultRole() == null) {
+            context.application.setDefaultRole(context.role);
+            persist(context.application);
+        }
+
         return this;
     }
 

--- a/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/RoleService.java
+++ b/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/RoleService.java
@@ -322,6 +322,11 @@ public final class RoleService extends AbstractService {
             throw new HttpStatusException(Status.FORBIDDEN);
         }
 
+        // You cannot delete a role that has been set as the default
+        if (role.equals(role.getApplication().getDefaultRole())) {
+            throw new HttpStatusException(Status.BAD_REQUEST);
+        }
+
         // Let's hope they now what they're doing.
         s.delete(role);
 

--- a/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/servlet/FirstRunContainerLifecycleListener.java
+++ b/kangaroo-server-admin/src/main/java/net/krotscheck/kangaroo/servlet/admin/v1/servlet/FirstRunContainerLifecycleListener.java
@@ -148,6 +148,7 @@ public final class FirstRunContainerLifecycleListener
         memberRole.setName("member");
         memberRole.setApplication(servletApp);
         memberRole.setScopes(userScopes);
+        servletApp.setDefaultRole(memberRole);
 
         // Create the first admin
         User adminUser = new User();

--- a/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/RoleServiceCRUDTest.java
+++ b/kangaroo-server-admin/src/test/java/net/krotscheck/kangaroo/servlet/admin/v1/resource/RoleServiceCRUDTest.java
@@ -357,6 +357,27 @@ public final class RoleServiceCRUDTest
     }
 
     /**
+     * Assert that we cannot delete the default role.
+     *
+     * @throws Exception Exception encountered during test.
+     */
+    @Test
+    public void testDeleteDefaultRole() throws Exception {
+        Application second = getSecondaryContext().getApplication();
+        Role defaultRole = second.getDefaultRole();
+
+        Assert.assertNotNull(defaultRole);
+
+        // Issue the request.
+        Response r = deleteEntity(defaultRole, getAdminToken());
+        if (isAccessible(defaultRole, getAdminToken())) {
+            assertErrorResponse(r, Status.BAD_REQUEST);
+        } else {
+            assertErrorResponse(r, Status.NOT_FOUND);
+        }
+    }
+
+    /**
      * Assert that we can link a scope.
      *
      * @throws Exception Exception encountered during test.


### PR DESCRIPTION
Every application can now have a default role, which - once set - must
be maintained. Roles that are currently set as the default cannot be
deleted.

Querying and assigning the default role during authentication is
left to the authenticator, as that may be prescribed by the AuthN provider.