### PR TITLE
Created CORS Feature

### DIFF
--- a/kangaroo-common/pom.xml
+++ b/kangaroo-common/pom.xml
@@ -245,6 +245,12 @@
       <artifactId>commons-io</artifactId>
     </dependency>
 
+    <!-- Google Commons -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
     <!-- Bouncy castle (SSL Certificate generation -->
     <dependency>
       <groupId>org.bouncycastle</groupId>

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/cors/AllowedHeaders.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/cors/AllowedHeaders.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.cors;
+
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+/**
+ * This class assists in managing the systems' permitted CORS headers. By
+ * constructing and registering this binder, you may add any headers you want.
+ *
+ * @author Michael Krotscheck
+ */
+public final class AllowedHeaders extends AbstractBinder {
+
+    /**
+     * The name used for this injection point.
+     */
+    public static final String NAME = "CORS_ALLOWED_HEADERS";
+
+    /**
+     * List of permitted CORS headers to inject.
+     */
+    private final String[] permittedHeaders;
+
+    /**
+     * @param headers The list of headers to provide to CORS as valid request
+     *                headers.
+     */
+    public AllowedHeaders(final String[] headers) {
+        this.permittedHeaders = headers;
+    }
+
+    /**
+     * Implement to provide binding definitions using the exposed binding
+     * methods.
+     */
+    @Override
+    protected void configure() {
+        for (String header : permittedHeaders) {
+            bind(header)
+                    .to(String.class)
+                    .named(NAME);
+        }
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/cors/AllowedMethods.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/cors/AllowedMethods.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.cors;
+
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+/**
+ *
+ */
+public final class AllowedMethods extends AbstractBinder {
+
+    /**
+     * The name used for this injection point.
+     */
+    public static final String NAME = "CORS_ALLOWED_METHODS";
+
+    /**
+     * List of permitted CORS headers to inject.
+     */
+    private final String[] permittedHeaders;
+
+    /**
+     * @param headers The list of headers to provide to CORS as valid request
+     *                headers.
+     */
+    public AllowedMethods(final String[] headers) {
+        this.permittedHeaders = headers;
+    }
+
+    /**
+     * Implement to provide binding definitions using the exposed binding
+     * methods.
+     */
+    @Override
+    protected void configure() {
+        for (String header : permittedHeaders) {
+            bind(header)
+                    .to(String.class)
+                    .named(NAME);
+        }
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/cors/CORSFeature.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/cors/CORSFeature.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.cors;
+
+import com.google.common.net.HttpHeaders;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+/**
+ * CORS Feature, including extendable configuration injectors, and a request
+ * filter that ensures content is only shared as desired.
+ *
+ * @author Michael Krotscheck
+ */
+public final class CORSFeature implements Feature {
+
+    /**
+     * Register this feature.
+     */
+    @Override
+    public boolean configure(final FeatureContext context) {
+
+        // Inject a set of sane defaults that a client may request. If you'd
+        // like to add more headers, please add a similar injector to the
+        // appropriate module.
+        context.register(new AllowedHeaders(new String[]{
+                HttpHeaders.ACCEPT,
+                HttpHeaders.ACCEPT_LANGUAGE,
+                HttpHeaders.CONTENT_LANGUAGE,
+                HttpHeaders.AUTHORIZATION,
+                HttpHeaders.CONTENT_TYPE,
+                HttpHeaders.ORIGIN,
+                HttpHeaders.X_REQUESTED_WITH
+        }));
+        // Inject a set of basic HTTP methods.
+        context.register(new AllowedMethods(new String[]{
+                HttpMethod.GET,
+                HttpMethod.PUT,
+                HttpMethod.POST,
+                HttpMethod.DELETE,
+                HttpMethod.OPTIONS
+        }));
+        // Inject a set of basic headers that can be exposed.
+        context.register(new ExposedHeaders(new String[]{
+                HttpHeaders.LOCATION,
+                HttpHeaders.WWW_AUTHENTICATE,
+                HttpHeaders.CACHE_CONTROL,
+                HttpHeaders.CONTENT_LANGUAGE,
+                HttpHeaders.CONTENT_TYPE,
+                HttpHeaders.EXPIRES,
+                HttpHeaders.LAST_MODIFIED,
+                HttpHeaders.PRAGMA,
+        }));
+
+        context.register(new CORSFilter.Binder());
+        return true;
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/cors/CORSFilter.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/cors/CORSFilter.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.cors;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Streams;
+import com.google.common.net.HttpHeaders;
+import net.krotscheck.kangaroo.util.RequestUtil;
+import org.glassfish.hk2.api.IterableProvider;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response.Status;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This request filter handles all CORS requests for the system.
+ *
+ * @author Michael Krotscheck
+ */
+@PreMatching
+@Priority(Priorities.AUTHENTICATION - 100)
+public final class CORSFilter implements ContainerResponseFilter {
+
+    /**
+     * List of allowed headers.
+     */
+    private final List<String> allowedHeaders;
+
+    /**
+     * List of allowed methods.
+     */
+    private final List<String> allowedMethods;
+
+    /**
+     * List of exposed headers.
+     */
+    private final List<String> exposedHeaders;
+
+    /**
+     * List of allowed methods.
+     */
+    private final ICORSValidator validator;
+
+    /**
+     * Create a new CORS filter.
+     *
+     * @param allowedHeaders Injected allowed headers.
+     * @param allowedMethods Injected allowed methods.
+     * @param exposedHeaders Injected exposed methods.
+     * @param validator      Validation handler. Should be provided by the
+     *                       consuming service.
+     */
+    @Inject
+    public CORSFilter(@Named(AllowedHeaders.NAME) final
+                      IterableProvider<String> allowedHeaders,
+                      @Named(AllowedMethods.NAME) final
+                      IterableProvider<String> allowedMethods,
+                      @Named(ExposedHeaders.NAME) final
+                      IterableProvider<String> exposedHeaders,
+                      final ICORSValidator validator) {
+        this.allowedHeaders = Streams.stream(allowedHeaders)
+                .filter(h -> !Strings.isNullOrEmpty(h))
+                .map(String::toLowerCase)
+                .collect(Collectors.toList());
+        this.allowedMethods = Streams.stream(allowedMethods)
+                .filter(h -> !Strings.isNullOrEmpty(h))
+                .collect(Collectors.toList());
+        this.exposedHeaders = Streams.stream(exposedHeaders)
+                .filter(h -> !Strings.isNullOrEmpty(h))
+                .map(String::toLowerCase)
+                .collect(Collectors.toList());
+        this.validator = validator;
+    }
+
+    /**
+     * This filter handles CORS responses. By this time, if it's a CORS
+     * request, we already know that the origin is valid, so we can proceed
+     * based on that.
+     *
+     * @param request  Request context.
+     * @param response Response context.
+     * @throws IOException if an I/O exception occurs.
+     * @see PreMatching
+     */
+    @Override
+    public void filter(final ContainerRequestContext request,
+                       final ContainerResponseContext response)
+            throws IOException {
+        // All CORS responses vary on Origin.
+        response.getHeaders().addAll(HttpHeaders.VARY, HttpHeaders.ORIGIN);
+
+        // If the origin header is not set, or not valid, exit.
+        URI origin = RequestUtil.getOrigin(request);
+        if (origin == null || !validator.isValidCORSOrigin(origin)) {
+            return;
+        }
+
+        // Handle a preflight request.
+        if (HttpMethod.OPTIONS.equals(request.getMethod())) {
+            preflightFilter(origin, request, response);
+        } else if (allowedMethods.contains(request.getMethod())) {
+            requestFilter(origin, response);
+        }
+    }
+
+    /**
+     * Annotate an OPTIONS response with the appropriate CORS headers.
+     *
+     * @param origin   The validated origin
+     * @param request  The request, with headers.
+     * @param response The response to annotate.
+     */
+    private void preflightFilter(final URI origin,
+                                 final ContainerRequestContext request,
+                                 final ContainerResponseContext response) {
+
+        MultivaluedMap<String, Object> resHeaders = response.getHeaders();
+
+        // If the underlying resource doesn't exist, take over the status code.
+        if (response.getStatus() == Status.NOT_FOUND.getStatusCode()) {
+            response.setStatus(Status.OK.getStatusCode());
+        }
+
+        // Annotate the VARY headers.
+        resHeaders.add(HttpHeaders.VARY,
+                HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS);
+        resHeaders.add(HttpHeaders.VARY,
+                HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD);
+
+        // Exit if the method is not permitted.
+        String method = RequestUtil.getCORSRequestedMethod(request);
+        if (!allowedMethods.contains(method)) {
+            return;
+        }
+        resHeaders.add(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, method);
+
+        // Echo the origin (since it's been validated.
+        resHeaders.add(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+
+        // Credentials and lifetime.
+        resHeaders.add(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+        resHeaders.add(HttpHeaders.ACCESS_CONTROL_MAX_AGE, 5 * 60);
+
+        // Build the intersection of requested and permitted headers
+        List<String> requestedHeaders =
+                RequestUtil.getCORSRequestedHeaders(request);
+        allowedHeaders.stream()
+                .filter(requestedHeaders::contains)
+                .forEach(h -> resHeaders
+                        .add(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, h));
+    }
+
+    /**
+     * Annotate the response for a regular response with the appropriate CORS
+     * headers. At this point, the request has already been validated.
+     *
+     * @param origin   The validated origin.
+     * @param response The response to annotate.
+     */
+    private void requestFilter(final URI origin,
+                               final ContainerResponseContext response) {
+
+        // Grab the headers that have already been sent.s
+        MultivaluedMap<String, Object> headers = response.getHeaders();
+
+        // Origin
+        headers.add(HttpHeaders.ORIGIN, origin);
+
+        // Interpolate the exposed headers.
+        List<Object> declaredExposedHeaders =
+                headers.keySet().stream()
+                        .map(String::toLowerCase)
+                        .filter(this.exposedHeaders::contains)
+                        .collect(Collectors.toList());
+        headers.addAll(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS,
+                declaredExposedHeaders);
+    }
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bind(CORSFilter.class)
+                    .to(ContainerResponseFilter.class)
+                    .in(Singleton.class);
+        }
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/cors/ExposedHeaders.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/cors/ExposedHeaders.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.cors;
+
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+/**
+ *
+ */
+public final class ExposedHeaders extends AbstractBinder {
+
+    /**
+     * The name used for this injection point.
+     */
+    public static final String NAME = "CORS_EXPOSED_HEADERS";
+
+    /**
+     * List of permitted CORS headers to inject.
+     */
+    private final String[] permittedHeaders;
+
+    /**
+     * @param headers The list of headers to provide to CORS as valid request
+     *                headers.
+     */
+    public ExposedHeaders(final String[] headers) {
+        this.permittedHeaders = headers;
+    }
+
+    /**
+     * Implement to provide binding definitions using the exposed binding
+     * methods.
+     */
+    @Override
+    protected void configure() {
+        for (String header : permittedHeaders) {
+            bind(header)
+                    .to(String.class)
+                    .named(NAME);
+        }
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/cors/ICORSValidator.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/cors/ICORSValidator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.cors;
+
+import java.net.URI;
+
+/**
+ * This interface describes an injected component, which should be provided
+ * by each service itself, that can validate in a synchronous fashion whether
+ * a particular Origin header is valid for a CORS request.
+ *
+ * @author Michael Krotscheck
+ */
+public interface ICORSValidator {
+
+    /**
+     * Return true if the URI is a valid origin for a CORS request.
+     *
+     * @param origin The origin to validate. Will only contain scheme, host,
+     *               and port.
+     * @return True if the origin is valid, otherwise false.
+     */
+    boolean isValidCORSOrigin(URI origin);
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/cors/package-info.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/cors/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * CORS Feature.
+ *
+ * This feature provides the necessary preflight and postflight filters for
+ * CORS request support.
+ */
+package net.krotscheck.kangaroo.common.cors;

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/util/RequestUtil.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/util/RequestUtil.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.util;
+
+import com.google.common.base.Strings;
+import com.google.common.net.HttpHeaders;
+import org.apache.http.client.utils.URIBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.MultivaluedMap;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This utility assists in extracting simple values from a Jersey request
+ * context.
+ *
+ * @author Michael Krotscheck
+ */
+public final class RequestUtil {
+
+    /**
+     * Logger instance.
+     */
+    private static Logger logger = LoggerFactory.getLogger(RequestUtil.class);
+
+    /**
+     * Utility class, private constructor.
+     */
+    private RequestUtil() {
+
+    }
+
+    /**
+     * Provided with a request context, will extract the CORS requested HTTP
+     * Method.
+     *
+     * @param request The request to analyze.
+     * @return The HTTP Request Method.
+     */
+    public static String getCORSRequestedMethod(
+            final ContainerRequestContext request) {
+        MultivaluedMap<String, String> headers = request.getHeaders();
+        return headers
+                .getFirst(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD);
+    }
+
+    /**
+     * Provided with a request context, will extract the CORS requested HTTP
+     * Headers.
+     *
+     * @param request The request to analyze.
+     * @return The HTTP Request Method.
+     */
+    public static List<String> getCORSRequestedHeaders(
+            final ContainerRequestContext request) {
+        MultivaluedMap<String, String> headers = request.getHeaders();
+        String rawHeaders = headers
+                .getFirst(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS);
+        if (Strings.isNullOrEmpty(rawHeaders)) {
+            return Collections.emptyList();
+        }
+
+        return Arrays.stream(rawHeaders.split(","))
+                .map(String::trim)
+                .map(String::toLowerCase)
+                .filter(s -> !Strings.isNullOrEmpty(s))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Provided with a request context, this method will extract the CORS
+     * origin header.
+     *
+     * @param request The request to analyze.
+     * @return Origin header as a URI.
+     */
+    public static URI getOrigin(final ContainerRequestContext request) {
+        MultivaluedMap<String, String> headers = request.getHeaders();
+        String rawHost = headers.getFirst(HttpHeaders.ORIGIN);
+
+        try {
+            return new URIBuilder(rawHost).build();
+        } catch (URISyntaxException | NullPointerException use) {
+            return null;
+        }
+    }
+
+    /**
+     * Provided with a request context, this method will extract the
+     * Referrer, or return null.
+     *
+     * @param request The request to analyze.
+     * @return Origin header as a URI.
+     */
+    public static URI getReferer(final ContainerRequestContext request) {
+        MultivaluedMap<String, String> headers = request.getHeaders();
+        String rawHost = headers.getFirst(HttpHeaders.REFERER);
+        try {
+            return new URIBuilder(rawHost).build();
+        } catch (URISyntaxException | NullPointerException use) {
+            return null;
+        }
+    }
+
+    /**
+     * Provided with a request context, this method will extract the host,
+     * port, and protocol into a simple URI. If the request does not contain
+     * any of these, it will throw an exception.
+     *
+     * @param request The request to analyze.
+     * @return The host as a URI, or null.
+     */
+    public static URI getHost(final ContainerRequestContext request) {
+        MultivaluedMap<String, String> headers = request.getHeaders();
+        String rawHost = headers.getFirst(HttpHeaders.HOST);
+
+        try {
+            // Split into host and port if necessary
+            String[] parts = rawHost.split(":");
+
+            URIBuilder builder = new URIBuilder();
+            builder.setScheme(request.getUriInfo().getRequestUri().getScheme());
+
+            builder.setHost(parts[0]);
+
+            if (parts.length > 1) {
+                builder.setPort(Integer.valueOf(parts[1]));
+            }
+
+            return builder.build();
+        } catch (URISyntaxException | NumberFormatException
+                | NullPointerException e) {
+            throw new BadRequestException(e);
+        }
+    }
+
+    /**
+     * Provided with a request, attempts to extract various X-Forwarded-*
+     * headers into a full URI. This method will return null unless a
+     * protocol and host are set.
+     *
+     * @param request The request from which to extract the X-Forwarded-Host.
+     * @return The Forwarded Host URI, or null.
+     */
+    public static URI getForwardedHost(
+            final ContainerRequestContext request) {
+        MultivaluedMap<String, String> headers = request.getHeaders();
+        String rawForwardedHost =
+                headers.getFirst(HttpHeaders.X_FORWARDED_HOST);
+        String rawForwardedPort =
+                headers.getFirst(HttpHeaders.X_FORWARDED_PORT);
+        String rawForwardedProto =
+                headers.getFirst(HttpHeaders.X_FORWARDED_PROTO);
+
+        try {
+            Integer forwardedPort = rawForwardedPort == null ? -1
+                    : Integer.valueOf(rawForwardedPort, 10);
+
+            URI result = new URIBuilder()
+                    .setHost(rawForwardedHost)
+                    .setPort(forwardedPort)
+                    .setScheme(rawForwardedProto)
+                    .build();
+            return Strings.isNullOrEmpty(result.toString()) ? null : result;
+        } catch (URISyntaxException | NumberFormatException use) {
+            logger.debug("Cannot parse forwarded header.", use);
+            return null;
+        }
+    }
+
+    /**
+     * This method attempts to determine if the request is a cross-origin
+     * request. This is not a check for CORS, as that standard demands the
+     * Origin header be set. Instead, it implements the OWASP Cross Origin
+     * detection algorithm.
+     *
+     * @param request The request from which to extract the X-Forwarded-Host.
+     * @return True if this is an OWASP-evaluated cross-origin request.
+     * @throws BadRequestException Thrown if the source or target cannot be
+     *                             determined from the provided headers.
+     * @see <a href="https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#Verifying_Same_Origin_with_Standard_Headers">https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#Verifying_Same_Origin_with_Standard_Headers</a>
+     */
+    public static Boolean isCrossOriginRequest(
+            final ContainerRequestContext request)
+            throws BadRequestException {
+
+        URI origin = getOrigin(request);
+        URI referer = getReferer(request);
+        URI host = getHost(request); // This will throw an exception.
+        URI forwardedHost = getForwardedHost(request);
+
+        try {
+            referer = new URIBuilder()
+                    .setScheme(referer.getScheme())
+                    .setHost(referer.getHost())
+                    .setPort(referer.getPort())
+                    .build();
+        } catch (NullPointerException | URISyntaxException e) {
+            referer = null;
+        }
+
+        // Try to find at least one target and source.
+        URI source = origin == null ? referer : origin;
+        URI target = forwardedHost == null ? host : forwardedHost;
+
+        // This request is bad, exit and return.
+        if (source == null) {
+            return false;
+        }
+
+        return !source.equals(target);
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/cors/AllowedHeadersTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/cors/AllowedHeadersTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.cors;
+
+import com.google.common.collect.Lists;
+import net.krotscheck.kangaroo.common.cors.AllowedHeaders;
+import org.glassfish.hk2.api.IterableProvider;
+import org.glassfish.hk2.api.ServiceLocatorFactory;
+import org.glassfish.hk2.utilities.Binder;
+import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
+import org.junit.Assert;
+import org.junit.Test;
+import org.jvnet.hk2.internal.ServiceLocatorImpl;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.List;
+
+/**
+ * Test that we can provide multiple sources of CORS allowed headers.
+ *
+ * @author Michael Krotscheck
+ */
+public class AllowedHeadersTest {
+    /**
+     * Assert that we can inject values using this binder
+     *
+     * @throws Exception An authenticator exception.
+     */
+    @Test
+    public void testBinder() throws Exception {
+        ServiceLocatorFactory factory = ServiceLocatorFactory.getInstance();
+        ServiceLocatorImpl locator = (ServiceLocatorImpl)
+                factory.create(this.getClass().getSimpleName());
+
+        Binder b1 = new AllowedHeaders(new String[]{"Test1", "Test2"});
+        ServiceLocatorUtilities.bind(locator, b1);
+        Binder b2 = new AllowedHeaders(new String[]{"Test3", "Test4"});
+        ServiceLocatorUtilities.bind(locator, b2);
+
+        Injectee testInjectee = new Injectee();
+
+        locator.inject(testInjectee);
+
+        List<String> values = Lists.newArrayList(testInjectee.getValues());
+        Assert.assertTrue(values.contains("Test1"));
+        Assert.assertTrue(values.contains("Test2"));
+        Assert.assertTrue(values.contains("Test3"));
+        Assert.assertTrue(values.contains("Test4"));
+        Assert.assertEquals(4, values.size());
+    }
+
+    /**
+     * Test class, used to inject our test data and then validate it.
+     */
+    public static final class Injectee {
+
+        /**
+         * The injected iterator of values.
+         */
+        private IterableProvider<String> values;
+
+        /**
+         * Get the values.
+         *
+         * @return The iterator, or null if not available.
+         */
+        public IterableProvider<String> getValues() {
+            return values;
+        }
+
+        /**
+         * Set the values.
+         *
+         * @param values An iterator of values.
+         */
+        @Inject
+        public void setValues(@Named(AllowedHeaders.NAME) final
+                              IterableProvider<String> values) {
+            this.values = values;
+        }
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/cors/AllowedMethodsTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/cors/AllowedMethodsTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.cors;
+
+import com.google.common.collect.Lists;
+import net.krotscheck.kangaroo.common.cors.AllowedMethods;
+import org.glassfish.hk2.api.IterableProvider;
+import org.glassfish.hk2.api.ServiceLocatorFactory;
+import org.glassfish.hk2.utilities.Binder;
+import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
+import org.junit.Assert;
+import org.junit.Test;
+import org.jvnet.hk2.internal.ServiceLocatorImpl;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.List;
+
+/**
+ * Test that we can provide multiple sources of CORS allowed methods.
+ *
+ * @author Michael Krotscheck
+ */
+public class AllowedMethodsTest {
+    /**
+     * Assert that we can inject values using this binder
+     *
+     * @throws Exception An authenticator exception.
+     */
+    @Test
+    public void testBinder() throws Exception {
+        ServiceLocatorFactory factory = ServiceLocatorFactory.getInstance();
+        ServiceLocatorImpl locator = (ServiceLocatorImpl)
+                factory.create(this.getClass().getSimpleName());
+
+        Binder b1 = new AllowedMethods(new String[]{"Test1", "Test2"});
+        ServiceLocatorUtilities.bind(locator, b1);
+        Binder b2 = new AllowedMethods(new String[]{"Test3", "Test4"});
+        ServiceLocatorUtilities.bind(locator, b2);
+
+        Injectee testInjectee = new Injectee();
+
+        locator.inject(testInjectee);
+
+        List<String> values = Lists.newArrayList(testInjectee.getValues());
+        Assert.assertTrue(values.contains("Test1"));
+        Assert.assertTrue(values.contains("Test2"));
+        Assert.assertTrue(values.contains("Test3"));
+        Assert.assertTrue(values.contains("Test4"));
+        Assert.assertEquals(4, values.size());
+    }
+
+    /**
+     * Test class, used to inject our test data and then validate it.
+     */
+    public static final class Injectee {
+
+        /**
+         * The injected iterator of values.
+         */
+        private IterableProvider<String> values;
+
+        /**
+         * Get the values.
+         *
+         * @return The iterator, or null if not available.
+         */
+        public IterableProvider<String> getValues() {
+            return values;
+        }
+
+        /**
+         * Set the values.
+         *
+         * @param values An iterator of values.
+         */
+        @Inject
+        public void setValues(@Named(AllowedMethods.NAME) final
+                              IterableProvider<String> values) {
+            this.values = values;
+        }
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/cors/CORSFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/cors/CORSFeatureTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.cors;
+
+import com.google.common.collect.Lists;
+import com.google.common.net.HttpHeaders;
+import net.krotscheck.kangaroo.test.ContainerTest;
+import org.apache.http.HttpStatus;
+import org.glassfish.hk2.api.IterableProvider;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.ws.rs.GET;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+/**
+ * Test the CORS feature, by injecting it and accessing its values.
+ *
+ * @author Michael Krotscheck
+ */
+public class CORSFeatureTest extends ContainerTest {
+
+    /**
+     * Convenience generic type for response decoding.
+     */
+    private static final GenericType<List<String>> LIST_TYPE =
+            new GenericType<List<String>>() {
+
+            };
+
+    /**
+     * Create an application.
+     *
+     * @return The application to test.
+     */
+    @Override
+    protected ResourceConfig createApplication() {
+        ResourceConfig a = new ResourceConfig();
+        a.register(new TestCORSValidator.Binder());
+        a.register(CORSFeature.class);
+        a.register(MockService.class);
+        return a;
+    }
+
+    /**
+     * Get the available allowed headers.
+     */
+    @Test
+    public void testAllowedHeaders() {
+        Response response = target("/allowed_headers").request().get();
+        List<String> results = response.readEntity(LIST_TYPE);
+        Assert.assertTrue(results.contains(HttpHeaders.ACCEPT));
+        Assert.assertTrue(results.contains(HttpHeaders.ACCEPT_LANGUAGE));
+        Assert.assertTrue(results.contains(HttpHeaders.CONTENT_LANGUAGE));
+        Assert.assertTrue(results.contains(HttpHeaders.AUTHORIZATION));
+        Assert.assertTrue(results.contains(HttpHeaders.CONTENT_TYPE));
+        Assert.assertTrue(results.contains(HttpHeaders.ORIGIN));
+        Assert.assertTrue(results.contains(HttpHeaders.X_REQUESTED_WITH));
+    }
+
+    /**
+     * Get the available allowed methods.
+     */
+    @Test
+    public void testAllowedMethods() {
+        Response response = target("/allowed_methods").request().get();
+        List<String> results = response.readEntity(LIST_TYPE);
+        Assert.assertTrue(results.contains(HttpMethod.GET));
+        Assert.assertTrue(results.contains(HttpMethod.PUT));
+        Assert.assertTrue(results.contains(HttpMethod.POST));
+        Assert.assertTrue(results.contains(HttpMethod.DELETE));
+        Assert.assertTrue(results.contains(HttpMethod.OPTIONS));
+    }
+
+    /**
+     * Get the available exposed headers.
+     */
+    @Test
+    public void testExposedHeaders() {
+        Response response = target("/exposed_headers").request().get();
+        List<String> results = response.readEntity(LIST_TYPE);
+        Assert.assertTrue(results.contains(HttpHeaders.LOCATION));
+        Assert.assertTrue(results.contains(HttpHeaders.WWW_AUTHENTICATE));
+        Assert.assertTrue(results.contains(HttpHeaders.CACHE_CONTROL));
+        Assert.assertTrue(results.contains(HttpHeaders.CONTENT_LANGUAGE));
+        Assert.assertTrue(results.contains(HttpHeaders.CONTENT_TYPE));
+        Assert.assertTrue(results.contains(HttpHeaders.EXPIRES));
+        Assert.assertTrue(results.contains(HttpHeaders.LAST_MODIFIED));
+        Assert.assertTrue(results.contains(HttpHeaders.PRAGMA));
+    }
+
+    /**
+     * Testing endpoint.
+     *
+     * @author Michael Krotscheck
+     */
+    @Path("/")
+    public static final class MockService {
+
+        /**
+         * List of allowed headers.
+         */
+        private List<String> allowedHeaders;
+
+        /**
+         * List of exposed headers.
+         */
+        private List<String> exposedHeaders;
+
+        /**
+         * List of allowed methods.
+         */
+        private List<String> allowedMethods;
+
+        /**
+         * Create a new instance of the test service.
+         *
+         * @param allowedHeaders Injected allowed headers.
+         * @param exposedHeaders Injected exposed headers.
+         * @param allowedMethods Injected allowed methods.
+         */
+        @Inject
+        public MockService(@Named(AllowedHeaders.NAME) final
+                           IterableProvider<String> allowedHeaders,
+                           @Named(ExposedHeaders.NAME) final
+                           IterableProvider<String> exposedHeaders,
+                           @Named(AllowedMethods.NAME) final
+                           IterableProvider<String> allowedMethods) {
+            this.allowedHeaders = Lists.newArrayList(allowedHeaders);
+            this.exposedHeaders = Lists.newArrayList(exposedHeaders);
+            this.allowedMethods = Lists.newArrayList(allowedMethods);
+        }
+
+        /**
+         * Return the allowed headers.
+         *
+         * @return HTTP Response object with the current service status.
+         */
+        @Path("/allowed_methods")
+        @GET
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response getAllowedMethods() {
+            return Response
+                    .status(HttpStatus.SC_OK)
+                    .entity(allowedMethods)
+                    .build();
+        }
+
+        /**
+         * Return the exposed headers.
+         *
+         * @return HTTP Response object with the current service status.
+         */
+        @Path("/exposed_headers")
+        @GET
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response getExposedHeaders() {
+            return Response
+                    .status(HttpStatus.SC_OK)
+                    .entity(exposedHeaders)
+                    .build();
+        }
+
+        /**
+         * Return the allowed methods.
+         *
+         * @return HTTP Response object with the current service status.
+         */
+        @Path("/allowed_headers")
+        @GET
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response getAllowedHeaders() {
+            return Response
+                    .status(HttpStatus.SC_OK)
+                    .entity(allowedHeaders)
+                    .build();
+        }
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/cors/CORSFilterTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/cors/CORSFilterTest.java
@@ -1,0 +1,646 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.cors;
+
+import com.google.common.net.HttpHeaders;
+import net.krotscheck.kangaroo.test.ContainerTest;
+import org.glassfish.hk2.api.ActiveDescriptor;
+import org.glassfish.hk2.api.ServiceLocatorFactory;
+import org.glassfish.hk2.utilities.BuilderHelper;
+import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.Assert;
+import org.junit.Test;
+import org.jvnet.hk2.internal.ServiceLocatorImpl;
+
+import javax.inject.Singleton;
+import javax.ws.rs.GET;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.OPTIONS;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.core.IsCollectionContaining.hasItems;
+
+/**
+ * Unit tests for the CORS filter.
+ *
+ * @author Michael Krotscheck
+ */
+public class CORSFilterTest extends ContainerTest {
+
+    /**
+     * Create an application.
+     *
+     * @return The application to test.
+     */
+    @Override
+    protected ResourceConfig createApplication() {
+        ResourceConfig config = new ResourceConfig();
+        config.register(CORSFilter.class);
+        config.register(new AllowedHeaders(new String[]{
+                "One", "Two", "Three", ""
+        }));
+        config.register(new ExposedHeaders(new String[]{
+                "One", "Two", "Three", ""
+        }));
+        // Inject a set of basic HTTP methods.
+        config.register(new AllowedMethods(new String[]{
+                HttpMethod.GET,
+                HttpMethod.OPTIONS,
+                ""
+        }));
+
+        config.register(new TestCORSValidator.Binder());
+        config.register(MockService.class);
+        return config;
+    }
+
+    /**
+     * Assert that we can inject values using this binder.
+     *
+     * @throws Exception An authenticator exception.
+     */
+    @Test
+    public void testBinder() throws Exception {
+        ServiceLocatorFactory factory = ServiceLocatorFactory.getInstance();
+        ServiceLocatorImpl locator = (ServiceLocatorImpl)
+                factory.create(this.getClass().getSimpleName());
+
+        ServiceLocatorUtilities.bind(locator, new CORSFilter.Binder());
+
+        // Ensure it's a response filter.
+        List<ActiveDescriptor<?>> respDescriptors =
+                locator.getDescriptors(
+                        BuilderHelper.createContractFilter(
+                                ContainerResponseFilter.class.getName()));
+        Assert.assertEquals(1, respDescriptors.size());
+
+        ActiveDescriptor respDescriptor = respDescriptors.get(0);
+        Assert.assertNotNull(respDescriptor);
+        Assert.assertEquals(Singleton.class.getCanonicalName(),
+                respDescriptor.getScope());
+    }
+
+    /**
+     * Validate that the full set of expected headers (and values) are in the
+     * received headers.
+     *
+     * @param expected List of expected headers & values.
+     * @param received List of received headers.
+     */
+    private void validateContainsHeaders(
+            final MultivaluedMap<String, Object> expected,
+            final MultivaluedMap<String, Object> received) {
+
+        expected.forEach((key, values) -> {
+            Assert.assertTrue(received.containsKey(key));
+            Assert.assertThat(received.get(key), hasItems(values.toArray()));
+        });
+    }
+
+    /**
+     * If the Origin header is not present terminate this set of steps. The
+     * request is outside the scope of this specification.
+     */
+    @Test
+    public void testRegularWithNoOrigin() {
+        MultivaluedMap<String, Object> reqHeaders = new MultivaluedHashMap<>();
+        reqHeaders.add("One", "One");
+        reqHeaders.add("Two", "Two");
+        reqHeaders.add("Three", "Three");
+
+        Response r = this.target("/")
+                .request()
+                .headers(reqHeaders)
+                .build("GET")
+                .invoke();
+
+        MultivaluedMap<String, Object> expHeaders = new MultivaluedHashMap<>();
+        expHeaders.add(HttpHeaders.VARY, HttpHeaders.ORIGIN);
+
+        List<String> omittedHeaders = new ArrayList<>();
+        omittedHeaders.addAll(Arrays.asList(
+                HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+                HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS,
+                HttpHeaders.ACCESS_CONTROL_MAX_AGE));
+
+        Assert.assertEquals(200, r.getStatus());
+        validateContainsHeaders(expHeaders, r.getHeaders());
+        validateOmitHeaders(omittedHeaders, r.getHeaders());
+    }
+
+    /**
+     * Validate the omitted headers.
+     *
+     * @param omittedHeaders The headers we do not want to see in a response.
+     * @param received       The headers received.
+     */
+    private void validateOmitHeaders(
+            final List<String> omittedHeaders,
+            final MultivaluedMap<String, Object> received) {
+        long foundHeaders = received.keySet().stream()
+                .filter(omittedHeaders::contains)
+                .count();
+        Assert.assertEquals(0, foundHeaders);
+    }
+
+    /**
+     * If the value of the Origin header is not a case-sensitive match for any
+     * of the values in list of origins, do not set any additional headers and
+     * terminate this set of steps.
+     */
+    @Test
+    public void testRegularWithUnregisteredOrigin() {
+        MultivaluedMap<String, Object> reqHeaders = new MultivaluedHashMap<>();
+        reqHeaders.add(HttpHeaders.ORIGIN, "http://invalid.example.com");
+        reqHeaders.add("One", "One");
+        reqHeaders.add("Two", "Two");
+        reqHeaders.add("Three", "Three");
+
+        Response r = this.target("/")
+                .request()
+                .headers(reqHeaders)
+                .build("GET")
+                .invoke();
+
+        MultivaluedMap<String, Object> expHeaders = new MultivaluedHashMap<>();
+        expHeaders.add(HttpHeaders.VARY, HttpHeaders.ORIGIN);
+
+        List<String> omittedHeaders = new ArrayList<>();
+        omittedHeaders.addAll(Arrays.asList(
+                HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+                HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS,
+                HttpHeaders.ACCESS_CONTROL_MAX_AGE));
+
+        Assert.assertEquals(200, r.getStatus());
+        validateContainsHeaders(expHeaders, r.getHeaders());
+        validateOmitHeaders(omittedHeaders, r.getHeaders());
+    }
+
+    /**
+     * If the HTTP method is not one of the permitted methods, do not set any
+     * additional headers and terminate this set of steps.
+     */
+    @Test
+    public void testRegularWithInvalidMethod() {
+        MultivaluedMap<String, Object> reqHeaders = new MultivaluedHashMap<>();
+        reqHeaders.add(HttpHeaders.ORIGIN, "http://valid.example.com");
+        reqHeaders.add("One", "One");
+        reqHeaders.add("Two", "Two");
+        reqHeaders.add("Three", "Three");
+
+        Response r = this.target("/")
+                .request()
+                .headers(reqHeaders)
+                .build("POST") // Not registered in the test app.
+                .invoke();
+
+        MultivaluedMap<String, Object> expHeaders = new MultivaluedHashMap<>();
+        expHeaders.add(HttpHeaders.VARY, HttpHeaders.ORIGIN);
+
+        List<String> omittedHeaders = new ArrayList<>();
+        omittedHeaders.addAll(Arrays.asList(
+                HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+                HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS,
+                HttpHeaders.ACCESS_CONTROL_MAX_AGE));
+
+        Assert.assertEquals(200, r.getStatus());
+        validateContainsHeaders(expHeaders, r.getHeaders());
+        validateOmitHeaders(omittedHeaders, r.getHeaders());
+    }
+
+    /**
+     * If the list of exposed headers is not empty add one or more
+     * Access-Control-Expose-Headers headers, with as values the header field
+     * names given in the list of exposed headers.
+     */
+    @Test
+    public void testRegularWithValidOrigin() {
+        MultivaluedMap<String, Object> reqHeaders = new MultivaluedHashMap<>();
+        reqHeaders.add(HttpHeaders.ORIGIN, "http://valid.example.com");
+        reqHeaders.add("One", "One");
+        reqHeaders.add("Two", "Two");
+        reqHeaders.add("Three", "Three");
+
+        Response r = this.target("/")
+                .request()
+                .headers(reqHeaders)
+                .build("GET")
+                .invoke();
+
+        MultivaluedMap<String, Object> expHeaders = new MultivaluedHashMap<>();
+        expHeaders.add(HttpHeaders.VARY, HttpHeaders.ORIGIN);
+        expHeaders.add(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, "one");
+        expHeaders.add(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, "two");
+        expHeaders.add(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, "three");
+
+        List<String> omittedHeaders = new ArrayList<>();
+        omittedHeaders.addAll(Arrays.asList(
+                HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+                HttpHeaders.ACCESS_CONTROL_MAX_AGE));
+
+        Assert.assertEquals(200, r.getStatus());
+        validateContainsHeaders(expHeaders, r.getHeaders());
+        validateOmitHeaders(omittedHeaders, r.getHeaders());
+    }
+
+    /**
+     * If the list of exposed headers is not empty add one or more
+     * Access-Control-Expose-Headers headers, with as values the header field
+     * names given in the list of exposed headers.
+     */
+    @Test
+    public void testRegularWithValidOriginAndUnregisteredHeaders() {
+        MultivaluedMap<String, Object> reqHeaders = new MultivaluedHashMap<>();
+        reqHeaders.add(HttpHeaders.ORIGIN, "http://valid.example.com");
+        reqHeaders.add("One", "One");
+        reqHeaders.add("Three", "Three");
+        reqHeaders.add("Four", "Four");
+        reqHeaders.add("Five", "Five");
+
+        Response r = this.target("/")
+                .request()
+                .headers(reqHeaders)
+                .build("GET")
+                .invoke();
+
+        MultivaluedMap<String, Object> expHeaders = new MultivaluedHashMap<>();
+        expHeaders.add(HttpHeaders.VARY, HttpHeaders.ORIGIN);
+        expHeaders.add(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, "one");
+        expHeaders.add(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, "three");
+
+        List<String> omittedHeaders = new ArrayList<>();
+        omittedHeaders.addAll(Arrays.asList(
+                HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+                HttpHeaders.ACCESS_CONTROL_MAX_AGE));
+
+        Assert.assertEquals(200, r.getStatus());
+        validateContainsHeaders(expHeaders, r.getHeaders());
+        validateOmitHeaders(omittedHeaders, r.getHeaders());
+    }
+
+    /**
+     * If the Origin header is not present terminate this set of steps. The
+     * request is outside the scope of this specification.
+     */
+    @Test
+    public void testPreflightWithNoOrigin() {
+        MultivaluedMap<String, Object> reqHeaders = new MultivaluedHashMap<>();
+        reqHeaders.addAll(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD,
+                "GET");
+        reqHeaders.addAll(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS,
+                "One", "Two", "Three");
+
+        Response r = this.target("/any")
+                .request()
+                .headers(reqHeaders)
+                .build("OPTIONS")
+                .invoke();
+
+        MultivaluedMap<String, Object> expHeaders = new MultivaluedHashMap<>();
+        expHeaders.add(HttpHeaders.VARY, HttpHeaders.ORIGIN);
+
+        List<String> omittedHeaders = new ArrayList<>();
+        omittedHeaders.addAll(Arrays.asList(
+                HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+                HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS,
+                HttpHeaders.ACCESS_CONTROL_MAX_AGE));
+
+        Assert.assertEquals(404, r.getStatus());
+        validateContainsHeaders(expHeaders, r.getHeaders());
+        validateOmitHeaders(omittedHeaders, r.getHeaders());
+    }
+
+    /**
+     * If the Origin header is not present terminate this set of steps. The
+     * request is outside the scope of this specification.
+     */
+    @Test
+    public void testPreflightWithInvalidOrigin() {
+        MultivaluedMap<String, Object> reqHeaders = new MultivaluedHashMap<>();
+        reqHeaders.addAll(HttpHeaders.ORIGIN,
+                "http://invalid.example.com");
+        reqHeaders.addAll(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD,
+                "GET");
+        reqHeaders.addAll(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS,
+                "One", "Two", "Three");
+
+        Response r = this.target("/any")
+                .request()
+                .headers(reqHeaders)
+                .build("OPTIONS")
+                .invoke();
+
+        MultivaluedMap<String, Object> expHeaders = new MultivaluedHashMap<>();
+        expHeaders.add(HttpHeaders.VARY, HttpHeaders.ORIGIN);
+
+        List<String> omittedHeaders = new ArrayList<>();
+        omittedHeaders.addAll(Arrays.asList(
+                HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+                HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS,
+                HttpHeaders.ACCESS_CONTROL_MAX_AGE));
+
+        Assert.assertEquals(404, r.getStatus());
+        validateContainsHeaders(expHeaders, r.getHeaders());
+        validateOmitHeaders(omittedHeaders, r.getHeaders());
+    }
+
+    /**
+     * If the Origin header is not present terminate this set of steps. The
+     * request is outside the scope of this specification.
+     */
+    @Test
+    public void testPreflightWithNoMethod() {
+        MultivaluedMap<String, Object> reqHeaders = new MultivaluedHashMap<>();
+        reqHeaders.addAll(HttpHeaders.ORIGIN,
+                "http://valid.example.com");
+        reqHeaders.addAll(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS,
+                "One", "Two", "Three");
+
+        Response r = this.target("/any")
+                .request()
+                .headers(reqHeaders)
+                .build("OPTIONS")
+                .invoke();
+
+        MultivaluedMap<String, Object> expHeaders = new MultivaluedHashMap<>();
+        expHeaders.add(HttpHeaders.VARY, HttpHeaders.ORIGIN);
+
+        List<String> omittedHeaders = new ArrayList<>();
+        omittedHeaders.addAll(Arrays.asList(
+                HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+                HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS,
+                HttpHeaders.ACCESS_CONTROL_MAX_AGE));
+
+        Assert.assertEquals(200, r.getStatus());
+        validateContainsHeaders(expHeaders, r.getHeaders());
+        validateOmitHeaders(omittedHeaders, r.getHeaders());
+    }
+
+    /**
+     * If the Origin header is not present terminate this set of steps. The
+     * request is outside the scope of this specification.
+     */
+    @Test
+    public void testPreflightWithInvalidMethod() {
+        MultivaluedMap<String, Object> reqHeaders = new MultivaluedHashMap<>();
+        reqHeaders.addAll(HttpHeaders.ORIGIN,
+                "http://valid.example.com");
+        reqHeaders.addAll(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD,
+                "POST");
+        reqHeaders.addAll(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS,
+                "One", "Two", "Three");
+
+        Response r = this.target("/any")
+                .request()
+                .headers(reqHeaders)
+                .build("OPTIONS")
+                .invoke();
+
+        MultivaluedMap<String, Object> expHeaders = new MultivaluedHashMap<>();
+        expHeaders.add(HttpHeaders.VARY, HttpHeaders.ORIGIN);
+
+        List<String> omittedHeaders = new ArrayList<>();
+        omittedHeaders.addAll(Arrays.asList(
+                HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
+                HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+                HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS,
+                HttpHeaders.ACCESS_CONTROL_MAX_AGE));
+
+        Assert.assertEquals(200, r.getStatus());
+        validateContainsHeaders(expHeaders, r.getHeaders());
+        validateOmitHeaders(omittedHeaders, r.getHeaders());
+    }
+
+    /**
+     * If the requested headers are not in the list of exposed headers, do
+     * not return them.
+     */
+    @Test
+    public void testPreflightWithInvalidHeaders() {
+        MultivaluedMap<String, Object> reqHeaders = new MultivaluedHashMap<>();
+        reqHeaders.addAll(HttpHeaders.ORIGIN,
+                "http://valid.example.com");
+        reqHeaders.addAll(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD,
+                "GET");
+        reqHeaders.addAll(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS,
+                "Four", "Five", "Six");
+
+        Response r = this.target("/any")
+                .request()
+                .headers(reqHeaders)
+                .build("OPTIONS")
+                .invoke();
+
+        MultivaluedMap<String, Object> expHeaders = new MultivaluedHashMap<>();
+        expHeaders.add(HttpHeaders.VARY, HttpHeaders.ORIGIN);
+        expHeaders.add(HttpHeaders.VARY, HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS);
+        expHeaders.add(HttpHeaders.VARY, HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD);
+        expHeaders.add(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, "GET");
+        expHeaders.add(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://valid.example.com");
+        expHeaders.add(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+        expHeaders.add(HttpHeaders.ACCESS_CONTROL_MAX_AGE, "300");
+
+        List<String> omittedHeaders = new ArrayList<>();
+        omittedHeaders.addAll(Arrays.asList(
+                HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS,
+                HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS));
+
+        Assert.assertEquals(200, r.getStatus());
+        validateContainsHeaders(expHeaders, r.getHeaders());
+        validateOmitHeaders(omittedHeaders, r.getHeaders());
+    }
+
+    /**
+     * Test a valid preflight request.
+     */
+    @Test
+    public void testValidPreflight() {
+        MultivaluedMap<String, Object> reqHeaders = new MultivaluedHashMap<>();
+        reqHeaders.addAll(HttpHeaders.ORIGIN,
+                "http://valid.example.com");
+        reqHeaders.addAll(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD,
+                "GET");
+        reqHeaders.addAll(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS,
+                "One", "Two", "Three");
+
+        Response r = this.target("/any")
+                .request()
+                .headers(reqHeaders)
+                .build("OPTIONS")
+                .invoke();
+
+        MultivaluedMap<String, Object> expHeaders = new MultivaluedHashMap<>();
+        expHeaders.add(HttpHeaders.VARY, HttpHeaders.ORIGIN);
+        expHeaders.add(HttpHeaders.VARY, HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS);
+        expHeaders.add(HttpHeaders.VARY, HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD);
+        expHeaders.add(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, "GET");
+        expHeaders.add(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://valid.example.com");
+        expHeaders.add(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+        expHeaders.add(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, "one");
+        expHeaders.add(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, "two");
+        expHeaders.add(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, "three");
+        expHeaders.add(HttpHeaders.ACCESS_CONTROL_MAX_AGE, "300");
+
+        List<String> omittedHeaders = new ArrayList<>();
+        omittedHeaders.addAll(Arrays.asList(
+                HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS));
+
+        Assert.assertEquals(200, r.getStatus());
+        validateContainsHeaders(expHeaders, r.getHeaders());
+        validateOmitHeaders(omittedHeaders, r.getHeaders());
+    }
+
+    /**
+     * Test a valid preflight request against a resource that has an options
+     * handler.
+     */
+    @Test
+    public void testValidPreflightExistingResource() {
+        MultivaluedMap<String, Object> reqHeaders = new MultivaluedHashMap<>();
+        reqHeaders.addAll(HttpHeaders.ORIGIN,
+                "http://valid.example.com");
+        reqHeaders.addAll(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD,
+                "GET");
+        reqHeaders.addAll(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS,
+                "One", "Two", "Three");
+
+        Response r = this.target("/")
+                .request()
+                .headers(reqHeaders)
+                .build("OPTIONS")
+                .invoke();
+
+        MultivaluedMap<String, Object> expHeaders = new MultivaluedHashMap<>();
+        expHeaders.add(HttpHeaders.VARY, HttpHeaders.ORIGIN);
+        expHeaders.add(HttpHeaders.VARY, HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS);
+        expHeaders.add(HttpHeaders.VARY, HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD);
+        expHeaders.add(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, "GET");
+        expHeaders.add(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "http://valid.example.com");
+        expHeaders.add(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+        expHeaders.add(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, "one");
+        expHeaders.add(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, "two");
+        expHeaders.add(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, "three");
+        expHeaders.add(HttpHeaders.ACCESS_CONTROL_MAX_AGE, "300");
+        expHeaders.add("Test", "One");
+
+        List<String> omittedHeaders = new ArrayList<>();
+        omittedHeaders.addAll(Arrays.asList(
+                HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS));
+
+        Assert.assertEquals(200, r.getStatus());
+        validateContainsHeaders(expHeaders, r.getHeaders());
+        validateOmitHeaders(omittedHeaders, r.getHeaders());
+    }
+
+    /**
+     * A simple endpoint that returns the system status.
+     *
+     * @author Michael Krotscheck
+     */
+    @Path("/")
+    public static final class MockService {
+
+        /**
+         * Always returns.
+         *
+         * @return HTTP Response object with some test headers.
+         */
+        @OPTIONS
+        public Response handleOptions() {
+            return Response
+                    .status(Status.OK)
+                    .header("Test", "One")
+                    .build();
+        }
+
+        /**
+         * Always returns.
+         *
+         * @return HTTP Response object with some test headers.
+         */
+        @GET
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response handleGet() {
+            return Response
+                    .status(Status.OK)
+                    .header("One", "One")
+                    .header("Two", "Two")
+                    .header("Three", "Three")
+                    .header("Four", "Four")
+                    .build();
+        }
+
+        /**
+         * Always returns.
+         *
+         * @return HTTP Response object with some test headers.
+         */
+        @POST
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response handlePost() {
+            return Response
+                    .status(Status.OK)
+                    .header("One", "One")
+                    .header("Two", "Two")
+                    .header("Three", "Three")
+                    .header("Four", "Four")
+                    .build();
+        }
+    }
+
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/cors/ExposedHeadersTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/cors/ExposedHeadersTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.cors;
+
+import com.google.common.collect.Lists;
+import net.krotscheck.kangaroo.common.cors.ExposedHeaders;
+import org.glassfish.hk2.api.IterableProvider;
+import org.glassfish.hk2.api.ServiceLocatorFactory;
+import org.glassfish.hk2.utilities.Binder;
+import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
+import org.junit.Assert;
+import org.junit.Test;
+import org.jvnet.hk2.internal.ServiceLocatorImpl;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.List;
+
+/**
+ * Test that we can provide multiple sources of CORS allowed methods.
+ *
+ * @author Michael Krotscheck
+ */
+public class ExposedHeadersTest {
+    /**
+     * Assert that we can inject values using this binder
+     *
+     * @throws Exception An authenticator exception.
+     */
+    @Test
+    public void testBinder() throws Exception {
+        ServiceLocatorFactory factory = ServiceLocatorFactory.getInstance();
+        ServiceLocatorImpl locator = (ServiceLocatorImpl)
+                factory.create(this.getClass().getSimpleName());
+
+        Binder b1 = new ExposedHeaders(new String[]{"Test1", "Test2"});
+        ServiceLocatorUtilities.bind(locator, b1);
+        Binder b2 = new ExposedHeaders(new String[]{"Test3", "Test4"});
+        ServiceLocatorUtilities.bind(locator, b2);
+
+        Injectee testInjectee = new Injectee();
+
+        locator.inject(testInjectee);
+
+        List<String> values = Lists.newArrayList(testInjectee.getValues());
+        Assert.assertTrue(values.contains("Test1"));
+        Assert.assertTrue(values.contains("Test2"));
+        Assert.assertTrue(values.contains("Test3"));
+        Assert.assertTrue(values.contains("Test4"));
+        Assert.assertEquals(4, values.size());
+    }
+
+    /**
+     * Test class, used to inject our test data and then validate it.
+     */
+    public static final class Injectee {
+
+        /**
+         * The injected iterator of values.
+         */
+        private IterableProvider<String> values;
+
+        /**
+         * Get the values.
+         *
+         * @return The iterator, or null if not available.
+         */
+        public IterableProvider<String> getValues() {
+            return values;
+        }
+
+        /**
+         * Set the values.
+         *
+         * @param values An iterator of values.
+         */
+        @Inject
+        public void setValues(@Named(ExposedHeaders.NAME) final
+                              IterableProvider<String> values) {
+            this.values = values;
+        }
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/cors/TestCORSValidator.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/cors/TestCORSValidator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.cors;
+
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+import javax.inject.Singleton;
+import java.net.URI;
+
+/**
+ * Test CORS validator for unit tests.
+ *
+ * @author Michael Krotscheck
+ */
+public class TestCORSValidator implements ICORSValidator {
+
+    /**
+     * Return true if the origin is 'http://valid.example.com'.
+     *
+     * @param origin A test origin.
+     * @return True or false, depending
+     */
+    @Override
+    public boolean isValidCORSOrigin(final URI origin) {
+        return origin.toString().equals("http://valid.example.com");
+    }
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bind(TestCORSValidator.class)
+                    .to(ICORSValidator.class)
+                    .in(Singleton.class);
+        }
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/cors/package-info.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/cors/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Tests for the CORS feature.
+ */
+package net.krotscheck.kangaroo.common.cors;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/util/RequestUtilTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/util/RequestUtilTest.java
@@ -1,0 +1,631 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.util;
+
+import com.google.common.net.HttpHeaders;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.net.URI;
+import java.util.List;
+
+/**
+ * Unit tests for the HTTP Header utility.
+ *
+ * @author Michael Krotscheck
+ */
+public class RequestUtilTest {
+
+    /**
+     * Build a test request context, with all necessary bits mocked.
+     *
+     * @param requestUri URL of the request to mock.
+     * @param headers    The headers to add.
+     * @return A request context.
+     * @throws Exception Thrown if the passed URI doesn't validate.
+     */
+    public ContainerRequestContext buildContext(
+            final String requestUri,
+            final MultivaluedMap<String, String> headers)
+            throws Exception {
+        ContainerRequestContext mockContext =
+                Mockito.mock(ContainerRequestContext.class);
+        UriInfo mockInfo = Mockito.mock(UriInfo.class);
+        URI uri = new URI(requestUri);
+
+        Mockito.doReturn(uri).when(mockInfo).getRequestUri();
+        Mockito.doReturn(headers).when(mockContext).getHeaders();
+        Mockito.doReturn(mockInfo).when(mockContext).getUriInfo();
+
+        return mockContext;
+    }
+
+    /**
+     * Assert the constructor is private.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testPrivateConstructor() throws Exception {
+        Constructor c = RequestUtil.class.getDeclaredConstructor();
+        Assert.assertTrue(Modifier.isPrivate(c.getModifiers()));
+
+        // Create a new instance for coverage.
+        c.setAccessible(true);
+        c.newInstance();
+    }
+
+    /**
+     * Test CORS get method.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testCorsRequestedMethod() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "OPTIONS");
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com",
+                headers
+        );
+        String method = RequestUtil.getCORSRequestedMethod(mockContext);
+        Assert.assertEquals("OPTIONS", method);
+    }
+
+    /**
+     * Test Empty CORS get method.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testCorsRequestedMethodEmpty() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com",
+                headers
+        );
+        String method = RequestUtil.getCORSRequestedMethod(mockContext);
+        Assert.assertNull(method);
+    }
+
+    /**
+     * Test CORS get headers.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testCorsRequestedHeaders() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS, "One, TWO , "
+                + "Three, Four,,Five");
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com",
+                headers
+        );
+        List<String> reqHeaders =
+                RequestUtil.getCORSRequestedHeaders(mockContext);
+
+        Assert.assertEquals(5, reqHeaders.size());
+        Assert.assertTrue(reqHeaders.contains("one"));
+        Assert.assertTrue(reqHeaders.contains("two"));
+        Assert.assertTrue(reqHeaders.contains("three"));
+        Assert.assertTrue(reqHeaders.contains("four"));
+        Assert.assertTrue(reqHeaders.contains("five"));
+    }
+
+    /**
+     * Test CORS get empty headers.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testCorsRequestedEmptyHeaders() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com",
+                headers
+        );
+        List<String> reqHeaders =
+                RequestUtil.getCORSRequestedHeaders(mockContext);
+        Assert.assertEquals(0, reqHeaders.size());
+    }
+
+    /**
+     * Assert that we can get the host.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testGetHost() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.HOST, "host.example.com");
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com",
+                headers
+        );
+        URI result = RequestUtil.getHost(mockContext);
+
+        Assert.assertEquals("https://host.example.com",
+                result.toString());
+    }
+
+    /**
+     * Assert that we can get the host with a port
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testGetHostPort() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.HOST, "host.example.com:8080");
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com:8080",
+                headers
+        );
+        URI result = RequestUtil.getHost(mockContext);
+
+        Assert.assertEquals("https://host.example.com:8080",
+                result.toString());
+    }
+
+    /**
+     * Assert that an invalid host header throws an exception.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test(expected = BadRequestException.class)
+    public void testGetHostInvalid() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.HOST, "host.example.com:string");
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com",
+                headers
+        );
+        RequestUtil.getHost(mockContext);
+    }
+
+    /**
+     * Assert that an invalid host header throws an exception.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test(expected = BadRequestException.class)
+    public void testGetHostEmpty() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.HOST, "");
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com",
+                headers
+        );
+        RequestUtil.getHost(mockContext);
+    }
+
+    /**
+     * Assert forwarded host works with expected values and types.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testForwardedHost() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.X_FORWARDED_PROTO, "https");
+        headers.add(HttpHeaders.X_FORWARDED_PORT, "8080");
+        headers.add(HttpHeaders.X_FORWARDED_HOST, "example.com");
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com",
+                headers
+        );
+        URI result = RequestUtil.getForwardedHost(mockContext);
+
+        Assert.assertEquals("https://example.com:8080",
+                result.toString());
+    }
+
+    /**
+     * Assert forwarded host works with no port.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testForwardedHostNoPort() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.X_FORWARDED_PROTO, "https");
+        headers.add(HttpHeaders.X_FORWARDED_HOST, "example.com");
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com",
+                headers
+        );
+
+        URI result = RequestUtil.getForwardedHost(mockContext);
+
+        Assert.assertEquals("https://example.com",
+                result.toString());
+    }
+
+    /**
+     * Assert forwarded host fails with no host.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testForwardedHostNoHost() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.X_FORWARDED_PROTO, "https");
+        headers.add(HttpHeaders.X_FORWARDED_PORT, "8080");
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com",
+                headers
+        );
+
+        URI result = RequestUtil.getForwardedHost(mockContext);
+
+        Assert.assertNull(result);
+    }
+
+    /**
+     * Assert forwarded host fails with invalid host.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testForwardedHostInvalidHost() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.X_FORWARDED_PROTO, "https");
+        headers.add(HttpHeaders.X_FORWARDED_PORT, "8080");
+        headers.add(HttpHeaders.X_FORWARDED_HOST, "     ");
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com",
+                headers
+        );
+
+        URI result = RequestUtil.getForwardedHost(mockContext);
+
+        Assert.assertNull(result);
+    }
+
+    /**
+     * Assert forwarded host fails with invalid host.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testForwardedHostInvalidPort() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.X_FORWARDED_PROTO, "https");
+        headers.add(HttpHeaders.X_FORWARDED_PORT, "string");
+        headers.add(HttpHeaders.X_FORWARDED_HOST, "example.com");
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com",
+                headers
+        );
+
+        URI result = RequestUtil.getForwardedHost(mockContext);
+
+        Assert.assertNull(result);
+    }
+
+    /**
+     * Assert forwarded host fails with invalid protocol.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testForwardedHostNoProtocol() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.X_FORWARDED_PORT, "string");
+        headers.add(HttpHeaders.X_FORWARDED_HOST, "example.com");
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com",
+                headers
+        );
+
+        URI result = RequestUtil.getForwardedHost(mockContext);
+
+        Assert.assertNull(result);
+    }
+
+    /**
+     * Assert forwarded host fails with invalid protocol.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testForwardedHostInvalidProtocol() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.X_FORWARDED_PROTO, "&&$$");
+        headers.add(HttpHeaders.X_FORWARDED_PORT, "string");
+        headers.add(HttpHeaders.X_FORWARDED_HOST, "example.com");
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com",
+                headers
+        );
+
+        URI result = RequestUtil.getForwardedHost(mockContext);
+
+        Assert.assertNull(result);
+    }
+
+    /**
+     * Test cross-origin with Host: only.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testCrossOriginWithHost() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.HOST, "host.example.com");
+        ContainerRequestContext mockContext = buildContext(
+                "http://host.example.com",
+                headers
+        );
+
+        Boolean result = RequestUtil.isCrossOriginRequest(mockContext);
+        Assert.assertFalse(result);
+    }
+
+    /**
+     * Test cross-origin with Origin: and Host:.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testCrossOriginWithOriginAndHost() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.ORIGIN, "http://host.example.com");
+        headers.add(HttpHeaders.HOST, "host.example.com");
+        ContainerRequestContext mockContext = buildContext(
+                "http://host.example.com",
+                headers
+        );
+
+        Boolean result = RequestUtil.isCrossOriginRequest(mockContext);
+        Assert.assertFalse(result);
+    }
+
+    /**
+     * Test cross-origin mismatch with Origin: and Host:.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testCrossOriginWithOriginAndHostMismatch() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.ORIGIN, "http://example.com");
+        headers.add(HttpHeaders.HOST, "host.example.com");
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com",
+                headers
+        );
+
+        Boolean result = RequestUtil.isCrossOriginRequest(mockContext);
+        Assert.assertTrue(result);
+    }
+
+    /**
+     * Test cross-origin with Origin: and X-Forwarded-*:.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testCrossOriginWithOriginAndForward() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.ORIGIN, "http://example.com:8080");
+        headers.add(HttpHeaders.X_FORWARDED_PROTO, "http");
+        headers.add(HttpHeaders.X_FORWARDED_PORT, "8080");
+        headers.add(HttpHeaders.X_FORWARDED_HOST, "example.com");
+        headers.add(HttpHeaders.HOST, "host.example.com");
+        ContainerRequestContext mockContext = buildContext(
+                "http://host.example.com",
+                headers
+        );
+
+        Boolean result = RequestUtil.isCrossOriginRequest(mockContext);
+        Assert.assertFalse(result);
+    }
+
+    /**
+     * Test cross-origin mismatch with Origin: and X-Forwarded-*:.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testCrossOriginWithOriginAndForwardMismatch() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.ORIGIN, "http://host.example.com:8080");
+        headers.add(HttpHeaders.X_FORWARDED_PROTO, "http");
+        headers.add(HttpHeaders.X_FORWARDED_PORT, "8081");
+        headers.add(HttpHeaders.X_FORWARDED_HOST, "example.com");
+        headers.add(HttpHeaders.HOST, "host.example.com");
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com:8080",
+                headers
+        );
+
+        Boolean result = RequestUtil.isCrossOriginRequest(mockContext);
+        Assert.assertTrue(result);
+    }
+
+    /**
+     * Test cross-origin with Origin: and invalid X-Forwarded-*:.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test(expected = BadRequestException.class)
+    public void testCrossOriginWithOriginAndInvalidForward() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.ORIGIN, "http://example.com:8080");
+        headers.add(HttpHeaders.X_FORWARDED_PROTO, "http");
+        headers.add(HttpHeaders.X_FORWARDED_PORT, "string");
+        headers.add(HttpHeaders.X_FORWARDED_HOST, "example.com");
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com",
+                headers
+        );
+
+        RequestUtil.isCrossOriginRequest(mockContext);
+    }
+
+    /**
+     * Test cross-origin with Referrer: and Host:.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testCrossOriginWithReferrerAndHost() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.REFERER,
+                "http://host.example.com/some/page.html");
+        headers.add(HttpHeaders.HOST,
+                "host.example.com");
+        ContainerRequestContext mockContext = buildContext(
+                "http://host.example.com",
+                headers
+        );
+
+        Boolean result = RequestUtil.isCrossOriginRequest(mockContext);
+        Assert.assertFalse(result);
+    }
+
+    /**
+     * Test cross-origin mismatch with Referrer: and Host:.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testCrossOriginWithReferrerAndHostMismatch() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.REFERER, "http://example.com/some/page.html");
+        headers.add(HttpHeaders.HOST, "another.example.com");
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com",
+                headers
+        );
+
+        Boolean result = RequestUtil.isCrossOriginRequest(mockContext);
+        Assert.assertTrue(result);
+    }
+
+    /**
+     * Test cross-origin with Referrer: and X-Forwarded-*:.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testCrossOriginWithReferrerAndForward() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.HOST, "proxied.example.com");
+        headers.add(HttpHeaders.REFERER,
+                "http://example.com:8080/some/page.html");
+        headers.add(HttpHeaders.X_FORWARDED_PROTO, "http");
+        headers.add(HttpHeaders.X_FORWARDED_PORT, "8080");
+        headers.add(HttpHeaders.X_FORWARDED_HOST, "example.com");
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com",
+                headers
+        );
+
+        Boolean result = RequestUtil.isCrossOriginRequest(mockContext);
+        Assert.assertFalse(result);
+    }
+
+    /**
+     * Test cross-origin mismatch with Referrer: and X-Forwarded-*:.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testCrossOriginWithReferrerAndForwardMisMatch() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.HOST, "proxy.example.com");
+        headers.add(HttpHeaders.REFERER, "http://example.com/some/page.html");
+        headers.add(HttpHeaders.X_FORWARDED_PROTO, "http");
+        headers.add(HttpHeaders.X_FORWARDED_HOST, "another.example.com");
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com",
+                headers
+        );
+
+        Boolean result = RequestUtil.isCrossOriginRequest(mockContext);
+        Assert.assertTrue(result);
+    }
+
+    /**
+     * Test cross-origin with Referrer: and invalid X-Forwarded-*:.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test(expected = BadRequestException.class)
+    public void testCrossOriginWithReferrerAndInvalidForward() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.REFERER, "http://example.com/some/page.html");
+        headers.add(HttpHeaders.X_FORWARDED_PROTO, "http");
+        headers.add(HttpHeaders.X_FORWARDED_PORT, "string");
+        headers.add(HttpHeaders.X_FORWARDED_HOST, "example.com");
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com",
+                headers
+        );
+
+        RequestUtil.isCrossOriginRequest(mockContext);
+    }
+
+    /**
+     * Test cross-origin with no Origin: or Referrer:.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test(expected = BadRequestException.class)
+    public void testCrossOriginNoOriginOrReferrer() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.X_FORWARDED_PROTO, "http");
+        headers.add(HttpHeaders.X_FORWARDED_PORT, "string");
+        headers.add(HttpHeaders.X_FORWARDED_HOST, "example.com");
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com",
+                headers
+        );
+
+        RequestUtil.isCrossOriginRequest(mockContext);
+    }
+
+    /**
+     * Test cross-origin with no Host: or X-Forwarded-*:.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test(expected = BadRequestException.class)
+    public void testCrossOriginNoHostOrForward() throws Exception {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(HttpHeaders.ORIGIN, "http://example.com:8080");
+        ContainerRequestContext mockContext = buildContext(
+                "https://host.example.com",
+                headers
+        );
+
+        RequestUtil.isCrossOriginRequest(mockContext);
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/AdminV1API.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/AdminV1API.java
@@ -32,6 +32,7 @@ import net.krotscheck.kangaroo.authz.admin.v1.resource.UserService;
 import net.krotscheck.kangaroo.authz.admin.v1.servlet.FirstRunContainerLifecycleListener;
 import net.krotscheck.kangaroo.authz.admin.v1.servlet.ServletConfigFactory;
 import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorFeature;
+import net.krotscheck.kangaroo.authz.common.cors.AuthzCORSFeature;
 import net.krotscheck.kangaroo.authz.common.database.DatabaseFeature;
 import net.krotscheck.kangaroo.common.config.ConfigurationFeature;
 import net.krotscheck.kangaroo.common.exception.ExceptionFeature;
@@ -71,6 +72,7 @@ public final class AdminV1API extends ResourceConfig {
         register(StatusFeature.class);           // Heartbeat service.
         register(TimedTasksFeature.class);       // Timed tasks service.
         register(AuthenticatorFeature.class);    // OAuth2 Authenticators
+        register(AuthzCORSFeature.class);        // CORS feature.
 
         // Internal components
         register(new ServletConfigFactory.Binder());

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/cors/AuthzCORSFeature.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/cors/AuthzCORSFeature.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.common.cors;
+
+import net.krotscheck.kangaroo.common.cors.CORSFeature;
+import net.krotscheck.kangaroo.common.cors.ExposedHeaders;
+import net.krotscheck.kangaroo.common.response.ApiParam;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+/**
+ * CORS Feature, specifically configured for the Admin API.
+ *
+ * @author Michael Krotscheck
+ */
+public final class AuthzCORSFeature implements Feature {
+
+    /**
+     * Configure the CORS feature for the Authz service.
+     *
+     * @param context configurable context in which the
+     *                feature should be enabled.
+     * @return {@code true} if the feature was successfully enabled.
+     */
+    @Override
+    public boolean configure(final FeatureContext context) {
+        // Inject the CORS feature.
+        context.register(CORSFeature.class);
+
+        // Add custom headers & Methods
+        context.register(new ExposedHeaders(new String[]{
+                ApiParam.LIMIT_HEADER,
+                ApiParam.OFFSET_HEADER,
+                ApiParam.ORDER_HEADER,
+                ApiParam.SORT_HEADER,
+                ApiParam.TOTAL_HEADER}));
+
+        // Add the cors validator.
+        context.register(new HibernateCORSCacheLoader.Binder());
+        context.register(new HibernateCORSValidator.Binder());
+
+        return true;
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/cors/HibernateCORSCacheLoader.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/cors/HibernateCORSCacheLoader.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.common.cors;
+
+import com.google.common.cache.CacheLoader;
+import net.krotscheck.kangaroo.authz.common.database.entity.ClientReferrer;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.hibernate.Criteria;
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.criterion.Projections;
+import org.hibernate.criterion.Restrictions;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.net.URI;
+
+/**
+ * This validator returns true if the CORS domain exists in our referrer
+ * table. Results are cached for 5 minutes, which is our CORS cache timeout.
+ *
+ * @author Michael Krotscheck
+ */
+public final class HibernateCORSCacheLoader
+        extends CacheLoader<URI, Boolean> {
+
+    /**
+     * The hibernate session factory.
+     */
+    private final SessionFactory factory;
+
+    /**
+     * The hibernate CORS session factory.
+     *
+     * @param factory Injected hibernate factory.
+     */
+    @Inject
+    public HibernateCORSCacheLoader(final SessionFactory factory) {
+        this.factory = factory;
+    }
+
+    /**
+     * Computes or retrieves the value corresponding to {@code key}.
+     *
+     * @param origin The non-null key whose value should be loaded.
+     * @return Whether the URI is valid or not.
+     * @throws Exception If unable to load the result.
+     */
+    @Override
+    public Boolean load(final URI origin) throws Exception {
+        Session s = factory.openSession();
+        try {
+            Transaction t = s.beginTransaction();
+            Criteria c = s.createCriteria(ClientReferrer.class)
+                    .add(Restrictions.eq("uri", origin))
+                    .setProjection(Projections.rowCount());
+            Long total = Long.valueOf(c.uniqueResult().toString());
+            t.commit();
+            return total > 0;
+        } catch (HibernateException e) {
+            // Do nothing.
+            return false;
+        } finally {
+            s.close();
+        }
+    }
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bind(HibernateCORSCacheLoader.class)
+                    .to(HibernateCORSCacheLoader.class)
+                    .in(Singleton.class);
+        }
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/cors/HibernateCORSValidator.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/cors/HibernateCORSValidator.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.common.cors;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.LoadingCache;
+import net.krotscheck.kangaroo.common.cors.ICORSValidator;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.net.URI;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This validator returns true if the CORS domain exists in our referrer
+ * table. Results are cached for 5 minutes, which is our CORS cache timeout.
+ *
+ * @author Michael Krotscheck
+ */
+public final class HibernateCORSValidator implements ICORSValidator {
+
+    /**
+     * This cache contains the last 1000 domains that were checked.
+     */
+    private final LoadingCache<URI, Boolean> validDomains;
+
+    /**
+     * The hibernate CORS session factory.
+     *
+     * @param cacheLoader The CORS cache loader.
+     */
+    @Inject
+    public HibernateCORSValidator(final HibernateCORSCacheLoader cacheLoader) {
+        this.validDomains = CacheBuilder.newBuilder()
+                .maximumSize(1000)
+                .expireAfterWrite(5, TimeUnit.MINUTES)
+                .build(cacheLoader);
+    }
+
+    /**
+     * Return true if the URI is a valid origin for a CORS request.
+     *
+     * @param origin The origin to validate. Will only contain scheme, host,
+     *               and port.
+     * @return True if the origin is valid, otherwise false.
+     */
+    @Override
+    public boolean isValidCORSOrigin(final URI origin) {
+        try {
+            return validDomains.get(origin);
+        } catch (ExecutionException ee) {
+            return false;
+        }
+    }
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bind(HibernateCORSValidator.class)
+                    .to(ICORSValidator.class)
+                    .in(Singleton.class);
+        }
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/cors/package-info.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/cors/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * CORS domain validation for the authz service.
+ */
+package net.krotscheck.kangaroo.authz.common.cors;

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/OAuthAPI.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/OAuthAPI.java
@@ -18,6 +18,7 @@
 package net.krotscheck.kangaroo.authz.oauth2;
 
 import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorFeature;
+import net.krotscheck.kangaroo.authz.common.cors.AuthzCORSFeature;
 import net.krotscheck.kangaroo.authz.common.database.DatabaseFeature;
 import net.krotscheck.kangaroo.authz.oauth2.factory.CredentialsFactory;
 import net.krotscheck.kangaroo.authz.oauth2.filter.ClientAuthorizationFilter;
@@ -60,6 +61,7 @@ public class OAuthAPI extends ResourceConfig {
         register(StatusFeature.class);           // Heartbeat service.
         register(TimedTasksFeature.class);       // Timed tasks service.
         register(AuthenticatorFeature.class);    // OAuth2 Authenticators
+        register(AuthzCORSFeature.class);        // CORS feature.
 
         // Asset factories
         register(new CredentialsFactory.Binder());

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/cors/AuthzCORSFeatureTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/cors/AuthzCORSFeatureTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.common.cors;
+
+import com.google.common.net.HttpHeaders;
+import net.krotscheck.kangaroo.authz.admin.AdminV1API;
+import net.krotscheck.kangaroo.authz.admin.Scope;
+import net.krotscheck.kangaroo.authz.admin.v1.test.rule.TestDataResource;
+import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
+import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.common.response.ApiParam;
+import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.HttpUtil;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+/**
+ * Unit tests for CORS specifically used in the authz application.
+ *
+ * @author Michael Krotscheck
+ */
+public final class AuthzCORSFeatureTest extends ContainerTest {
+
+    /**
+     * Preload data into the system.
+     */
+    @ClassRule
+    public static final TestDataResource TEST_DATA_RESOURCE =
+            new TestDataResource(HIBERNATE_RESOURCE);
+
+    /**
+     * Create the application under test.
+     *
+     * @return A configured api servlet.
+     */
+    @Override
+    protected ResourceConfig createApplication() {
+        return new AdminV1API();
+    }
+
+    /**
+     * CORS overall works, we just need to make sure that the feature is
+     * bound properly and spits out the list parameters.
+     */
+    @Test
+    public void testListResponse() {
+        ApplicationContext context = TEST_DATA_RESOURCE.getAdminApplication();
+        context.getBuilder().referrer("http://valid.example.com").build();
+
+        OAuthToken adminAppToken = context
+                .getBuilder()
+                .bearerToken(Scope.APPLICATION_ADMIN)
+                .build()
+                .getToken();
+
+        Response r = target("/application/")
+                .request()
+                .header(HttpHeaders.ORIGIN, "http://valid.example.com")
+                .header(HttpHeaders.AUTHORIZATION,
+                        HttpUtil.authHeaderBearer(adminAppToken.getId()))
+                .get();
+
+        MultivaluedMap<String, Object> headers = r.getHeaders();
+        List<Object> exposedHeaders = headers.get(HttpHeaders
+                .ACCESS_CONTROL_EXPOSE_HEADERS);
+
+        Assert.assertTrue(exposedHeaders
+                .indexOf(ApiParam.LIMIT_HEADER.toLowerCase()) > -1);
+        Assert.assertTrue(exposedHeaders
+                .indexOf(ApiParam.OFFSET_HEADER.toLowerCase()) > -1);
+        Assert.assertTrue(exposedHeaders
+                .indexOf(ApiParam.ORDER_HEADER.toLowerCase()) > -1);
+        Assert.assertTrue(exposedHeaders
+                .indexOf(ApiParam.SORT_HEADER.toLowerCase()) > -1);
+        Assert.assertTrue(exposedHeaders
+                .indexOf(ApiParam.TOTAL_HEADER.toLowerCase()) > -1);
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/cors/HibernateCORSCacheLoaderTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/cors/HibernateCORSCacheLoaderTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.common.cors;
+
+import net.krotscheck.kangaroo.authz.admin.v1.test.rule.TestDataResource;
+import net.krotscheck.kangaroo.test.DatabaseTest;
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.net.URI;
+
+/**
+ * Unit test for the CORS cache loader.
+ *
+ * @author Michael Krotscheck
+ */
+public final class HibernateCORSCacheLoaderTest extends DatabaseTest {
+
+    /**
+     * Preload data into the system.
+     */
+    @ClassRule
+    public static final TestDataResource TEST_DATA_RESOURCE =
+            new TestDataResource(HIBERNATE_RESOURCE);
+
+    /**
+     * Assert that we can load valid domains.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void loadValid() throws Exception {
+        TEST_DATA_RESOURCE.getAdminApplication()
+                .getBuilder()
+                .referrer("https://valid.example.com")
+                .build();
+
+        URI valid = new URI("https://valid.example.com");
+        HibernateCORSCacheLoader loader =
+                new HibernateCORSCacheLoader(getSessionFactory());
+
+        Boolean result = loader.load(valid);
+        Assert.assertTrue(result);
+    }
+
+    /**
+     * Assert that we can load invalid domains.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void loadInvalid() throws Exception {
+        URI invalid = new URI("https://invalid.example.com");
+        HibernateCORSCacheLoader loader =
+                new HibernateCORSCacheLoader(getSessionFactory());
+
+        Boolean result = loader.load(invalid);
+        Assert.assertFalse(result);
+    }
+
+    /**
+     * Assert that we don't die if the database throws errors.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void loadWithHibernateException() throws Exception {
+        SessionFactory mockFactory = Mockito.mock(SessionFactory.class);
+        Session mockSession = Mockito.mock(Session.class);
+        Mockito.doReturn(mockSession).when(mockFactory).openSession();
+        Mockito.doThrow(HibernateException.class).when(mockSession)
+                .beginTransaction();
+
+        URI invalid = new URI("https://invalid.example.com");
+        HibernateCORSCacheLoader loader =
+                new HibernateCORSCacheLoader(mockFactory);
+
+        Boolean result = loader.load(invalid);
+        Assert.assertFalse(result);
+    }
+
+    /**
+     * Assert that exceptions thrown in the final catch block are recast.
+     * This is really done for coverage.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test(expected = Exception.class)
+    public void loadWithGenericException() throws Exception {
+        SessionFactory mockFactory = Mockito.mock(SessionFactory.class);
+        Session mockSession = Mockito.mock(Session.class);
+        Mockito.doReturn(mockSession).when(mockFactory).openSession();
+        Mockito.doThrow(Exception.class).when(mockSession)
+                .beginTransaction();
+
+        URI invalid = new URI("https://invalid.example.com");
+        HibernateCORSCacheLoader loader =
+                new HibernateCORSCacheLoader(mockFactory);
+
+        Boolean result = loader.load(invalid);
+        Assert.assertFalse(result);
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/cors/HibernateCORSValidatorTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/cors/HibernateCORSValidatorTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.common.cors;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareOnlyThisForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.net.URI;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Unit tests for the ICORSValidator.
+ *
+ * @author Michael Krotscheck
+ */
+@RunWith(PowerMockRunner.class)
+public class HibernateCORSValidatorTest {
+
+    /**
+     * Assert that we can load valid domains.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    @PrepareOnlyThisForTest(HibernateCORSCacheLoader.class)
+    public void loadValid() throws Exception {
+        HibernateCORSCacheLoader loader =
+                Mockito.mock(HibernateCORSCacheLoader.class);
+        Mockito.doReturn(true)
+                .when(loader)
+                .load(Matchers.any(URI.class));
+
+        HibernateCORSValidator validator = new HibernateCORSValidator(loader);
+
+        URI uri = new URI("http://valid.example.com");
+        Boolean response1 = validator.isValidCORSOrigin(uri);
+        validator.isValidCORSOrigin(uri);
+
+        Assert.assertTrue(response1);
+
+        Mockito.verify(loader, Mockito.times(1))
+                .load(Matchers.any(URI.class));
+    }
+
+    /**
+     * Assert that we still return valid data in the case an exception is
+     * thrown.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    @PrepareOnlyThisForTest(HibernateCORSCacheLoader.class)
+    public void loadValidWithException() throws Exception {
+        HibernateCORSCacheLoader loader =
+                Mockito.mock(HibernateCORSCacheLoader.class);
+        Mockito.doThrow(ExecutionException.class)
+                .when(loader)
+                .load(Matchers.any(URI.class));
+
+        HibernateCORSValidator validator = new HibernateCORSValidator(loader);
+
+        URI uri = new URI("http://valid.example.com");
+        Boolean response1 = validator.isValidCORSOrigin(uri);
+        validator.isValidCORSOrigin(uri);
+
+        Assert.assertFalse(response1);
+
+        Mockito.verify(loader, Mockito.times(2))
+                .load(Matchers.any(URI.class));
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/cors/package-info.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/cors/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Unit tests for CORS domain validation.
+ */
+package net.krotscheck.kangaroo.authz.common.cors;

--- a/pom.xml
+++ b/pom.xml
@@ -295,6 +295,7 @@
             <argLine>-Xmx1024m</argLine>
 
             <systemProperties>
+              <sun.net.http.allowRestrictedHeaders>true</sun.net.http.allowRestrictedHeaders>
               <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
             </systemProperties>
 
@@ -705,6 +706,13 @@
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>2.4</version>
+      </dependency>
+
+      <!-- Google Commons -->
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>22.0</version>
       </dependency>
 
       <!-- Hibernate -->


### PR DESCRIPTION
This patch includes an injection-configurable CORS feature, as well as
the necessary Origin URL providers. It includes:

- Injection helpers for common permitted methods, headers, and exposed headers.
- An implementable interface for domain valiation.
- A RequestUtil that assists in decoding Container Requests, and their headers.
- CORSFilter, which decorates all service responses.
- A customized injector for the Authz application.
- Tests for the above.