### PR TITLE
Removed redirect from KangarooException

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/exception/ExceptionFeature.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/exception/ExceptionFeature.java
@@ -19,6 +19,7 @@ package net.krotscheck.kangaroo.common.exception;
 
 import net.krotscheck.kangaroo.common.exception.mapper.JerseyExceptionMapper;
 import net.krotscheck.kangaroo.common.exception.mapper.JsonParseExceptionMapper;
+import net.krotscheck.kangaroo.common.exception.mapper.KangarooExceptionMapper;
 import net.krotscheck.kangaroo.common.exception.mapper.UnhandledExceptionMapper;
 
 import javax.ws.rs.core.Feature;
@@ -41,6 +42,7 @@ public final class ExceptionFeature implements Feature {
     public boolean configure(final FeatureContext context) {
 
         // Exception mappers.
+        context.register(new KangarooExceptionMapper.Binder());
         context.register(new JerseyExceptionMapper.Binder());
         context.register(new JsonParseExceptionMapper.Binder());
         context.register(new UnhandledExceptionMapper.Binder());

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/exception/mapper/KangarooExceptionMapper.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/exception/mapper/KangarooExceptionMapper.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.exception.mapper;
+
+import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder;
+import net.krotscheck.kangaroo.common.exception.KangarooException;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+import javax.inject.Singleton;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Exception mapper for Web Application exceptions that are otherwise
+ * unhandled.
+ *
+ * @author Michael Krotscheck
+ */
+@Provider
+public final class KangarooExceptionMapper
+        implements ExceptionMapper<KangarooException> {
+
+    /**
+     * Convert to response.
+     *
+     * @param e The exceptions to handle.
+     * @return The Response instance for this error.
+     */
+    public Response toResponse(final KangarooException e) {
+        return ErrorResponseBuilder.from(e).build();
+    }
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bind(KangarooExceptionMapper.class)
+                    .to(ExceptionMapper.class)
+                    .in(Singleton.class);
+        }
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/exception/ErrorResponseBuilderTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/exception/ErrorResponseBuilderTest.java
@@ -33,6 +33,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import java.net.URI;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -59,7 +60,6 @@ public final class ErrorResponseBuilderTest {
                 r.getStatus());
         Assert.assertEquals(Status.NOT_FOUND, er.getHttpStatus());
         Assert.assertEquals("Not Found", er.getErrorDescription());
-        Assert.assertNull(er.getRedirectUrl());
         Assert.assertEquals("not_found", er.getError());
     }
 
@@ -77,7 +77,6 @@ public final class ErrorResponseBuilderTest {
                 r.getStatus());
         Assert.assertEquals(Status.NOT_FOUND, er.getHttpStatus());
         Assert.assertEquals("message", er.getErrorDescription());
-        Assert.assertNull(er.getRedirectUrl());
         Assert.assertEquals("not_found", er.getError());
     }
 
@@ -95,7 +94,6 @@ public final class ErrorResponseBuilderTest {
                 r.getStatus());
         Assert.assertEquals(Status.NOT_FOUND, er.getHttpStatus());
         Assert.assertEquals("message", er.getErrorDescription());
-        Assert.assertNull(er.getRedirectUrl());
         Assert.assertEquals("test_code", er.getError());
     }
 
@@ -114,12 +112,11 @@ public final class ErrorResponseBuilderTest {
                 r.getStatus());
         Assert.assertEquals(Status.BAD_REQUEST, er.getHttpStatus());
         Assert.assertTrue(er.getErrorDescription().indexOf("foo") > -1);
-        Assert.assertEquals(null, er.getRedirectUrl());
         Assert.assertEquals("bad_request", er.getError());
     }
 
     /**
-     * Test building from a WebApplicationException.
+     * Test building from a KangarooException.
      */
     @Test
     public void testFromKangarooException() {
@@ -133,7 +130,6 @@ public final class ErrorResponseBuilderTest {
         Assert.assertEquals(Status.BAD_REQUEST, er.getHttpStatus());
         Assert.assertEquals("Test Error",
                 er.getErrorDescription());
-        Assert.assertNull(er.getRedirectUrl());
         Assert.assertEquals("test_error", er.getError());
     }
 
@@ -152,7 +148,6 @@ public final class ErrorResponseBuilderTest {
         Assert.assertEquals(Status.INTERNAL_SERVER_ERROR, er.getHttpStatus());
         Assert.assertEquals("HTTP 500 Internal Server Error",
                 er.getErrorDescription());
-        Assert.assertNull(er.getRedirectUrl());
         Assert.assertEquals("internal_server_error", er.getError());
     }
 
@@ -176,7 +171,6 @@ public final class ErrorResponseBuilderTest {
                 r.getStatus());
         Assert.assertEquals(Status.BAD_REQUEST, er.getHttpStatus());
         Assert.assertEquals("test 1", er.getErrorDescription());
-        Assert.assertNull(er.getRedirectUrl());
         Assert.assertEquals("bad_request", er.getError());
     }
 
@@ -196,7 +190,6 @@ public final class ErrorResponseBuilderTest {
                 r.getStatus());
         Assert.assertEquals(Status.INTERNAL_SERVER_ERROR, er.getHttpStatus());
         Assert.assertEquals("Internal Server Error", er.getErrorDescription());
-        Assert.assertNull(er.getRedirectUrl());
         Assert.assertEquals("internal_server_error", er.getError());
     }
 
@@ -214,7 +207,6 @@ public final class ErrorResponseBuilderTest {
                 r.getStatus());
         Assert.assertEquals(Status.INTERNAL_SERVER_ERROR, er.getHttpStatus());
         Assert.assertEquals("Internal Server Error", er.getErrorDescription());
-        Assert.assertNull(er.getRedirectUrl());
         Assert.assertEquals("internal_server_error", er.getError());
     }
 

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/exception/mapper/JerseyExceptionMapperTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/exception/mapper/JerseyExceptionMapperTest.java
@@ -50,7 +50,6 @@ public final class JerseyExceptionMapperTest {
                 r.getStatus());
         Assert.assertEquals(Status.INTERNAL_SERVER_ERROR, er.getHttpStatus());
         Assert.assertEquals("test", er.getErrorDescription());
-        Assert.assertNull(er.getRedirectUrl());
     }
 
     /**
@@ -67,7 +66,6 @@ public final class JerseyExceptionMapperTest {
         Assert.assertEquals(Status.NOT_FOUND.getStatusCode(), r.getStatus());
         Assert.assertEquals(Status.NOT_FOUND, er.getHttpStatus());
         Assert.assertEquals("HTTP 404 Not Found", er.getErrorDescription());
-        Assert.assertNull(er.getRedirectUrl());
         Assert.assertEquals("not_found", er.getError());
     }
 
@@ -85,7 +83,6 @@ public final class JerseyExceptionMapperTest {
         Assert.assertEquals(Status.FORBIDDEN.getStatusCode(), r.getStatus());
         Assert.assertEquals(Status.FORBIDDEN, er.getHttpStatus());
         Assert.assertEquals("HTTP 403 Forbidden", er.getErrorDescription());
-        Assert.assertNull(er.getRedirectUrl());
         Assert.assertEquals("forbidden", er.getError());
     }
 }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/exception/mapper/JsonParseExceptionMapperTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/exception/mapper/JsonParseExceptionMapperTest.java
@@ -50,6 +50,5 @@ public final class JsonParseExceptionMapperTest {
 
         Assert.assertEquals(Status.BAD_REQUEST.getStatusCode(), r.getStatus());
         Assert.assertEquals(Status.BAD_REQUEST, er.getHttpStatus());
-        Assert.assertEquals(null, er.getRedirectUrl());
     }
 }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/exception/mapper/KangarooExceptionMapperTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/exception/mapper/KangarooExceptionMapperTest.java
@@ -16,52 +16,38 @@
  *
  */
 
-package net.krotscheck.kangaroo.common.exception;
+package net.krotscheck.kangaroo.common.exception.mapper;
 
-import net.krotscheck.kangaroo.common.exception.KangarooException.ErrorCode;
+import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder.ErrorResponse;
+import net.krotscheck.kangaroo.common.exception.KangarooException;
 import org.junit.Assert;
 import org.junit.Test;
 
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 /**
- * Unit tests for our common application exception.
+ * Unit tests for mapping kangaroo exceptions.
  *
  * @author Michael Krotscheck
  */
-public class KangarooExceptionTest {
+public class KangarooExceptionMapperTest {
 
     /**
-     * Test the error code class.
+     * Test converting to a response.
      */
     @Test
-    public void testErrorCode() {
-        ErrorCode testCode = new ErrorCode(Status.FORBIDDEN,
-                "code", "description");
-        Assert.assertEquals(Status.FORBIDDEN, testCode.getHttpStatus());
-        Assert.assertEquals("code", testCode.getError());
-        Assert.assertEquals("description", testCode.getErrorDescription());
-    }
+    public void testToResponse() {
+        KangarooExceptionMapper mapper = new KangarooExceptionMapper();
+        TestError jpe = new TestError();
 
-    /**
-     * Assert creating with code, but no redirect.
-     */
-    @Test
-    public void testGetCode() {
-        KangarooException e = new TestError();
-        Assert.assertSame(TestError.CODE, e.getCode());
-    }
+        Response r = mapper.toResponse(jpe);
+        ErrorResponse er = (ErrorResponse) r.getEntity();
 
-    /**
-     * Assert creating with code, but no redirect.
-     */
-    @Test
-    public void testPlain() {
-        KangarooException e = new TestError();
-
-        Assert.assertEquals(TestError.CODE.getHttpStatus().getStatusCode(),
-                e.getResponse().getStatus());
-        Assert.assertEquals(e.getCode(), TestError.CODE);
+        Assert.assertEquals(Status.FORBIDDEN.getStatusCode(), r.getStatus());
+        Assert.assertEquals(Status.FORBIDDEN, er.getHttpStatus());
+        Assert.assertEquals("test_error", er.getError());
+        Assert.assertEquals("Test Error", er.getErrorDescription());
     }
 
     /**
@@ -73,7 +59,7 @@ public class KangarooExceptionTest {
          * The error code.
          */
         public static final ErrorCode CODE = new ErrorCode(
-                Status.BAD_REQUEST,
+                Status.FORBIDDEN,
                 "test_error",
                 "Test Error"
         );
@@ -85,4 +71,5 @@ public class KangarooExceptionTest {
             super(CODE);
         }
     }
+
 }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/exception/mapper/UnhandledExceptionMapperTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/exception/mapper/UnhandledExceptionMapperTest.java
@@ -47,6 +47,5 @@ public final class UnhandledExceptionMapperTest {
                 r.getStatus());
         Assert.assertEquals(Status.INTERNAL_SERVER_ERROR, er.getHttpStatus());
         Assert.assertEquals("Internal Server Error", er.getErrorDescription());
-        Assert.assertNull(er.getRedirectUrl());
     }
 }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/mapper/ConstraintViolationExceptionMapperTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/mapper/ConstraintViolationExceptionMapperTest.java
@@ -59,7 +59,6 @@ public final class ConstraintViolationExceptionMapperTest {
         Assert.assertEquals(Status.BAD_REQUEST.getStatusCode(), r.getStatus());
         Assert.assertEquals(Status.BAD_REQUEST, er.getHttpStatus());
         Assert.assertEquals("test 1", er.getErrorDescription());
-        Assert.assertNull(er.getRedirectUrl());
     }
 
 }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/mapper/HibernateExceptionMapperTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/mapper/HibernateExceptionMapperTest.java
@@ -48,6 +48,5 @@ public final class HibernateExceptionMapperTest {
                 r.getStatus());
         Assert.assertEquals(Status.INTERNAL_SERVER_ERROR, er.getHttpStatus());
         Assert.assertEquals("Internal Server Error", er.getErrorDescription());
-        Assert.assertNull(er.getRedirectUrl());
     }
 }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/mapper/PersistenceExceptionMapperTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/mapper/PersistenceExceptionMapperTest.java
@@ -53,7 +53,6 @@ public final class PersistenceExceptionMapperTest {
         Assert.assertEquals(Status.CONFLICT.getStatusCode(), r.getStatus());
         Assert.assertEquals(Status.CONFLICT, er.getHttpStatus());
         Assert.assertEquals("Conflict", er.getErrorDescription());
-        Assert.assertNull(er.getRedirectUrl());
     }
 
     /**
@@ -71,6 +70,5 @@ public final class PersistenceExceptionMapperTest {
                 r.getStatus());
         Assert.assertEquals(Status.INTERNAL_SERVER_ERROR, er.getHttpStatus());
         Assert.assertEquals("Internal Server Error", er.getErrorDescription());
-        Assert.assertNull(er.getRedirectUrl());
     }
 }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/mapper/PropertyValueExceptionMapperTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/mapper/PropertyValueExceptionMapperTest.java
@@ -50,6 +50,5 @@ public final class PropertyValueExceptionMapperTest {
         Assert.assertEquals(Status.BAD_REQUEST, er.getHttpStatus());
         Assert.assertEquals("Property \"name\" is invalid.",
                 er.getErrorDescription());
-        Assert.assertNull(er.getRedirectUrl());
     }
 }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/mapper/QueryExceptionMapperTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/mapper/QueryExceptionMapperTest.java
@@ -45,7 +45,6 @@ public final class QueryExceptionMapperTest {
         Assert.assertEquals(Status.BAD_REQUEST.getStatusCode(), r.getStatus());
         Assert.assertEquals(Status.BAD_REQUEST, er.getHttpStatus());
         Assert.assertEquals("Bad Request", er.getErrorDescription());
-        Assert.assertNull(er.getRedirectUrl());
     }
 
 }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/mapper/SearchExceptionMapperTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/mapper/SearchExceptionMapperTest.java
@@ -49,7 +49,6 @@ public final class SearchExceptionMapperTest {
                 r.getStatus());
         Assert.assertEquals(Status.INTERNAL_SERVER_ERROR, er.getHttpStatus());
         Assert.assertEquals("Internal Server Error", er.getErrorDescription());
-        Assert.assertNull(er.getRedirectUrl());
     }
 
     /**
@@ -67,6 +66,5 @@ public final class SearchExceptionMapperTest {
                 r.getStatus());
         Assert.assertEquals(Status.BAD_REQUEST, er.getHttpStatus());
         Assert.assertEquals("Bad Request", er.getErrorDescription());
-        Assert.assertNull(er.getRedirectUrl());
     }
 }

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/OAuthAPI.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/OAuthAPI.java
@@ -20,6 +20,7 @@ package net.krotscheck.kangaroo.authz.oauth2;
 import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorFeature;
 import net.krotscheck.kangaroo.authz.common.cors.AuthzCORSFeature;
 import net.krotscheck.kangaroo.authz.common.database.DatabaseFeature;
+import net.krotscheck.kangaroo.authz.oauth2.exception.RedirectingExceptionMapper;
 import net.krotscheck.kangaroo.authz.oauth2.factory.CredentialsFactory;
 import net.krotscheck.kangaroo.authz.oauth2.filter.ClientAuthorizationFilter;
 import net.krotscheck.kangaroo.authz.oauth2.resource.AuthorizationService;
@@ -80,6 +81,9 @@ public class OAuthAPI extends ResourceConfig {
 
         // Timed tasks
         register(new TokenCleanupTask.Binder()); // Cleanup old tokens.
+
+        // Exception Mappers
+        register(new RedirectingExceptionMapper.Binder());
 
         // Resource services
         register(TokenService.class);

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/exception/RFC6749.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/exception/RFC6749.java
@@ -21,7 +21,6 @@ package net.krotscheck.kangaroo.authz.oauth2.exception;
 import net.krotscheck.kangaroo.common.exception.KangarooException;
 
 import javax.ws.rs.core.Response.Status;
-import java.net.URI;
 
 /**
  * Error codes specified in the OAuth2 Specification.
@@ -62,15 +61,6 @@ public final class RFC6749 {
         public InvalidRequestException() {
             super(CODE);
         }
-
-        /**
-         * Build this exception with a redirect.
-         *
-         * @param redirect The redirect.
-         */
-        public InvalidRequestException(final URI redirect) {
-            super(CODE, redirect);
-        }
     }
 
 
@@ -97,15 +87,6 @@ public final class RFC6749 {
         public UnauthorizedClientException() {
             super(CODE);
         }
-
-        /**
-         * Build this exception with a redirect.
-         *
-         * @param redirect The redirect.
-         */
-        public UnauthorizedClientException(final URI redirect) {
-            super(CODE, redirect);
-        }
     }
 
     /**
@@ -129,15 +110,6 @@ public final class RFC6749 {
          */
         public AccessDeniedException() {
             super(CODE);
-        }
-
-        /**
-         * Build this exception with a redirect.
-         *
-         * @param redirect The redirect.
-         */
-        public AccessDeniedException(final URI redirect) {
-            super(CODE, redirect);
         }
     }
 
@@ -164,15 +136,6 @@ public final class RFC6749 {
         public UnsupportedResponseTypeException() {
             super(CODE);
         }
-
-        /**
-         * Build this exception with a redirect.
-         *
-         * @param redirect The redirect.
-         */
-        public UnsupportedResponseTypeException(final URI redirect) {
-            super(CODE, redirect);
-        }
     }
 
     /**
@@ -196,15 +159,6 @@ public final class RFC6749 {
          */
         public InvalidScopeException() {
             super(CODE);
-        }
-
-        /**
-         * Build this exception with a redirect.
-         *
-         * @param redirect The redirect.
-         */
-        public InvalidScopeException(final URI redirect) {
-            super(CODE, redirect);
         }
     }
 
@@ -232,15 +186,6 @@ public final class RFC6749 {
          */
         public ServerErrorException() {
             super(CODE);
-        }
-
-        /**
-         * Build this exception with a redirect.
-         *
-         * @param redirect The redirect.
-         */
-        public ServerErrorException(final URI redirect) {
-            super(CODE, redirect);
         }
     }
 
@@ -270,15 +215,6 @@ public final class RFC6749 {
         public TemporarilyUnavailableException() {
             super(CODE);
         }
-
-        /**
-         * Build this exception with a redirect.
-         *
-         * @param redirect The redirect.
-         */
-        public TemporarilyUnavailableException(final URI redirect) {
-            super(CODE, redirect);
-        }
     }
 
     /**
@@ -302,15 +238,6 @@ public final class RFC6749 {
          */
         public InvalidClientException() {
             super(CODE);
-        }
-
-        /**
-         * Build this exception with a redirect.
-         *
-         * @param redirect The redirect.
-         */
-        public InvalidClientException(final URI redirect) {
-            super(CODE, redirect);
         }
     }
 
@@ -336,15 +263,6 @@ public final class RFC6749 {
         public InvalidGrantException() {
             super(CODE);
         }
-
-        /**
-         * Build this exception with a redirect.
-         *
-         * @param redirect The redirect.
-         */
-        public InvalidGrantException(final URI redirect) {
-            super(CODE, redirect);
-        }
     }
 
     /**
@@ -368,15 +286,6 @@ public final class RFC6749 {
          */
         public UnsupportedGrantTypeException() {
             super(CODE);
-        }
-
-        /**
-         * Build this exception with a redirect.
-         *
-         * @param redirect The redirect.
-         */
-        public UnsupportedGrantTypeException(final URI redirect) {
-            super(CODE, redirect);
         }
     }
 }

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/exception/RedirectingException.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/exception/RedirectingException.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.oauth2.exception;
+
+import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response.Status;
+import java.net.URI;
+
+/**
+ * This is a wrapper exception for unexpected exceptions, which need to be
+ * redirected as per the OAuth2 Specification. It requires a throwable, as
+ * this exception is only an expression of an OAuth2 targeted exception
+ * response.
+ *
+ * @author Michael Krotscheck
+ */
+public final class RedirectingException extends WebApplicationException {
+
+    /**
+     * A redirect, required.
+     */
+    private final URI redirect;
+
+    /**
+     * The client type. This is needed to decide whether the response should
+     * be placed in the fragment, or in the query string.
+     */
+    private final ClientType clientType;
+
+    /**
+     * Create a new RedirectingException for a provided exception, including
+     * the redirect to which the details should be sent.
+     *
+     * @param cause      The cause.
+     * @param redirect   The redirect.
+     * @param clientType The client type.
+     */
+    public RedirectingException(final Throwable cause,
+                                final URI redirect,
+                                final ClientType clientType) {
+        super(cause.getMessage(), cause, Status.FOUND);
+        this.redirect = redirect;
+        this.clientType = clientType;
+    }
+
+    /**
+     * Return the provided redirect.
+     *
+     * @return The redirect. Could be null.
+     */
+    public URI getRedirect() {
+        return redirect;
+    }
+
+    /**
+     * Return the client type that threw this exception.
+     *
+     * @return The client type.
+     */
+    public ClientType getClientType() {
+        return clientType;
+    }
+
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/exception/RedirectingExceptionMapper.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/exception/RedirectingExceptionMapper.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.oauth2.exception;
+
+import com.google.common.net.HttpHeaders;
+import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
+import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder.ErrorResponse;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.spi.ExceptionMappers;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.ext.ExceptionMapper;
+
+/**
+ * This exception mapper handles RedirectingExceptions thrown by the system.
+ * It first invokes the existing ErrorResponseBuilder and then remaps the
+ * response to an OAuth2 redirected exception.
+ *
+ * @author Michael Krotscheck
+ */
+public final class RedirectingExceptionMapper
+        implements ExceptionMapper<RedirectingException> {
+
+    /**
+     * The service locator. This class makes use of all registered
+     * ExceptionMappers to perform a first-pass of the exception before
+     * turning it into a redirect. Since that creates a circular dependency,
+     * we read it - on request - from the injector instead.
+     */
+    private final ServiceLocator serviceLocator;
+
+    /**
+     * Create a new exception mapper for our redirecting exceptions.
+     *
+     * @param serviceLocator The service locator.
+     */
+    @Inject
+    RedirectingExceptionMapper(final ServiceLocator serviceLocator) {
+        this.serviceLocator = serviceLocator;
+    }
+
+    /**
+     * Convert to response.
+     *
+     * @param exception The exception to convert.
+     * @return A Response instance for this error.
+     */
+    public Response toResponse(final RedirectingException exception) {
+        Throwable cause = exception.getCause();
+
+        // Retrieve the exception mapper for this cause.
+        ExceptionMappers mappers =
+                serviceLocator.getService(ExceptionMappers.class);
+        ExceptionMapper mapper = mappers.findMapping(cause);
+        Response r = mapper.toResponse(cause);
+        ErrorResponse responseEntity = (ErrorResponse) r.getEntity();
+
+        // Build the Redirect URI from the response.
+        UriBuilder builder = UriBuilder.fromUri(exception.getRedirect());
+        builder.queryParam("error", responseEntity.getError());
+        builder.queryParam("error_description",
+                responseEntity.getErrorDescription());
+
+        if (exception.getClientType().equals(ClientType.Implicit)) {
+            // Generate the query, and feed it right back into the builder.
+            builder.fragment(builder.build().getQuery());
+            builder.replaceQuery("");
+        }
+
+        return Response.fromResponse(r)
+                .status(Status.FOUND)
+                .header(HttpHeaders.LOCATION, builder.build())
+                .build();
+    }
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bind(RedirectingExceptionMapper.class)
+                    .to(ExceptionMapper.class)
+                    .in(Singleton.class);
+        }
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/AuthorizationService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/AuthorizationService.java
@@ -30,8 +30,8 @@ import net.krotscheck.kangaroo.authz.common.database.entity.UserIdentity;
 import net.krotscheck.kangaroo.authz.common.util.ValidationUtil;
 import net.krotscheck.kangaroo.authz.oauth2.annotation.OAuthFilterChain;
 import net.krotscheck.kangaroo.authz.oauth2.exception.RFC6749.InvalidRequestException;
+import net.krotscheck.kangaroo.authz.oauth2.exception.RedirectingException;
 import net.krotscheck.kangaroo.authz.oauth2.factory.CredentialsFactory.Credentials;
-import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder;
 import net.krotscheck.kangaroo.common.exception.KangarooException;
 import net.krotscheck.kangaroo.common.hibernate.transaction.Transactional;
 import org.apache.commons.lang3.StringUtils;
@@ -177,9 +177,7 @@ public final class AuthorizationService {
         } catch (KangarooException e) {
             // Any caught exceptions here should be redirected to the
             // validated redirect_url instead.
-            ErrorResponseBuilder builder = ErrorResponseBuilder
-                    .from(e, redirect);
-            return builder.build();
+            throw new RedirectingException(e, redirect, client.getType());
         }
     }
 
@@ -220,9 +218,8 @@ public final class AuthorizationService {
         } catch (KangarooException e) {
             // Any caught exceptions here should be redirected to the
             // validated redirect_url instead.
-            ErrorResponseBuilder builder = ErrorResponseBuilder
-                    .from(e, s.getClientRedirect());
-            return builder.build();
+            throw new RedirectingException(e, s.getClientRedirect(),
+                    c.getType());
         }
     }
 

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/exception/RFC6749Test.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/exception/RFC6749Test.java
@@ -114,9 +114,5 @@ public class RFC6749Test {
         KangarooException e = errorClass.newInstance();
         // We assume that KangarooException is well tested.
         Assert.assertEquals(expectedCode, e.getCode().getError());
-
-        // Make sure we can creat this with a redirect as well.
-        URI redirect = new URI("http://redirect.example.com");
-        errorClass.getConstructor(URI.class).newInstance(redirect);
     }
 }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/exception/RedirectingExceptionMapperTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/exception/RedirectingExceptionMapperTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.oauth2.exception;
+
+import com.google.common.net.HttpHeaders;
+import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
+import net.krotscheck.kangaroo.authz.oauth2.exception.RFC6749.InvalidClientException;
+import net.krotscheck.kangaroo.common.exception.KangarooException;
+import net.krotscheck.kangaroo.common.exception.mapper.KangarooExceptionMapper;
+import net.krotscheck.kangaroo.test.HttpUtil;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.jersey.spi.ExceptionMappers;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+
+import static org.mockito.Mockito.doReturn;
+
+/**
+ * Tests for the redirecting exception mapper.
+ *
+ * @author Michael Krotscheck
+ */
+public final class RedirectingExceptionMapperTest {
+
+    /**
+     * Test that a regular client puts the error results in the query string.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testRegularMapping() throws Exception {
+        KangarooException ke = new InvalidClientException();
+        ExceptionMappers mockMappers = Mockito.mock(ExceptionMappers.class);
+        ServiceLocator mockLocator = Mockito.mock(ServiceLocator.class);
+
+        doReturn(mockMappers).when(mockLocator)
+                .getService(ExceptionMappers.class);
+        doReturn(new KangarooExceptionMapper()).when(mockMappers)
+                .findMapping(ke);
+
+        RedirectingExceptionMapper mapper =
+                new RedirectingExceptionMapper(mockLocator);
+
+        URI redirect = UriBuilder.fromUri("http://redirect.example.com/")
+                .build();
+        RedirectingException re = new RedirectingException(ke, redirect,
+                ClientType.AuthorizationGrant);
+
+        Response r = mapper.toResponse(re);
+        Assert.assertEquals(302, r.getStatus());
+
+        URI location =
+                UriBuilder.fromUri(r.getHeaderString(HttpHeaders.LOCATION))
+                        .build();
+
+        Assert.assertEquals(location.getScheme(), redirect.getScheme());
+        Assert.assertEquals(location.getHost(), redirect.getHost());
+        Assert.assertEquals(location.getPort(), redirect.getPort());
+        Assert.assertEquals(location.getPath(), redirect.getPath());
+
+        MultivaluedMap<String, String> params =
+                HttpUtil.parseQueryParams(location);
+        Assert.assertEquals(params.getFirst("error"),
+                ke.getCode().getError());
+        Assert.assertEquals(params.getFirst("error_description"),
+                ke.getCode().getErrorDescription());
+    }
+
+    /**
+     * Assert that an implicit client puts the error results in the fragment.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testImplicitMapping() throws Exception {
+        KangarooException ke = new InvalidClientException();
+        ExceptionMappers mockMappers = Mockito.mock(ExceptionMappers.class);
+        ServiceLocator mockLocator = Mockito.mock(ServiceLocator.class);
+
+        doReturn(mockMappers).when(mockLocator)
+                .getService(ExceptionMappers.class);
+        doReturn(new KangarooExceptionMapper()).when(mockMappers)
+                .findMapping(ke);
+
+        RedirectingExceptionMapper mapper =
+                new RedirectingExceptionMapper(mockLocator);
+
+        URI redirect = UriBuilder.fromUri("http://redirect.example.com/")
+                .build();
+        RedirectingException re = new RedirectingException(ke, redirect,
+                ClientType.Implicit);
+
+        Response r = mapper.toResponse(re);
+        Assert.assertEquals(302, r.getStatus());
+
+        URI location =
+                UriBuilder.fromUri(r.getHeaderString(HttpHeaders.LOCATION))
+                        .build();
+
+        Assert.assertEquals(location.getScheme(), redirect.getScheme());
+        Assert.assertEquals(location.getHost(), redirect.getHost());
+        Assert.assertEquals(location.getPort(), redirect.getPort());
+        Assert.assertEquals(location.getPath(), redirect.getPath());
+
+        MultivaluedMap<String, String> params =
+                HttpUtil.parseQueryParams(location.getFragment());
+        Assert.assertEquals(params.getFirst("error"),
+                ke.getCode().getError());
+        Assert.assertEquals(params.getFirst("error_description"),
+                ke.getCode().getErrorDescription());
+    }
+
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/exception/RedirectingExceptionTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/exception/RedirectingExceptionTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.oauth2.exception;
+
+import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
+import net.krotscheck.kangaroo.authz.oauth2.exception.RFC6749.InvalidScopeException;
+import net.krotscheck.kangaroo.common.exception.KangarooException;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+
+/**
+ * Test for the redirecting exception.
+ *
+ * @author Michael Krotscheck
+ */
+public class RedirectingExceptionTest {
+
+    /**
+     * Test that the constructor is reasonably functional.
+     */
+    @Test
+    public void testConstructor() {
+        KangarooException cause = new InvalidScopeException();
+        URI redirect = UriBuilder.fromUri("http://redirect.example.com")
+                .build();
+        RedirectingException r = new RedirectingException(cause, redirect,
+                ClientType.Implicit);
+
+        Assert.assertEquals(ClientType.Implicit, r.getClientType());
+        Assert.assertEquals(redirect, r.getRedirect());
+        Assert.assertEquals(cause.getMessage(), r.getMessage());
+        Assert.assertEquals(cause, r.getCause());
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/resource/AuthorizationServiceTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/resource/AuthorizationServiceTest.java
@@ -109,7 +109,7 @@ public final class AuthorizationServiceTest extends ContainerTest {
 
         URI location = r.getLocation();
         MultivaluedMap<String, String> params =
-                HttpUtil.parseQueryParams(location.getQuery());
+                HttpUtil.parseQueryParams(location.getFragment());
         Assert.assertEquals("valid.example.com", location.getHost());
         Assert.assertEquals("/redirect", location.getPath());
         Assert.assertEquals("unsupported_response_type",
@@ -130,7 +130,7 @@ public final class AuthorizationServiceTest extends ContainerTest {
 
         URI location = r.getLocation();
         MultivaluedMap<String, String> params =
-                HttpUtil.parseQueryParams(location.getQuery());
+                HttpUtil.parseQueryParams(location.getFragment());
         Assert.assertEquals("valid.example.com", location.getHost());
         Assert.assertEquals("/redirect", location.getPath());
         Assert.assertEquals("unsupported_response_type",

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/Section420ImplicitGrantTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/Section420ImplicitGrantTest.java
@@ -193,7 +193,7 @@ public final class Section420ImplicitGrantTest
 
         // Validate the query parameters received.
         MultivaluedMap<String, String> params =
-                HttpUtil.parseQueryParams(location.getQuery());
+                HttpUtil.parseQueryParams(location.getFragment());
         assertTrue(params.containsKey("error"));
         assertEquals("unsupported_response_type", params.getFirst("error"));
         assertTrue(params.containsKey("error_description"));
@@ -276,7 +276,7 @@ public final class Section420ImplicitGrantTest
 
         // Validate the query parameters received.
         MultivaluedMap<String, String> params =
-                HttpUtil.parseQueryParams(location.getQuery());
+                HttpUtil.parseQueryParams(location.getFragment());
         assertTrue(params.containsKey("error"));
         assertEquals("invalid_request", params.getFirst("error"));
         assertTrue(params.containsKey("error_description"));
@@ -305,7 +305,7 @@ public final class Section420ImplicitGrantTest
 
         // Validate the query parameters received.
         MultivaluedMap<String, String> params =
-                HttpUtil.parseQueryParams(location.getQuery());
+                HttpUtil.parseQueryParams(location.getFragment());
         assertTrue(params.containsKey("error"));
         assertEquals("invalid_scope", params.getFirst("error"));
         assertTrue(params.containsKey("error_description"));
@@ -573,7 +573,7 @@ public final class Section420ImplicitGrantTest
 
         // Extract the query parameters in the fragment
         MultivaluedMap<String, String> params =
-                HttpUtil.parseQueryParams(secondLocation.getQuery());
+                HttpUtil.parseQueryParams(secondLocation.getFragment());
         assertTrue(params.containsKey("error"));
         assertEquals("invalid_scope", params.getFirst("error"));
         assertTrue(params.containsKey("error_description"));
@@ -616,7 +616,7 @@ public final class Section420ImplicitGrantTest
 
         // Extract the query parameters in the fragment
         MultivaluedMap<String, String> params =
-                HttpUtil.parseQueryParams(secondLocation.getQuery());
+                HttpUtil.parseQueryParams(secondLocation.getFragment());
         assertTrue(params.containsKey("error"));
         assertEquals("invalid_scope", params.getFirst("error"));
         assertTrue(params.containsKey("error_description"));


### PR DESCRIPTION
The common exception does not have a redirect use case- that is isolated
to the OAuth2 service, and should be handled there. This patch removes
all references to Redirect from the base KangarooException, and adds
a new RedirectingException type in the OAuth2 application which adds the
necessary transforms to provide a compliant error code, targeted at a
valid redirect return.