### PR TITLE
Added CSRF Protection Filters.

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/security/SecurityFeature.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/security/SecurityFeature.java
@@ -18,6 +18,8 @@
 
 package net.krotscheck.kangaroo.common.security;
 
+import org.glassfish.jersey.server.filter.CsrfProtectionFilter;
+
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 
@@ -39,6 +41,7 @@ public final class SecurityFeature implements Feature {
     @Override
     public boolean configure(final FeatureContext context) {
         context.register(new SecurityHeadersFilter.Binder());
+        context.register(CsrfProtectionFilter.class);
         return true;
     }
 }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/KangarooJerseyTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/KangarooJerseyTest.java
@@ -20,6 +20,7 @@ package net.krotscheck.kangaroo.test;
 
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.filter.CsrfProtectionFilter;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.TestProperties;
@@ -77,6 +78,7 @@ public abstract class KangarooJerseyTest extends JerseyTest {
     @Override
     protected final void configureClient(final ClientConfig config) {
         config.property(ClientProperties.FOLLOW_REDIRECTS, false);
+        config.register(CsrfProtectionFilter.class);
     }
 
     /**


### PR DESCRIPTION
We do not need fancy processing here, as OAuth2 already provides us with a randomized,
refreshing token. However, adding the X-Requested-By header won't hurt anything.

Closes #280