### PR TITLE
Created HtmlApplicationHttpHandler for root server.

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/security/SecurityHeadersFilter.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/security/SecurityHeadersFilter.java
@@ -18,7 +18,7 @@
 
 package net.krotscheck.kangaroo.common.security;
 
-import com.google.common.net.HttpHeaders;
+import net.krotscheck.kangaroo.server.SecurityHeaders;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 
 import javax.inject.Singleton;
@@ -26,6 +26,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
 
 /**
@@ -48,8 +49,8 @@ public final class SecurityHeadersFilter implements ContainerResponseFilter {
                        final ContainerResponseContext responseContext) throws
             IOException {
 
-        // Not strictly necessary for API's, but might as well.
-        responseContext.getHeaders().add(HttpHeaders.X_FRAME_OPTIONS, "Deny");
+        MultivaluedMap<String, Object> headers = responseContext.getHeaders();
+        SecurityHeaders.ALL.forEach(headers::add);
     }
 
     /**

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/Config.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/Config.java
@@ -74,6 +74,12 @@ public final class Config {
             SimpleImmutableEntry<>("kangaroo.cert_key_password", "kangaroo");
 
     /**
+     * Filesystem path to the directory to use as our HTML5 Application root.
+     */
+    public static final Entry<String, String> HTML_APP_ROOT = new
+            SimpleImmutableEntry<>("kangaroo.html_app_root", null);
+
+    /**
      * Private constructor for a utility class.
      */
     private Config() {

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/ConfigurationBuilder.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/ConfigurationBuilder.java
@@ -113,6 +113,15 @@ public final class ConfigurationBuilder {
                 .desc("Password of the private key for the certificate.")
                 .build();
 
+        Option htmlAppRoot = Option.builder()
+                .longOpt(Config.HTML_APP_ROOT.getKey())
+                .argName(Config.HTML_APP_ROOT.getKey())
+                .hasArg()
+                .desc("Path to the server's HTML5 Application root. We "
+                        + "presume HTML5 routing support in the application "
+                        + "served there.")
+                .build();
+
         CLI_OPTIONS.addOption(bindHost);
         CLI_OPTIONS.addOption(bindPort);
         CLI_OPTIONS.addOption(keystorePath);
@@ -120,6 +129,7 @@ public final class ConfigurationBuilder {
         CLI_OPTIONS.addOption(keystoreType);
         CLI_OPTIONS.addOption(certAlias);
         CLI_OPTIONS.addOption(certKeyPass);
+        CLI_OPTIONS.addOption(htmlAppRoot);
     }
 
     /**

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/HtmlApplicationHttpHandler.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/HtmlApplicationHttpHandler.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.server;
+
+import org.glassfish.grizzly.http.Method;
+import org.glassfish.grizzly.http.server.Request;
+import org.glassfish.grizzly.http.server.Response;
+import org.glassfish.grizzly.http.server.StaticHttpHandlerBase;
+import org.glassfish.grizzly.http.util.Header;
+import org.glassfish.grizzly.http.util.HttpStatus;
+
+import java.io.File;
+
+/**
+ * This handler enables our grizzly server to serve HTML applications, which
+ * we define as a rich javascript client, able to manage its own
+ * routing via the HTML5 history API. For these, the server needs to return
+ * the root directory's index.html file whenever a requested resource is not
+ * found. In all other cases, it should simply return the requested resource.
+ *
+ * @author Michael Krotscheck
+ */
+public final class HtmlApplicationHttpHandler extends StaticHttpHandlerBase {
+
+    /**
+     * The document root path.
+     */
+    private final File docRoot;
+
+    /**
+     * The root index.html file.
+     */
+    private final File indexResource;
+
+    /**
+     * Create a new instance which will look for static pages located
+     * under the <tt>docRoot</tt>.
+     *
+     * @param docRoot the folder where the static resource are located.
+     */
+    public HtmlApplicationHttpHandler(final String docRoot) {
+        this.docRoot = new File(docRoot);
+
+        // Make sure that we have an indexResource.html.
+        this.indexResource = new File(this.docRoot, "/index.html");
+        if (!this.indexResource.exists()) {
+            throw new RuntimeException("docRoot does not contain index.html");
+        }
+    }
+
+    /**
+     * Each HTTP Request is checked to see if it exists. If it is not, or if
+     * it is a directory, return the index.html file from the root directory.
+     * Otherwise, simply return the resource.
+     */
+    @Override
+    protected boolean handle(final String uri,
+                             final Request request,
+                             final Response response) throws Exception {
+
+        // If it's not HTTP GET - return method is not supported status
+        if (!Method.GET.equals(request.getMethod())) {
+            // TODO(krotscheck): return common error format.
+            response.setStatus(HttpStatus.METHOD_NOT_ALLOWED_405);
+            response.setHeader(Header.Allow, "GET");
+            return true;
+        }
+
+        // local file
+        File resource = new File(docRoot, uri);
+        final boolean exists = resource.exists();
+        final boolean isDirectory = resource.isDirectory();
+
+        // If it doesn't exist, or is a directory, simply return index.html
+        if (!exists || isDirectory) {
+            resource = indexResource;
+        }
+
+        // All responses have a small number of security headers that must be
+        // added to all requests.
+        SecurityHeaders.ALL.forEach(response::addHeader);
+
+        pickupContentType(response, resource.getPath());
+
+        addToFileCache(request, response, resource);
+        sendFile(response, resource);
+
+        return true;
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/SecurityHeaders.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/SecurityHeaders.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.server;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.net.HttpHeaders;
+
+import java.util.Map;
+
+/**
+ * A small class that stores all of our requred HTTP Seucrity headers. We
+ * don't really discriminate between API and static asset responses here.
+ *
+ * @author Michael Krotscheck
+ */
+public final class SecurityHeaders {
+
+    /**
+     * List of all HTTP headers that must be attached to all responses.
+     */
+    public static final Map<String, String> ALL =
+            ImmutableMap.<String, String>builder()
+                    .put(HttpHeaders.X_FRAME_OPTIONS, "Deny")
+                    .build();
+
+    /**
+     * Utility class, private constructor.
+     */
+    private SecurityHeaders() {
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/ServerFactory.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/ServerFactory.java
@@ -18,6 +18,7 @@
 
 package net.krotscheck.kangaroo.server;
 
+import com.google.common.base.Strings;
 import net.krotscheck.kangaroo.server.keystore.FSKeystoreProvider;
 import net.krotscheck.kangaroo.server.keystore.GeneratedKeystoreProvider;
 import net.krotscheck.kangaroo.server.keystore.IKeystoreProvider;
@@ -121,6 +122,16 @@ public final class ServerFactory {
             registration.addMapping(String.format("%s/*", path));
 
             context.deploy(server);
+        }
+
+        // Build a static HTTP handler, serving from --kangaroo.html_app_root
+        String htmlAppRoot = config.getString(Config.HTML_APP_ROOT.getKey(),
+                Config.HTML_APP_ROOT.getValue());
+        if (!Strings.isNullOrEmpty(htmlAppRoot)) {
+            HtmlApplicationHttpHandler handler =
+                    new HtmlApplicationHttpHandler(htmlAppRoot);
+            handler.setFileCacheEnabled(true);
+            server.getServerConfiguration().addHttpHandler(handler, "/*");
         }
 
         return server;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/ConfigTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/ConfigTest.java
@@ -76,5 +76,9 @@ public class ConfigTest {
         Assert.assertEquals("kangaroo.cert_key_password",
                 Config.CERT_KEY_PASS.getKey());
         Assert.assertEquals("kangaroo", Config.CERT_KEY_PASS.getValue());
+
+        Assert.assertEquals("kangaroo.html_app_root",
+                Config.HTML_APP_ROOT.getKey());
+        Assert.assertNull(Config.HTML_APP_ROOT.getValue());
     }
 }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/ConfigurationBuilderTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/ConfigurationBuilderTest.java
@@ -49,7 +49,8 @@ public final class ConfigurationBuilderTest {
                         "--kangaroo.keystore_password=keystore_password",
                         "--kangaroo.keystore_type=JKS",
                         "--kangaroo.cert_alias=cert_alias",
-                        "--kangaroo.cert_key_password=key_password"
+                        "--kangaroo.cert_key_password=key_password",
+                        "--kangaroo.html_app_root=/var/www"
                 })
                 .build();
 
@@ -67,6 +68,8 @@ public final class ConfigurationBuilderTest {
                 Config.CERT_ALIAS.getKey()), "cert_alias");
         Assert.assertEquals(config.getString(
                 Config.CERT_KEY_PASS.getKey()), "key_password");
+        Assert.assertEquals(config.getString(
+                Config.HTML_APP_ROOT.getKey()), "/var/www");
     }
 
     /**
@@ -100,6 +103,7 @@ public final class ConfigurationBuilderTest {
         Assert.assertNull(config.getString(Config.KEYSTORE_TYPE.getKey()));
         Assert.assertNull(config.getString(Config.CERT_ALIAS.getKey()));
         Assert.assertNull(config.getString(Config.CERT_KEY_PASS.getKey()));
+        Assert.assertNull(config.getString(Config.HTML_APP_ROOT.getKey()));
     }
 
     /**
@@ -128,6 +132,8 @@ public final class ConfigurationBuilderTest {
                 Config.CERT_ALIAS.getKey()), "cert_alias");
         Assert.assertEquals(config.getString(
                 Config.CERT_KEY_PASS.getKey()), "key_password");
+        Assert.assertEquals(config.getString(
+                Config.HTML_APP_ROOT.getKey()), "/var/www");
     }
 
     /**
@@ -148,6 +154,7 @@ public final class ConfigurationBuilderTest {
         Assert.assertNull(config.getString(Config.KEYSTORE_TYPE.getKey()));
         Assert.assertNull(config.getString(Config.CERT_ALIAS.getKey()));
         Assert.assertNull(config.getString(Config.CERT_KEY_PASS.getKey()));
+        Assert.assertNull(config.getString(Config.HTML_APP_ROOT.getKey()));
     }
 
     /**
@@ -173,6 +180,7 @@ public final class ConfigurationBuilderTest {
         Assert.assertNull(config.getString(Config.KEYSTORE_TYPE.getKey()));
         Assert.assertNull(config.getString(Config.CERT_ALIAS.getKey()));
         Assert.assertNull(config.getString(Config.CERT_KEY_PASS.getKey()));
+        Assert.assertNull(config.getString(Config.HTML_APP_ROOT.getKey()));
     }
 
     /**

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/HtmlApplicationHttpHandlerTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/HtmlApplicationHttpHandlerTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.server;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+import java.nio.file.Paths;
+
+/**
+ * Unit test for our HTML Application HTTP handler.
+ *
+ * @author Michael Krotscheck
+ */
+public final class HtmlApplicationHttpHandlerTest {
+
+    /**
+     * The server under test, which contains our handler.
+     */
+    public static HttpServer server;
+
+    /**
+     * Create and start up the server.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @BeforeClass
+    public static void startServer() throws Exception {
+        URI serverUri = UriBuilder.fromUri("http://localhost:8080/").build();
+        String appRoot = Paths.get("src/test/resources/html/index")
+                .toAbsolutePath().toString();
+        server = GrizzlyHttpServerFactory.createHttpServer(serverUri, false);
+        HtmlApplicationHttpHandler handler =
+                new HtmlApplicationHttpHandler(appRoot);
+        server.getServerConfiguration().addHttpHandler(handler, "/*");
+        server.start();
+    }
+
+    /**
+     * Shut down the server.
+     */
+    @AfterClass
+    public static void stopServer() {
+        server.shutdownNow();
+        server = null;
+    }
+
+    /**
+     * Construct an HTTP client.
+     *
+     * @return An HTTP client that accepts all certificates.
+     * @throws Exception Should not be thrown.
+     */
+    private CloseableHttpClient getHttpClient() throws Exception {
+        return HttpClients.createDefault();
+    }
+
+    /**
+     * Assert that we cannot create an instance with an invalid root directory.
+     *
+     * @throws Exception Should be thrown
+     */
+    @Test(expected = RuntimeException.class)
+    public void handleCreateWithInvalidRoot() throws Exception {
+        String appRoot = Paths.get("src/test/resources/html/noindex")
+                .toAbsolutePath().toString();
+        new HtmlApplicationHttpHandler(appRoot);
+    }
+
+    /**
+     * Assert that we can read the index.html file.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void handleReadIndex() throws Exception {
+        CloseableHttpClient httpclient = HttpClients.createDefault();
+
+        HttpGet httpGet1 = new HttpGet("http://localhost:8080/index.html");
+        CloseableHttpResponse response = httpclient.execute(httpGet1);
+        String responseBody1 = EntityUtils.toString(response.getEntity());
+        response.close();
+
+        Assert.assertEquals(response.getStatusLine().getStatusCode(),
+                200);
+        Assert.assertEquals("Hello world", responseBody1);
+
+        httpclient.close();
+    }
+
+    /**
+     * Assert that we can read the root directory and get index.html
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void handleReadRootPath() throws Exception {
+        CloseableHttpClient httpclient = HttpClients.createDefault();
+
+        HttpGet httpGet1 = new HttpGet("http://localhost:8080");
+        CloseableHttpResponse response = httpclient.execute(httpGet1);
+        String responseBody1 = EntityUtils.toString(response.getEntity());
+        response.close();
+
+        Assert.assertEquals(response.getStatusLine().getStatusCode(),
+                200);
+        Assert.assertEquals("Hello world", responseBody1);
+
+        httpclient.close();
+    }
+
+    /**
+     * Assert that a valid subdirectory request returns index.html
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void handleValidSubdirectory() throws Exception {
+        CloseableHttpClient httpclient = HttpClients.createDefault();
+
+        HttpGet httpGet1 = new HttpGet("http://localhost:8080/subdir/");
+        CloseableHttpResponse response = httpclient.execute(httpGet1);
+        String responseBody1 = EntityUtils.toString(response.getEntity());
+        response.close();
+
+        Assert.assertEquals(response.getStatusLine().getStatusCode(),
+                200);
+        Assert.assertEquals("Hello world", responseBody1);
+
+        httpclient.close();
+    }
+
+    /**
+     * Assert that a 404 request returns index.html
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void handle404Resource() throws Exception {
+        CloseableHttpClient httpclient = HttpClients.createDefault();
+
+        HttpGet httpGet1 = new HttpGet("http://localhost:8080/invalid.html");
+        CloseableHttpResponse response = httpclient.execute(httpGet1);
+        String responseBody1 = EntityUtils.toString(response.getEntity());
+        response.close();
+
+        Assert.assertEquals(response.getStatusLine().getStatusCode(),
+                200);
+        Assert.assertEquals("Hello world", responseBody1);
+
+        httpclient.close();
+    }
+
+    /**
+     * Assert that an existing subresource is returned properly.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void handleValidSubresource() throws Exception {
+        CloseableHttpClient httpclient = HttpClients.createDefault();
+
+        HttpGet httpGet1 =
+                new HttpGet("http://localhost:8080/subdir/other.html");
+        CloseableHttpResponse response = httpclient.execute(httpGet1);
+        String responseBody1 = EntityUtils.toString(response.getEntity());
+        response.close();
+
+        Assert.assertEquals(response.getStatusLine().getStatusCode(),
+                200);
+        Assert.assertEquals("Other hello world", responseBody1);
+
+        httpclient.close();
+    }
+
+    /**
+     * Assert that a non-get method throws an appropriate response.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testNonGetResource() throws Exception {
+        CloseableHttpClient httpclient = HttpClients.createDefault();
+
+        HttpDelete httpDelete = new HttpDelete(
+                "http://localhost:8080/subdir/other.html");
+        CloseableHttpResponse response = httpclient.execute(httpDelete);
+        String responseBody1 = EntityUtils.toString(response.getEntity());
+        response.close();
+
+        Assert.assertEquals(response.getStatusLine().getStatusCode(),
+                405);
+
+        httpclient.close();
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/SecurityHeadersTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/SecurityHeadersTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.server;
+
+import com.google.common.net.HttpHeaders;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+/**
+ * Unit test for our common security headers.
+ *
+ * @author Michael Krotscheck
+ */
+public class SecurityHeadersTest {
+
+    /**
+     * Assert that the constructor is private.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testPrivateConstructor() throws Exception {
+        Constructor c = SecurityHeaders.class.getDeclaredConstructor();
+        Assert.assertTrue(Modifier.isPrivate(c.getModifiers()));
+
+        // Create a new instance for coverage.
+        c.setAccessible(true);
+        c.newInstance();
+    }
+
+    /**
+     * Assert that our expected headers are present.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testExpectedHeaders() throws Exception {
+        Assert.assertEquals(1, SecurityHeaders.ALL.size());
+
+        Assert.assertEquals("Deny",
+                SecurityHeaders.ALL.get(HttpHeaders.X_FRAME_OPTIONS));
+    }
+}

--- a/kangaroo-common/src/test/resources/config/test.properties
+++ b/kangaroo-common/src/test/resources/config/test.properties
@@ -22,3 +22,4 @@ kangaroo.keystore_password=keystore_password
 kangaroo.keystore_type=JKS
 kangaroo.cert_alias=cert_alias
 kangaroo.cert_key_password=key_password
+kangaroo.html_app_root=/var/www

--- a/kangaroo-common/src/test/resources/html/index/index.html
+++ b/kangaroo-common/src/test/resources/html/index/index.html
@@ -1,0 +1,1 @@
+Hello world

--- a/kangaroo-common/src/test/resources/html/index/subdir/other.html
+++ b/kangaroo-common/src/test/resources/html/index/subdir/other.html
@@ -1,0 +1,1 @@
+Other hello world


### PR DESCRIPTION
By providing the --kangaroo.html_app_root commandline parameter,
a user may instruct the server to host an HTML application at the root
of the server path. We define this  as a rich javascript client, able
to manage its own routing via the HTML5 history API.

In order to ensure consistent usage of security headers, we also extracted
these values into a common configuration list, which is used both in the
newly created handler, and in the SecurityFeature.

Closes #289