### PR TITLE
Created new OAuth2 AuthN/AuthZ Feature

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/exception/ErrorResponseBuilder.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/exception/ErrorResponseBuilder.java
@@ -28,8 +28,11 @@ import javax.validation.ConstraintViolationException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -197,15 +200,29 @@ public final class ErrorResponseBuilder {
     }
 
     /**
+     * Add a header to the response, before building.
+     *
+     * @param header The header name.
+     * @param value  The header value.
+     * @return This builder.
+     */
+    public ErrorResponseBuilder addHeader(final String header,
+                                          final String value) {
+        this.response.headers.put(header, value);
+        return this;
+    }
+
+    /**
      * Build the response from this builder.
      *
      * @return HTTP Response object for this error.
      */
     public Response build() {
-        return Response.status(response.httpStatus)
+        ResponseBuilder b = Response.status(response.httpStatus)
                 .type(MediaType.APPLICATION_JSON)
-                .entity(response)
-                .build();
+                .entity(response);
+        response.headers.forEach(b::header);
+        return b.build();
     }
 
     /**
@@ -229,6 +246,12 @@ public final class ErrorResponseBuilder {
          */
         @JsonIgnore
         private Status httpStatus = Status.BAD_REQUEST;
+
+        /**
+         * List of headers to add to the response.
+         */
+        @JsonIgnore
+        private Map<String, String> headers = new HashMap<>();
 
         /**
          * Private constructor.

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/exception/ErrorResponseBuilderTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/exception/ErrorResponseBuilderTest.java
@@ -211,6 +211,21 @@ public final class ErrorResponseBuilderTest {
     }
 
     /**
+     * Test building from a generic exception.
+     */
+    @Test
+    public void testWithHeader() {
+        Exception e = new Exception();
+
+        Response r = ErrorResponseBuilder.from(e)
+                .addHeader("test", "test")
+                .build();
+        ErrorResponse er = (ErrorResponse) r.getEntity();
+
+        Assert.assertEquals("test", r.getHeaderString("test"));
+    }
+
+    /**
      * Test serializing to json.
      *
      * @throws Exception Should not be thrown (hopefully).

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/AdminV1API.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/AdminV1API.java
@@ -19,7 +19,7 @@
 package net.krotscheck.kangaroo.authz.admin;
 
 
-import net.krotscheck.kangaroo.authz.admin.v1.filter.OAuth2AuthorizationFilter;
+import net.krotscheck.kangaroo.authz.admin.v1.auth.OAuth2AuthFeature;
 import net.krotscheck.kangaroo.authz.admin.v1.resource.ApplicationService;
 import net.krotscheck.kangaroo.authz.admin.v1.resource.AuthenticatorService;
 import net.krotscheck.kangaroo.authz.admin.v1.resource.ClientService;
@@ -43,7 +43,6 @@ import net.krotscheck.kangaroo.common.status.StatusFeature;
 import net.krotscheck.kangaroo.common.timedtasks.TimedTasksFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.ServerProperties;
-import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
 
 
 /**
@@ -62,9 +61,6 @@ public final class AdminV1API extends ResourceConfig {
         property(ServerProperties.FEATURE_AUTO_DISCOVERY_DISABLE, true);
         property(ServerProperties.WADL_FEATURE_DISABLE, true);
 
-        // Ensure that role annotations are respected.
-        register(RolesAllowedDynamicFeature.class);
-
         // Common features.
         register(LoggingFeature.class);          // Logging Configuration
         register(ConfigurationFeature.class);    // Configuration loader
@@ -81,8 +77,8 @@ public final class AdminV1API extends ResourceConfig {
         register(new ServletConfigFactory.Binder());
         register(new FirstRunContainerLifecycleListener.Binder());
 
-        // API Authorization
-        register(new OAuth2AuthorizationFilter.Binder());
+        // API Authentication and Authorization.
+        register(OAuth2AuthFeature.class);
 
         // API Resources
         register(ApplicationService.class);

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/OAuth2AuthFeature.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/OAuth2AuthFeature.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.admin.v1.auth;
+
+import net.krotscheck.kangaroo.authz.admin.v1.auth.exception.WWWChallengeExceptionMapper;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+/**
+ * This feature ensures that all entities that are annotated with the
+ * `@ScopesAllowed` tag, have appropriate HTTP exceptions and WWW-Authenticate
+ * challenges thrown in response to invalid requests.
+ *
+ * @author Michael Krotscheck
+ */
+public final class OAuth2AuthFeature implements Feature {
+
+    /**
+     * Configure this feature.
+     *
+     * @param context The context to configure.
+     * @return true.
+     */
+    @Override
+    public boolean configure(final FeatureContext context) {
+
+        // The dynamic feature which provides per-resource authz/authn filters.
+        context.register(OAuth2ScopeDynamicFeature.class);
+
+        // The error response writer that knows how to return the above
+        // exceptions to the client.
+        context.register(new WWWChallengeExceptionMapper.Binder());
+
+        return true;
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/OAuth2ScopeDynamicFeature.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/OAuth2ScopeDynamicFeature.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.admin.v1.auth;
+
+import net.krotscheck.kangaroo.authz.admin.v1.auth.filter.OAuth2AuthenticationFilter;
+import net.krotscheck.kangaroo.authz.admin.v1.auth.filter.OAuth2AuthorizationFilter;
+import net.krotscheck.kangaroo.authz.admin.v1.servlet.ServletConfigFactory;
+import org.apache.commons.configuration.Configuration;
+import org.glassfish.jersey.server.model.AnnotatedMethod;
+import org.hibernate.Session;
+
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.PermitAll;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.FeatureContext;
+
+/**
+ * This feature checks itself dynamically against all resources, so that
+ * we can determine (at runtime) which token scopes are required for a
+ * particular resource or resource method.
+ *
+ * It was heavily inspired by the ScopesAllowedDynamicFeature, with the
+ * noted exception that both ForbiddenException and NotAuthorizedException
+ * thrown will provide an accurate WWW-Authenticate header, based
+ * on the scopes annotated to the resource.
+ *
+ * @author Michael Krotscheck
+ */
+final class OAuth2ScopeDynamicFeature implements DynamicFeature {
+
+    /**
+     * Session provider.
+     */
+    private final Provider<Session> sessionProvider;
+
+    /**
+     * The request's servlet configuration provider.
+     */
+    private final Provider<Configuration> configProvider;
+
+    /**
+     * Feature initialization - including some provider injections.
+     *
+     * @param sessionProvider The Hibernate Session provider, needed for the
+     *                        feature.
+     * @param configProvider  The system configuration provider.
+     */
+    @Inject
+    OAuth2ScopeDynamicFeature(final Provider<Session> sessionProvider,
+                                     @Named(ServletConfigFactory.GROUP_NAME)
+                                     final Provider<Configuration>
+                                             configProvider) {
+        this.sessionProvider = sessionProvider;
+        this.configProvider = configProvider;
+    }
+
+    /**
+     * Given a resource, provide filters which check the identity and
+     * scope grants needed by the resource itself.
+     *
+     * @param resourceInfo  The resource information.
+     * @param configuration The feature configuration provider.
+     */
+    @Override
+    public void configure(final ResourceInfo resourceInfo,
+                          final FeatureContext configuration) {
+        final AnnotatedMethod am =
+                new AnnotatedMethod(resourceInfo.getResourceMethod());
+
+        // DenyAll takes precedence over ScopesAllowed and PermitAll
+        if (am.isAnnotationPresent(DenyAll.class)) {
+            configuration.register(new OAuth2AuthenticationFilter(
+                    sessionProvider,
+                    configProvider,
+                    new String[]{}));
+            configuration.register(new OAuth2AuthorizationFilter());
+            return;
+        }
+
+        // ScopesAllowed on the method takes precedence over PermitAll
+        ScopesAllowed ra = am.getAnnotation(ScopesAllowed.class);
+        if (ra != null) {
+            configuration.register(new OAuth2AuthenticationFilter(
+                    sessionProvider,
+                    configProvider,
+                    ra.value()));
+            configuration.register(new OAuth2AuthorizationFilter(ra.value()));
+            return;
+        }
+
+        // PermitAll takes precedence over ScopesAllowed on the class
+        if (am.isAnnotationPresent(PermitAll.class)) {
+            // Do nothing.
+            return;
+        }
+
+        // DenyAll can't be attached to classes
+
+        // ScopesAllowed on the class takes precedence over PermitAll
+        ra = resourceInfo.getResourceClass().getAnnotation(ScopesAllowed.class);
+        if (ra != null) {
+            configuration.register(new OAuth2AuthenticationFilter(
+                    sessionProvider,
+                    configProvider,
+                    ra.value()));
+            configuration.register(new OAuth2AuthorizationFilter(ra.value()));
+        }
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/OAuth2SecurityContext.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/OAuth2SecurityContext.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.admin.v1.auth;
+
+import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
+
+import javax.ws.rs.core.SecurityContext;
+import java.security.Principal;
+import java.util.Set;
+
+/**
+ * Private security context implementation that validates against our
+ * database of tokens.
+ *
+ * @author Michael Krotscheck
+ */
+// TODO(krotscheck): This class shouldn't depend on an active DB session.
+public final class OAuth2SecurityContext implements SecurityContext {
+
+    /**
+     * Is this secure?
+     */
+    private final boolean secure;
+
+    /**
+     * The principal.
+     */
+    private final OAuthToken principal;
+
+    /**
+     * The scopes.
+     */
+    private final Set<String> scopes;
+
+    /**
+     * Construct an authentication context from an OAuth token and a secure
+     * flag.
+     *
+     * @param token    The OAuth token for this principal.
+     * @param isSecure Whether to secure the context.
+     */
+    public OAuth2SecurityContext(final OAuthToken token,
+                                 final Boolean isSecure) {
+        // Materialize the scopes and the user identity.
+        principal = token;
+        scopes = token.getScopes().keySet();
+        secure = isSecure;
+    }
+
+    /**
+     * Return the current user identity.
+     */
+    @Override
+    public Principal getUserPrincipal() {
+        return principal;
+    }
+
+    /**
+     * WARNING: OVERLOADED TERMS
+     * <p>
+     * In order to simplify the declaration of scope permissions, this
+     * method will check to see if the current user has been granted the
+     * provied "scope" rather than "role".
+     */
+    @Override
+    public boolean isUserInRole(final String roleName) {
+        return scopes.contains(roleName);
+    }
+
+    /**
+     * Was this request done via a secure request method?
+     */
+    @Override
+    public boolean isSecure() {
+        return secure;
+    }
+
+    /**
+     * Get the authentication scheme.
+     */
+    @Override
+    public String getAuthenticationScheme() {
+        return "OAuth2";
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/ScopesAllowed.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/ScopesAllowed.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.admin.v1.auth;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Specifies the list of scopes permitted to access method(s) in an application.
+ * The value of the ScopesAllowed annotation is a list of scope names.
+ * This annotation can be specified on a class or on method(s). Specifying it
+ * at a class level means that it applies to all the methods in the class.
+ * Specifying it on a method means that it is applicable to that method only.
+ * If applied at both the class and methods level , the method value overrides
+ * the class value if the two conflict.
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({TYPE, METHOD})
+public @interface ScopesAllowed {
+    /**
+     * List of scopes that are permitted for this resource.
+     *
+     * @return The list of scopes.
+     */
+    String[] value();
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/exception/OAuth2ForbiddenException.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/exception/OAuth2ForbiddenException.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.admin.v1.auth.exception;
+
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * Throw this exception when you know who the user is, but they do not have
+ * the appropriate token scopes to access this resource.
+ *
+ * @author Michael Krotscheck
+ */
+public class OAuth2ForbiddenException extends WWWChallengeException {
+
+    /**
+     * The error code for this exception.
+     */
+    public static final ErrorCode CODE = new ErrorCode(
+            Status.FORBIDDEN,
+            "forbidden",
+            "This token may not access this resource."
+    );
+
+    /**
+     * Create a new exception with the specified error code.
+     *
+     * @param requestInfo    The original URI request, from which we're
+     *                       going to derive our realm.
+     * @param requiredScopes A list of required scopes.
+     */
+    public OAuth2ForbiddenException(final UriInfo requestInfo,
+                                    final String[] requiredScopes) {
+        super(CODE, requestInfo, requiredScopes);
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/exception/OAuth2NotAuthorizedException.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/exception/OAuth2NotAuthorizedException.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.admin.v1.auth.exception;
+
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * Throw this exception when the token is invalid.
+ *
+ * @author Michael Krotscheck
+ */
+public class OAuth2NotAuthorizedException extends WWWChallengeException {
+
+    /**
+     * The error code for this exception.
+     */
+    public static final ErrorCode CODE = new ErrorCode(
+            Status.UNAUTHORIZED,
+            "unauthorized",
+            "You are not authorized."
+    );
+
+    /**
+     * Create a new exception with the specified error code.
+     *
+     * @param requestInfo    The original URI request, from which we're
+     *                       going to derive our realm.
+     * @param requiredScopes A list of required scopes.
+     */
+    public OAuth2NotAuthorizedException(final UriInfo requestInfo,
+                                        final String[] requiredScopes) {
+        super(CODE, requestInfo, requiredScopes);
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/exception/WWWChallengeException.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/exception/WWWChallengeException.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.admin.v1.auth.exception;
+
+import net.krotscheck.kangaroo.common.exception.KangarooException;
+
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import java.net.URI;
+import java.util.List;
+
+/**
+ * Private, common implementation of all exceptions that need to return a
+ * WWW-Authenticate challenge.
+ *
+ * @author Michael Krotscheck
+ */
+public abstract class WWWChallengeException extends KangarooException {
+
+    /**
+     * List of required scopes for this resource.
+     */
+    private final String[] requiredScopes;
+
+    /**
+     * The URI Realm.
+     */
+    private final URI realm;
+
+    /**
+     * Create a new exception with the specified error code.
+     *
+     * @param code           The error code enum type.
+     * @param requestInfo    The original URI request, from which we're
+     *                       going to derive our realm.
+     * @param requiredScopes A list of required scopes.
+     */
+    protected WWWChallengeException(final ErrorCode code,
+                                    final UriInfo requestInfo,
+                                    final String[] requiredScopes) {
+        super(code);
+        this.requiredScopes = requiredScopes;
+
+        UriBuilder realmBuilder = requestInfo.getBaseUriBuilder();
+        List<String> paths = requestInfo.getMatchedURIs();
+        if (paths.size() > 0) {
+            realmBuilder.path(paths.get(paths.size() - 1));
+        }
+        this.realm = realmBuilder.build();
+    }
+
+    /**
+     * Get the required scopes.
+     *
+     * @return List of required scopes.
+     */
+    public final String[] getRequiredScopes() {
+        return requiredScopes;
+    }
+
+    /**
+     * The URI Realm.
+     *
+     * @return URI of the authorization realm.
+     */
+    public final URI getRealm() {
+        return realm;
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/exception/WWWChallengeExceptionMapper.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/exception/WWWChallengeExceptionMapper.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.admin.v1.auth.exception;
+
+import com.google.common.net.HttpHeaders;
+import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder;
+import net.krotscheck.kangaroo.common.exception.KangarooException.ErrorCode;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+import javax.inject.Singleton;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Error mapper for all WWW-Authorization challenge exceptions. Ensures that
+ * the WWW-Authenticate header is added to the response.
+ *
+ * @author Michael Krotscheck
+ */
+public final class WWWChallengeExceptionMapper
+        implements ExceptionMapper<WWWChallengeException> {
+
+    /**
+     * Convert to response.
+     *
+     * @param exception The exception to convert.
+     * @return A Response instance for this error.
+     */
+    public Response toResponse(final WWWChallengeException exception) {
+        String authHeader = buildAuthHeader(exception);
+        return ErrorResponseBuilder.from(exception)
+                .addHeader(HttpHeaders.WWW_AUTHENTICATE, authHeader)
+                .build();
+    }
+
+    /**
+     * This method adds a WWW-Authenticate header to the response wrapped
+     * in this exception.
+     *
+     * @param exception The exception from which to read our required
+     *                  values.
+     * @return The raw bearer challenge for the WWW-Authenticate header.
+     */
+    private String buildAuthHeader(final WWWChallengeException exception) {
+        ErrorCode code = exception.getCode();
+
+        String realm = exception.getRealm().toString();
+        String scopes = String.join(" ", exception.getRequiredScopes());
+        String error = code.getError();
+        String description = code.getErrorDescription();
+
+        List<String> entries = new ArrayList<>();
+        entries.add(String.format("realm=\"%s\"", realm));
+        entries.add(String.format("scope=\"%s\"", scopes));
+        entries.add(String.format("error=\"%s\"", error));
+        entries.add(String.format("error_description=\"%s\"", description));
+
+        return String.format("Bearer %s", String.join(", ", entries));
+    }
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bind(WWWChallengeExceptionMapper.class)
+                    .to(ExceptionMapper.class)
+                    .in(Singleton.class);
+        }
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/exception/package-info.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/exception/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Exceptions thrown by our OAuth2 Feature.
+ */
+package net.krotscheck.kangaroo.authz.admin.v1.auth.exception;

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/filter/OAuth2AuthorizationFilter.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/filter/OAuth2AuthorizationFilter.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.admin.v1.auth.filter;
+
+import net.krotscheck.kangaroo.authz.admin.v1.auth.exception.OAuth2ForbiddenException;
+
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.SecurityContext;
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * This filter checks the user principal on every request, to see whether it
+ * posesses the appropriate "scopes". For the sake of expediency, we're
+ * conflating "roles" and "scopes" here, as the methods for the former
+ * already exist.
+ *
+ * @author Michael Krotscheck
+ */
+@Priority(Priorities.AUTHORIZATION)
+public final class OAuth2AuthorizationFilter
+        implements ContainerRequestFilter {
+
+    /**
+     * Short list of roles allowed for this particular resource.
+     */
+    private final String[] scopesAllowed;
+
+    /**
+     * Create a new filter, denying all requests.
+     */
+    public OAuth2AuthorizationFilter() {
+        this(new String[]{});
+    }
+
+    /**
+     * Create a new filter, only permitting the provided scopes.
+     *
+     * @param scopesAllowed The permitted scopes.
+     */
+    public OAuth2AuthorizationFilter(final String[] scopesAllowed) {
+        this.scopesAllowed = scopesAllowed;
+    }
+
+    /**
+     * Handle the request.
+     *
+     * @param requestContext Request context.
+     * @throws IOException Should (hopefully) not be thrown.
+     */
+    @Override
+    public void filter(final ContainerRequestContext requestContext)
+            throws IOException {
+
+        SecurityContext context = requestContext.getSecurityContext();
+
+        if (context == null) {
+            throw new OAuth2ForbiddenException(requestContext.getUriInfo(),
+                    scopesAllowed);
+        }
+
+        long matchedScopes = Arrays.stream(scopesAllowed)
+                .filter(context::isUserInRole)
+                .count();
+
+        if (matchedScopes == 0) {
+            throw new OAuth2ForbiddenException(requestContext.getUriInfo(),
+                    scopesAllowed);
+        }
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/filter/package-info.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/filter/package-info.java
@@ -17,6 +17,6 @@
  */
 
 /**
- * Request filters for the admin server.
+ * Request filters that enforce OAuth2.
  */
-package net.krotscheck.kangaroo.authz.admin.v1.filter;
+package net.krotscheck.kangaroo.authz.admin.v1.auth.filter;

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/package-info.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/auth/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Authentication and Authorization via DB-Backed OAuth2 Tokens.
+ */
+package net.krotscheck.kangaroo.authz.admin.v1.auth;

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ApplicationService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ApplicationService.java
@@ -19,7 +19,7 @@
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
 import net.krotscheck.kangaroo.authz.admin.Scope;
-import net.krotscheck.kangaroo.authz.admin.v1.filter.OAuth2;
+import net.krotscheck.kangaroo.authz.admin.v1.auth.ScopesAllowed;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.Role;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
@@ -38,7 +38,6 @@ import org.hibernate.search.query.dsl.BooleanJunction;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.jvnet.hk2.annotations.Optional;
 
-import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -63,8 +62,7 @@ import java.util.UUID;
  * @author Michael Krotscheck
  */
 @Path("/application")
-@RolesAllowed({Scope.APPLICATION, Scope.APPLICATION_ADMIN})
-@OAuth2
+@ScopesAllowed({Scope.APPLICATION, Scope.APPLICATION_ADMIN})
 @Transactional
 public final class ApplicationService extends AbstractService {
 

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AuthenticatorService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AuthenticatorService.java
@@ -20,7 +20,7 @@ package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
 
 import net.krotscheck.kangaroo.authz.admin.Scope;
-import net.krotscheck.kangaroo.authz.admin.v1.filter.OAuth2;
+import net.krotscheck.kangaroo.authz.admin.v1.auth.ScopesAllowed;
 import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorType;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.Authenticator;
@@ -41,7 +41,6 @@ import org.hibernate.search.query.dsl.BooleanJunction;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.jvnet.hk2.annotations.Optional;
 
-import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -64,8 +63,7 @@ import java.util.UUID;
  * @author Michael Krotscheck
  */
 @Path("/authenticator")
-@RolesAllowed({Scope.AUTHENTICATOR, Scope.AUTHENTICATOR_ADMIN})
-@OAuth2
+@ScopesAllowed({Scope.AUTHENTICATOR, Scope.AUTHENTICATOR_ADMIN})
 @Transactional
 public final class AuthenticatorService extends AbstractService {
 

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientRedirectService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientRedirectService.java
@@ -19,7 +19,7 @@
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
 import net.krotscheck.kangaroo.authz.admin.Scope;
-import net.krotscheck.kangaroo.authz.admin.v1.filter.OAuth2;
+import net.krotscheck.kangaroo.authz.admin.v1.auth.ScopesAllowed;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractClientUri;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientRedirect;
@@ -33,7 +33,6 @@ import org.hibernate.Session;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 
-import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ClientErrorException;
@@ -60,8 +59,7 @@ import java.util.UUID;
  *
  * @author Michael Krotscheck
  */
-@OAuth2
-@RolesAllowed({Scope.CLIENT, Scope.CLIENT_ADMIN})
+@ScopesAllowed({Scope.CLIENT, Scope.CLIENT_ADMIN})
 @Transactional
 public final class ClientRedirectService extends AbstractService {
 

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientReferrerService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientReferrerService.java
@@ -19,7 +19,7 @@
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
 import net.krotscheck.kangaroo.authz.admin.Scope;
-import net.krotscheck.kangaroo.authz.admin.v1.filter.OAuth2;
+import net.krotscheck.kangaroo.authz.admin.v1.auth.ScopesAllowed;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractClientUri;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientReferrer;
@@ -33,7 +33,6 @@ import org.hibernate.Session;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 
-import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ClientErrorException;
@@ -60,8 +59,7 @@ import java.util.UUID;
  *
  * @author Michael Krotscheck
  */
-@OAuth2
-@RolesAllowed({Scope.CLIENT, Scope.CLIENT_ADMIN})
+@ScopesAllowed({Scope.CLIENT, Scope.CLIENT_ADMIN})
 @Transactional
 public final class ClientReferrerService extends AbstractService {
 

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientService.java
@@ -19,7 +19,7 @@
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
 import net.krotscheck.kangaroo.authz.admin.Scope;
-import net.krotscheck.kangaroo.authz.admin.v1.filter.OAuth2;
+import net.krotscheck.kangaroo.authz.admin.v1.auth.ScopesAllowed;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
@@ -40,7 +40,6 @@ import org.hibernate.search.query.dsl.BooleanJunction;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.jvnet.hk2.annotations.Optional;
 
-import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.Consumes;
@@ -65,8 +64,7 @@ import java.util.UUID;
  * @author Michael Krotscheck
  */
 @Path("/client")
-@RolesAllowed({Scope.CLIENT, Scope.CLIENT_ADMIN})
-@OAuth2
+@ScopesAllowed({Scope.CLIENT, Scope.CLIENT_ADMIN})
 @Transactional
 public final class ClientService extends AbstractService {
 

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/OAuthTokenService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/OAuthTokenService.java
@@ -19,7 +19,7 @@
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
 import net.krotscheck.kangaroo.authz.admin.Scope;
-import net.krotscheck.kangaroo.authz.admin.v1.filter.OAuth2;
+import net.krotscheck.kangaroo.authz.admin.v1.auth.ScopesAllowed;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
@@ -44,7 +44,6 @@ import org.hibernate.search.query.dsl.BooleanJunction;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.jvnet.hk2.annotations.Optional;
 
-import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -68,8 +67,7 @@ import java.util.UUID;
  * @author Michael Krotscheck
  */
 @Path("/token")
-@RolesAllowed({Scope.TOKEN_ADMIN, Scope.TOKEN})
-@OAuth2
+@ScopesAllowed({Scope.TOKEN_ADMIN, Scope.TOKEN})
 @Transactional
 public final class OAuthTokenService extends AbstractService {
 

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleScopeService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleScopeService.java
@@ -19,7 +19,7 @@
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
 import net.krotscheck.kangaroo.authz.admin.Scope;
-import net.krotscheck.kangaroo.authz.admin.v1.filter.OAuth2;
+import net.krotscheck.kangaroo.authz.admin.v1.auth.ScopesAllowed;
 import net.krotscheck.kangaroo.authz.common.database.entity.ApplicationScope;
 import net.krotscheck.kangaroo.authz.common.database.entity.Role;
 import net.krotscheck.kangaroo.authz.oauth2.exception.RFC6749.InvalidScopeException;
@@ -28,7 +28,6 @@ import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.process.internal.RequestScope;
 import org.hibernate.Session;
 
-import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.DELETE;
@@ -47,8 +46,7 @@ import java.util.UUID;
  *
  * @author Michael Krotscheck
  */
-@OAuth2
-@RolesAllowed({Scope.ROLE, Scope.ROLE_ADMIN})
+@ScopesAllowed({Scope.ROLE, Scope.ROLE_ADMIN})
 @Transactional
 public final class RoleScopeService extends AbstractService {
 

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleService.java
@@ -19,7 +19,7 @@
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
 import net.krotscheck.kangaroo.authz.admin.Scope;
-import net.krotscheck.kangaroo.authz.admin.v1.filter.OAuth2;
+import net.krotscheck.kangaroo.authz.admin.v1.auth.ScopesAllowed;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.Role;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
@@ -38,7 +38,6 @@ import org.hibernate.search.query.dsl.BooleanJunction;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.jvnet.hk2.annotations.Optional;
 
-import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -62,8 +61,7 @@ import java.util.UUID;
  * @author Michael Krotscheck
  */
 @Path("/role")
-@RolesAllowed({Scope.ROLE, Scope.ROLE_ADMIN})
-@OAuth2
+@ScopesAllowed({Scope.ROLE, Scope.ROLE_ADMIN})
 @Transactional
 public final class RoleService extends AbstractService {
 

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ScopeService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ScopeService.java
@@ -19,7 +19,7 @@
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
 import net.krotscheck.kangaroo.authz.admin.Scope;
-import net.krotscheck.kangaroo.authz.admin.v1.filter.OAuth2;
+import net.krotscheck.kangaroo.authz.admin.v1.auth.ScopesAllowed;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.ApplicationScope;
 import net.krotscheck.kangaroo.authz.common.database.entity.Role;
@@ -39,7 +39,6 @@ import org.hibernate.search.query.dsl.BooleanJunction;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.jvnet.hk2.annotations.Optional;
 
-import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -63,8 +62,7 @@ import java.util.UUID;
  * @author Michael Krotscheck
  */
 @Path("/scope")
-@RolesAllowed({Scope.SCOPE, Scope.SCOPE_ADMIN})
-@OAuth2
+@ScopesAllowed({Scope.SCOPE, Scope.SCOPE_ADMIN})
 @Transactional
 public final class ScopeService extends AbstractService {
 

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserIdentityService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserIdentityService.java
@@ -20,7 +20,7 @@ package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import net.krotscheck.kangaroo.authz.admin.Scope;
-import net.krotscheck.kangaroo.authz.admin.v1.filter.OAuth2;
+import net.krotscheck.kangaroo.authz.admin.v1.auth.ScopesAllowed;
 import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorType;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
@@ -42,7 +42,6 @@ import org.hibernate.search.query.dsl.BooleanJunction;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.jvnet.hk2.annotations.Optional;
 
-import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -65,8 +64,7 @@ import java.util.UUID;
  * @author Michael Krotscheck
  */
 @Path("/identity")
-@RolesAllowed({Scope.IDENTITY, Scope.IDENTITY_ADMIN})
-@OAuth2
+@ScopesAllowed({Scope.IDENTITY, Scope.IDENTITY_ADMIN})
 @Transactional
 public final class UserIdentityService extends AbstractService {
 

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserService.java
@@ -19,7 +19,7 @@
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
 import net.krotscheck.kangaroo.authz.admin.Scope;
-import net.krotscheck.kangaroo.authz.admin.v1.filter.OAuth2;
+import net.krotscheck.kangaroo.authz.admin.v1.auth.ScopesAllowed;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.Role;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
@@ -38,7 +38,6 @@ import org.hibernate.search.query.dsl.BooleanJunction;
 import org.hibernate.search.query.dsl.QueryBuilder;
 import org.jvnet.hk2.annotations.Optional;
 
-import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -61,8 +60,7 @@ import java.util.UUID;
  * @author Michael Krotscheck
  */
 @Path("/user")
-@RolesAllowed({Scope.USER, Scope.USER_ADMIN})
-@OAuth2
+@ScopesAllowed({Scope.USER, Scope.USER_ADMIN})
 @Transactional
 public final class UserService extends AbstractService {
 

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/OAuth2AuthFeatureTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/OAuth2AuthFeatureTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.admin.v1.auth;
+
+import net.krotscheck.kangaroo.authz.admin.v1.auth.exception.WWWChallengeExceptionMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.ws.rs.core.FeatureContext;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+/**
+ * Unit tests for the feature injector.
+ *
+ * @author Michael Krotscheck
+ */
+public class OAuth2AuthFeatureTest {
+
+    /**
+     * Assert that we are injecting expected features.
+     *
+     * @throws Exception An authenticator exception.
+     */
+    @Test
+    public void testBinder() throws Exception {
+
+        OAuth2AuthFeature feature = new OAuth2AuthFeature();
+        FeatureContext mockContext = mock(FeatureContext.class);
+
+        boolean result = feature.configure(mockContext);
+        Assert.assertTrue(result);
+
+        verify(mockContext, times(1))
+                .register(OAuth2ScopeDynamicFeature.class);
+        verify(mockContext, times(1))
+                .register(any(WWWChallengeExceptionMapper.Binder.class));
+
+        verifyNoMoreInteractions(mockContext);
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/OAuth2ScopeDynamicFeatureTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/OAuth2ScopeDynamicFeatureTest.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.admin.v1.auth;
+
+import com.google.common.net.HttpHeaders;
+import net.krotscheck.kangaroo.authz.admin.Scope;
+import net.krotscheck.kangaroo.authz.admin.v1.servlet.FirstRunContainerLifecycleListener;
+import net.krotscheck.kangaroo.authz.admin.v1.servlet.ServletConfigFactory;
+import net.krotscheck.kangaroo.authz.admin.v1.test.rule.TestDataResource;
+import net.krotscheck.kangaroo.authz.common.database.DatabaseFeature;
+import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
+import net.krotscheck.kangaroo.common.config.ConfigurationFeature;
+import net.krotscheck.kangaroo.common.exception.ExceptionFeature;
+import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.HttpUtil;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.PermitAll;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+/**
+ * Unit tests for the oauth2 feature.
+ *
+ * @author Michael Krotscheck
+ */
+public class OAuth2ScopeDynamicFeatureTest extends ContainerTest {
+
+    /**
+     * Preload data into the system.
+     */
+    @ClassRule
+    public static final TestDataResource TEST_DATA_RESOURCE =
+            new TestDataResource(HIBERNATE_RESOURCE);
+
+    /**
+     * Setup an application.
+     *
+     * @return A configured application.
+     */
+    @Override
+    protected ResourceConfig createApplication() {
+        ResourceConfig a = new ResourceConfig();
+        a.register(DatabaseFeature.class);
+        a.register(OAuth2ScopeDynamicFeature.class);
+        a.register(MockService.class);
+        a.register(SecondMockService.class);
+        a.register(ThirdMockService.class);
+        a.register(ExceptionFeature.class);
+        a.register(ConfigurationFeature.class);
+        a.register(new ServletConfigFactory.Binder());
+        a.register(new FirstRunContainerLifecycleListener.Binder());
+        return a;
+    }
+
+    /**
+     * Test the denyall flag.
+     */
+    @Test
+    public void testDenyAllMethod() {
+        Response response = target("/first/deny")
+                .request()
+                .get();
+        Assert.assertEquals(401, response.getStatus());
+    }
+
+    /**
+     * Test the permitall flag.
+     */
+    @Test
+    public void testPermitAllMethod() {
+        Response response = target("/first/permit")
+                .request()
+                .get();
+        Assert.assertEquals(200, response.getStatus());
+    }
+
+    /**
+     * Test the Scopes flag.
+     */
+    @Test
+    public void testValidScopesMethod() {
+        OAuthToken token = TEST_DATA_RESOURCE.getAdminApplication()
+                .getBuilder()
+                .bearerToken(Scope.CLIENT)
+                .build()
+                .getToken();
+
+        Response response = target("/first/scopes")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION,
+                        HttpUtil.authHeaderBearer(token.getId()))
+                .get();
+        Assert.assertEquals(200, response.getStatus());
+    }
+
+    /**
+     * Test the Scopes flag.
+     */
+    @Test
+    public void testInvalidScopesMethod() {
+        OAuthToken token = TEST_DATA_RESOURCE.getAdminApplication()
+                .getBuilder()
+                .bearerToken(Scope.USER)
+                .build()
+                .getToken();
+
+        Response response = target("/first/scopes")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION,
+                        HttpUtil.authHeaderBearer(token.getId()))
+                .get();
+        Assert.assertEquals(403, response.getStatus());
+    }
+
+    /**
+     * Test the Scopes flag.
+     */
+    @Test
+    public void testValidScopesClass() {
+        OAuthToken token = TEST_DATA_RESOURCE.getAdminApplication()
+                .getBuilder()
+                .bearerToken(Scope.CLIENT)
+                .build()
+                .getToken();
+
+        Response response = target("/second")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION,
+                        HttpUtil.authHeaderBearer(token.getId()))
+                .get();
+        Assert.assertEquals(200, response.getStatus());
+    }
+
+    /**
+     * Test the Scopes flag.
+     */
+    @Test
+    public void testInvalidScopeClass() {
+        OAuthToken token = TEST_DATA_RESOURCE.getAdminApplication()
+                .getBuilder()
+                .bearerToken(Scope.USER)
+                .build()
+                .getToken();
+
+        Response response = target("/second")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION,
+                        HttpUtil.authHeaderBearer(token.getId()))
+                .get();
+        Assert.assertEquals(403, response.getStatus());
+    }
+
+    /**
+     * Test class-based permit all.
+     */
+    @Test
+    public void testPermitAllClass() {
+        OAuthToken token = TEST_DATA_RESOURCE.getAdminApplication()
+                .getBuilder()
+                .bearerToken(Scope.USER)
+                .build()
+                .getToken();
+
+        Response response = target("/third")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION,
+                        HttpUtil.authHeaderBearer(token.getId()))
+                .get();
+        Assert.assertEquals(200, response.getStatus());
+    }
+
+    /**
+     * A simple endpoint that contains annotated methods.
+     *
+     * @author Michael Krotscheck
+     */
+    @Path("/first")
+    public static final class MockService {
+
+        /**
+         * Return true.
+         *
+         * @return HTTP OK response
+         */
+        @GET
+        @Path("/deny")
+        @DenyAll
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response denyAll() {
+            return Response.status(Status.OK).build();
+        }
+
+        /**
+         * Return true.
+         *
+         * @return HTTP OK response
+         */
+        @GET
+        @Path("/permit")
+        @PermitAll
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response permitAll() {
+            return Response.status(Status.OK).build();
+        }
+
+        /**
+         * Return true.
+         *
+         * @return HTTP OK response
+         */
+        @GET
+        @Path("/scopes")
+        @ScopesAllowed(Scope.CLIENT)
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response permitScopes() {
+            return Response.status(Status.OK).build();
+        }
+    }
+
+    /**
+     * A simple endpoint that requires scopes.
+     *
+     * @author Michael Krotscheck
+     */
+    @Path("/second")
+    @ScopesAllowed(Scope.CLIENT)
+    public static final class SecondMockService {
+
+        /**
+         * Return true.
+         *
+         * @return HTTP OK response
+         */
+        @GET
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response permitScopes() {
+            return Response.status(Status.OK).build();
+        }
+    }
+
+    /**
+     * A simple endpoint that requires nothing.
+     *
+     * @author Michael Krotscheck
+     */
+    @Path("/third")
+    @PermitAll
+    public static final class ThirdMockService {
+
+        /**
+         * Return true.
+         *
+         * @return HTTP OK response
+         */
+        @GET
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response permitAll() {
+            return Response.status(Status.OK).build();
+        }
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/OAuth2SecurityContextTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/OAuth2SecurityContextTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.admin.v1.auth;
+
+import net.krotscheck.kangaroo.authz.admin.v1.test.rule.TestDataResource;
+import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
+import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.test.DatabaseTest;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/**
+ * Unit tests for the Security Context.
+ *
+ * @author Michael Krotscheck
+ */
+public class OAuth2SecurityContextTest extends DatabaseTest {
+
+    /**
+     * Preload data into the system.
+     */
+    @ClassRule
+    public static final TestDataResource TEST_DATA_RESOURCE =
+            new TestDataResource(HIBERNATE_RESOURCE);
+
+    /**
+     * Test constructor passthrough.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void getUserPrincipal() throws Exception {
+        ApplicationContext context = TEST_DATA_RESOURCE.getAdminApplication();
+        OAuthToken token = context.getBuilder()
+                .scope("principal-1")
+                .scope("principal-2")
+                .bearerToken("principal-1", "principal-2")
+                .build()
+                .getToken();
+
+        OAuth2SecurityContext securityContext = new OAuth2SecurityContext(
+                token, false);
+
+        Assert.assertEquals(false,
+                securityContext.isSecure());
+        Assert.assertEquals("OAuth2",
+                securityContext.getAuthenticationScheme());
+        Assert.assertSame(token, securityContext.getUserPrincipal());
+        Assert.assertTrue(securityContext.isUserInRole("principal-1"));
+        Assert.assertTrue(securityContext.isUserInRole("principal-2"));
+        Assert.assertFalse(securityContext.isUserInRole("principal-3"));
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/exception/OAuth2ForbiddenExceptionTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/exception/OAuth2ForbiddenExceptionTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.admin.v1.auth.exception;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Unit tests for the forbidden exception.
+ *
+ * @author Michael Krotscheck
+ */
+public class OAuth2ForbiddenExceptionTest {
+
+    /**
+     * Assert that we can create an exception, and that the response values
+     * are as expected.
+     */
+    @Test
+    public void assertConstructor() {
+        UriInfo mockInfo = Mockito.mock(UriInfo.class);
+        List<String> mockPaths = Arrays.asList("foo");
+
+        UriBuilder mockBuilder = UriBuilder.fromUri("http://localhost/");
+
+        Mockito.doReturn(mockBuilder).when(mockInfo).getBaseUriBuilder();
+        Mockito.doReturn(mockPaths).when(mockInfo).getMatchedURIs();
+
+        String[] requiredScopes = new String[]{"one", "two"};
+
+        OAuth2ForbiddenException e =
+                new OAuth2ForbiddenException(mockInfo, requiredScopes);
+
+        Assert.assertEquals(OAuth2ForbiddenException.CODE, e.getCode());
+        Assert.assertEquals("forbidden", e.getMessage());
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/exception/OAuth2NotAuthorizedExceptionTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/exception/OAuth2NotAuthorizedExceptionTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.admin.v1.auth.exception;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Unit tests for the forbidden exception.
+ *
+ * @author Michael Krotscheck
+ */
+public class OAuth2NotAuthorizedExceptionTest {
+
+    /**
+     * Assert that we can create an exception, and that the response values
+     * are as expected.
+     */
+    @Test
+    public void assertConstructor() {
+        UriInfo mockInfo = Mockito.mock(UriInfo.class);
+        List<String> mockPaths = Arrays.asList("foo");
+
+        UriBuilder mockBuilder = UriBuilder.fromUri("http://localhost/");
+
+        Mockito.doReturn(mockBuilder).when(mockInfo).getBaseUriBuilder();
+        Mockito.doReturn(mockPaths).when(mockInfo).getMatchedURIs();
+
+        String[] requiredScopes = new String[]{"one", "two"};
+
+        OAuth2NotAuthorizedException e =
+                new OAuth2NotAuthorizedException(mockInfo, requiredScopes);
+
+        Assert.assertEquals(OAuth2NotAuthorizedException.CODE, e.getCode());
+        Assert.assertEquals("unauthorized", e.getMessage());
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/exception/WWWChallengeExceptionMapperTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/exception/WWWChallengeExceptionMapperTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.admin.v1.auth.exception;
+
+import com.google.common.net.HttpHeaders;
+import net.krotscheck.kangaroo.authz.admin.v1.auth.OAuth2AuthFeature;
+import net.krotscheck.kangaroo.common.exception.ExceptionFeature;
+import net.krotscheck.kangaroo.common.jackson.JacksonFeature;
+import net.krotscheck.kangaroo.test.ContainerTest;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Unit tests for exceptions that carry an authorization challenge.
+ *
+ * @author Michael Krotscheck
+ */
+public final class WWWChallengeExceptionMapperTest extends ContainerTest {
+
+    /**
+     * Create an application.
+     *
+     * @return The application to test.
+     */
+    @Override
+    protected ResourceConfig createApplication() {
+        ResourceConfig config = new ResourceConfig();
+        config.register(ErrorService.class);
+
+        config.register(JacksonFeature.class);
+        config.register(ExceptionFeature.class);
+        config.register(OAuth2AuthFeature.class);
+        return config;
+    }
+
+    /**
+     * Assert that we get the correct headers back with a 401.
+     */
+    @Test
+    public void test401Serialization() {
+        Response r = target("/error/401").request().get();
+
+        Assert.assertEquals(401, r.getStatus());
+
+        Map<String, String> headerValues =
+                decodeHeader(r.getHeaderString(HttpHeaders.WWW_AUTHENTICATE));
+
+        Assert.assertEquals(
+                "unauthorized",
+                headerValues.get("error"));
+        Assert.assertEquals(
+                "You are not authorized.",
+                headerValues.get("error_description"));
+        Assert.assertEquals(
+                "one two",
+                headerValues.get("scope"));
+
+        URI realm = UriBuilder.fromUri(headerValues.get("realm")).build();
+        Assert.assertEquals("/error", realm.getPath());
+    }
+
+    /**
+     * Assert that we get the correct headers back with a 403.
+     */
+    @Test
+    public void test403Serialization() {
+        Response r = target("/error/403").request().get();
+
+        Assert.assertEquals(403, r.getStatus());
+
+        Map<String, String> headerValues =
+                decodeHeader(r.getHeaderString(HttpHeaders.WWW_AUTHENTICATE));
+
+        Assert.assertEquals(
+                "forbidden",
+                headerValues.get("error"));
+        Assert.assertEquals(
+                "This token may not access this resource.",
+                headerValues.get("error_description"));
+        Assert.assertEquals(
+                "one two",
+                headerValues.get("scope"));
+
+        URI realm = UriBuilder.fromUri(headerValues.get("realm")).build();
+        Assert.assertEquals("/error", realm.getPath());
+    }
+
+    /**
+     * Decode headers.
+     *
+     * @param headerString The string value of the header.
+     * @return Map of key/value pairs.
+     */
+    private Map<String, String> decodeHeader(String headerString) {
+
+        Assert.assertTrue(headerString.indexOf("Bearer") == 0);
+
+        Map<String, String> headerValues = new HashMap<>();
+        Arrays.stream(headerString.substring(7).split(","))
+                .map(String::trim)
+                .map(s -> s.split("="))
+                .peek(s -> s[1] = s[1].substring(1, s[1].length() - 1))
+                .forEach((s) -> headerValues.put(s[0], s[1]));
+
+        return headerValues;
+    }
+
+    /**
+     * A simple error throwing endpoint.
+     *
+     * @author Michael Krotscheck
+     */
+    @Path("/error")
+    public static final class ErrorService {
+
+        /**
+         * Return 401.
+         *
+         * @param uriInfo The injected URI info.
+         * @return Nothing, error thrown.
+         */
+        @GET()
+        @Path("/401")
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response notAuthorized(@Context final UriInfo uriInfo) {
+            throw new OAuth2NotAuthorizedException(uriInfo,
+                    new String[]{"one", "two"});
+        }
+
+        /**
+         * Return 403.
+         *
+         * @param uriInfo The injected URI info.
+         * @return Nothing, error thrown.
+         */
+        @GET()
+        @Path("/403")
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response forbidden(@Context final UriInfo uriInfo) {
+            throw new OAuth2ForbiddenException(uriInfo,
+                    new String[]{"one", "two"});
+        }
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/exception/WWWChallengeExceptionTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/exception/WWWChallengeExceptionTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.admin.v1.auth.exception;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+/**
+ * Unit tests for exceptions that carry an authorization challenge.
+ *
+ * @author Michael Krotscheck
+ */
+public final class WWWChallengeExceptionTest {
+
+    /**
+     * Assert that we can create an exception, and expect the provided
+     * variables in response.
+     */
+    @Test
+    public void assertConstructorWithPath() {
+        UriInfo mockInfo = Mockito.mock(UriInfo.class);
+        List<String> mockPaths = Arrays.asList("foo");
+
+        UriBuilder mockBuilder = UriBuilder.fromUri("http://localhost/");
+
+        Mockito.doReturn(mockBuilder).when(mockInfo).getBaseUriBuilder();
+        Mockito.doReturn(mockPaths).when(mockInfo).getMatchedURIs();
+
+        String[] requiredScopes = new String[]{"one", "two"};
+
+        TestException e = new TestException(mockInfo, requiredScopes);
+
+        Assert.assertSame(requiredScopes, e.getRequiredScopes());
+        Assert.assertEquals("http://localhost/foo", e.getRealm().toString());
+    }
+
+    /**
+     * Assert that constructing the realm will drop all but the first string.
+     */
+    @Test
+    public void assertConstructorWithManyPaths() {
+        UriInfo mockInfo = Mockito.mock(UriInfo.class);
+        List<String> mockPaths = Arrays.asList("one", "two", "three");
+
+        UriBuilder mockBuilder = UriBuilder.fromUri("http://localhost/");
+
+        Mockito.doReturn(mockBuilder).when(mockInfo).getBaseUriBuilder();
+        Mockito.doReturn(mockPaths).when(mockInfo).getMatchedURIs();
+
+        String[] requiredScopes = new String[]{"one", "two"};
+
+        TestException e = new TestException(mockInfo, requiredScopes);
+
+        Assert.assertSame(requiredScopes, e.getRequiredScopes());
+        Assert.assertEquals("http://localhost/three", e.getRealm().toString());
+    }
+
+    /**
+     * Assert that constructing the realm will drop all but the first string.
+     */
+    @Test
+    public void assertConstructorWithNoPaths() {
+        UriInfo mockInfo = Mockito.mock(UriInfo.class);
+        List<String> mockPaths = new ArrayList<>();
+
+        UriBuilder mockBuilder = UriBuilder.fromUri("http://localhost/");
+
+        Mockito.doReturn(mockBuilder).when(mockInfo).getBaseUriBuilder();
+        Mockito.doReturn(mockPaths).when(mockInfo).getMatchedURIs();
+
+        String[] requiredScopes = new String[]{"one", "two"};
+
+        TestException e = new TestException(mockInfo, requiredScopes);
+
+        Assert.assertSame(requiredScopes, e.getRequiredScopes());
+        Assert.assertEquals("http://localhost/", e.getRealm().toString());
+
+    }
+
+    /**
+     * Test exception.
+     */
+    public static final class TestException extends WWWChallengeException {
+
+        /**
+         * The error code.
+         */
+        public static final ErrorCode CODE = new ErrorCode(
+                Status.UNAUTHORIZED,
+                "test_error",
+                "Test Error"
+        );
+
+
+        /**
+         * Create a new exception with the specified error code.
+         *
+         * @param requestInfo    The original URI request, from which we're
+         *                       going to derive our realm.
+         * @param requiredScopes A list of required scopes.
+         */
+        protected TestException(final UriInfo requestInfo,
+                                final String[] requiredScopes) {
+            super(CODE, requestInfo, requiredScopes);
+        }
+    }
+
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/exception/package-info.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/exception/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Unit tests for the exceptions.
+ */
+package net.krotscheck.kangaroo.authz.admin.v1.auth.exception;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/filter/OAuth2AuthenticationFilterTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/filter/OAuth2AuthenticationFilterTest.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.admin.v1.auth.filter;
+
+import com.google.common.net.HttpHeaders;
+import net.krotscheck.kangaroo.authz.admin.v1.auth.OAuth2SecurityContext;
+import net.krotscheck.kangaroo.authz.admin.v1.auth.exception.OAuth2NotAuthorizedException;
+import net.krotscheck.kangaroo.authz.admin.v1.servlet.Config;
+import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorType;
+import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
+import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
+import net.krotscheck.kangaroo.authz.common.database.entity.OAuthTokenType;
+import net.krotscheck.kangaroo.authz.test.ApplicationBuilder;
+import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.test.DatabaseTest;
+import net.krotscheck.kangaroo.test.HttpUtil;
+import net.krotscheck.kangaroo.test.rule.TestDataResource;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.MapConfiguration;
+import org.hibernate.Session;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import javax.annotation.Priority;
+import javax.inject.Provider;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for the AuthenticationFilter.
+ *
+ * @author Michael Krotscheck
+ */
+public class OAuth2AuthenticationFilterTest extends DatabaseTest {
+
+    /**
+     * The application context from which we'll build our test scenarios.
+     */
+    private static ApplicationContext context;
+
+    /**
+     * Preload data into the system.
+     */
+    @ClassRule
+    public static final TestDataResource TEST_DATA_RESOURCE =
+            new TestDataResource(HIBERNATE_RESOURCE) {
+                @Override
+                protected void loadTestData(final Session session) {
+                    context = ApplicationBuilder.newApplication(session)
+                            .role("admin")
+                            .scope("one")
+                            .scope("two")
+                            .client(ClientType.OwnerCredentials)
+                            .authenticator(AuthenticatorType.Test)
+                            .user()
+                            .build();
+                }
+            };
+    /**
+     * Session provider, used in tests.
+     */
+    private final Provider<Session> sessionProvider = this::getSession;
+
+    /**
+     * The request's servlet configuration provider.
+     */
+    private final Provider<Configuration> configProvider = () -> {
+        Map<String, Object> config = new HashMap<>();
+        config.put(Config.APPLICATION_ID,
+                context.getApplication().getId().toString());
+        return new MapConfiguration(config);
+    };
+
+    /**
+     * Request context.
+     */
+    private ContainerRequestContext requestContext;
+
+    /**
+     * Security context.
+     */
+    private SecurityContext securityContext;
+
+    /**
+     * Assert that this filter has the Authentication priority.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void assertCorrectPriority() throws Exception {
+        Priority a = OAuth2AuthenticationFilter.class
+                .getAnnotation(Priority.class);
+        Assert.assertEquals(Priorities.AUTHENTICATION, a.value());
+    }
+
+    /**
+     * Setup of common mocks.
+     */
+    @Before
+    public void setup() {
+        requestContext = mock(ContainerRequestContext.class);
+        securityContext = mock(SecurityContext.class);
+        UriInfo mockInfo = mock(UriInfo.class);
+        UriBuilder mockBuilder = UriBuilder.fromPath("http://example.com/");
+        List<String> matchedPaths = Collections.singletonList("path");
+
+        doReturn(securityContext).when(requestContext).getSecurityContext();
+        doReturn(mockInfo).when(requestContext).getUriInfo();
+        doReturn(mockBuilder).when(mockInfo).getBaseUriBuilder();
+        doReturn(matchedPaths).when(mockInfo).getMatchedURIs();
+    }
+
+    /**
+     * Assert that a valid bearer token resolves.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void assertValidToken() throws Exception {
+        OAuthToken token = context.getBuilder()
+                .bearerToken("one")
+                .build()
+                .getToken();
+
+        OAuth2AuthenticationFilter filter = new OAuth2AuthenticationFilter(
+                sessionProvider, configProvider, new String[]{"one"});
+
+        String header = HttpUtil.authHeaderBearer(token.getId());
+        doReturn(header).when(requestContext)
+                .getHeaderString(HttpHeaders.AUTHORIZATION);
+
+        filter.filter(requestContext);
+
+        ArgumentCaptor<OAuth2SecurityContext> contextCaptor =
+                ArgumentCaptor.forClass(OAuth2SecurityContext.class);
+        verify(requestContext, times(1))
+                .setSecurityContext(contextCaptor.capture());
+
+        Assert.assertEquals(token, contextCaptor.getValue().getUserPrincipal());
+    }
+
+    /**
+     * Assert that running without a security context throws.
+     *
+     * @throws Exception Should be thrown.
+     */
+    @Test(expected = OAuth2NotAuthorizedException.class)
+    public void assertNoContext() throws Exception {
+        doReturn(null).when(requestContext).getSecurityContext();
+
+        OAuth2AuthenticationFilter filter = new OAuth2AuthenticationFilter(
+                sessionProvider, configProvider, new String[]{"one"});
+
+        filter.filter(requestContext);
+    }
+
+    /**
+     * Assert that a null token exists.
+     *
+     * @throws Exception Should be thrown.
+     */
+    @Test(expected = OAuth2NotAuthorizedException.class)
+    public void assertEmptyToken() throws Exception {
+        OAuth2AuthenticationFilter filter = new OAuth2AuthenticationFilter(
+                sessionProvider, configProvider, new String[]{"one"});
+
+        String header = HttpUtil.authHeaderBearer("");
+        doReturn(header).when(requestContext)
+                .getHeaderString(HttpHeaders.AUTHORIZATION);
+
+        filter.filter(requestContext);
+    }
+
+    /**
+     * Assert that a null token exists.
+     *
+     * @throws Exception Should be thrown.
+     */
+    @Test(expected = OAuth2NotAuthorizedException.class)
+    public void assertInvalidToken() throws Exception {
+        OAuth2AuthenticationFilter filter = new OAuth2AuthenticationFilter(
+                sessionProvider, configProvider, new String[]{"one"});
+
+        String header = HttpUtil.authHeaderBearer(UUID.randomUUID());
+        doReturn(header).when(requestContext)
+                .getHeaderString(HttpHeaders.AUTHORIZATION);
+
+        filter.filter(requestContext);
+    }
+
+    /**
+     * Assert that an expired token exists.
+     *
+     * @throws Exception Should be thrown.
+     */
+    @Test(expected = OAuth2NotAuthorizedException.class)
+    public void assertExpiredToken() throws Exception {
+        OAuthToken token = context.getBuilder()
+                .token(OAuthTokenType.Bearer, true, "one", null, null)
+                .build()
+                .getToken();
+
+        OAuth2AuthenticationFilter filter = new OAuth2AuthenticationFilter(
+                sessionProvider, configProvider, new String[]{"one"});
+
+        String header = HttpUtil.authHeaderBearer(token.getId());
+        doReturn(header).when(requestContext)
+                .getHeaderString(HttpHeaders.AUTHORIZATION);
+
+        filter.filter(requestContext);
+    }
+
+    /**
+     * Assert that an empty header fails.
+     *
+     * @throws Exception Should be thrown.
+     */
+    @Test(expected = OAuth2NotAuthorizedException.class)
+    public void assertEmptyHeader() throws Exception {
+        OAuth2AuthenticationFilter filter = new OAuth2AuthenticationFilter(
+                sessionProvider, configProvider, new String[]{"one"});
+
+        doReturn("").when(requestContext)
+                .getHeaderString(HttpHeaders.AUTHORIZATION);
+
+        filter.filter(requestContext);
+    }
+
+    /**
+     * Assert that a header with an invalid format fails.
+     *
+     * @throws Exception Should be thrown.
+     */
+    @Test(expected = OAuth2NotAuthorizedException.class)
+    public void assertBadlyFormattedHeader() throws Exception {
+        OAuth2AuthenticationFilter filter = new OAuth2AuthenticationFilter(
+                sessionProvider, configProvider, new String[]{"one"});
+
+        doReturn("invalid_format").when(requestContext)
+                .getHeaderString(HttpHeaders.AUTHORIZATION);
+
+        filter.filter(requestContext);
+    }
+
+    /**
+     * Assert that a non-bearer token header fails.
+     *
+     * @throws Exception Should be thrown.
+     */
+    @Test(expected = OAuth2NotAuthorizedException.class)
+    public void assertNoBearerHeader() throws Exception {
+        OAuth2AuthenticationFilter filter = new OAuth2AuthenticationFilter(
+                sessionProvider, configProvider, new String[]{"one"});
+
+        doReturn("HMAC Token").when(requestContext)
+                .getHeaderString(HttpHeaders.AUTHORIZATION);
+
+        filter.filter(requestContext);
+    }
+
+    /**
+     * Assert that a non-UUID bearer header value fails.
+     *
+     * @throws Exception Should be thrown.
+     */
+    @Test(expected = OAuth2NotAuthorizedException.class)
+    public void assertBadlyFormedToken() throws Exception {
+        OAuth2AuthenticationFilter filter = new OAuth2AuthenticationFilter(
+                sessionProvider, configProvider, new String[]{"one"});
+
+        doReturn("Bearer not_a_uuid").when(requestContext)
+                .getHeaderString(HttpHeaders.AUTHORIZATION);
+
+        filter.filter(requestContext);
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/filter/OAuth2AuthorizationFilterTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/filter/OAuth2AuthorizationFilterTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.admin.v1.auth.filter;
+
+import net.krotscheck.kangaroo.authz.admin.v1.auth.exception.OAuth2ForbiddenException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit test for the authorization step of the OAuth2 Dynamic filter chain.
+ *
+ * @author Michael Krotscheck
+ */
+public class OAuth2AuthorizationFilterTest {
+
+    /**
+     * Request context.
+     */
+    private ContainerRequestContext requestContext;
+
+    /**
+     * Security context.
+     */
+    private SecurityContext securityContext;
+
+    /**
+     * Setup of common mocks.
+     */
+    @Before
+    public void setup() {
+        requestContext = mock(ContainerRequestContext.class);
+        securityContext = mock(SecurityContext.class);
+        UriInfo mockInfo = mock(UriInfo.class);
+        UriBuilder mockBuilder = UriBuilder.fromPath("http://example.com/");
+        List<String> matchedPaths = Collections.singletonList("path");
+
+        doReturn(securityContext).when(requestContext).getSecurityContext();
+        doReturn(false).when(securityContext).isUserInRole("invalid");
+        doReturn(true).when(securityContext).isUserInRole("valid");
+        doReturn(mockInfo).when(requestContext).getUriInfo();
+        doReturn(mockBuilder).when(mockInfo).getBaseUriBuilder();
+        doReturn(matchedPaths).when(mockInfo).getMatchedURIs();
+    }
+
+    /**
+     * Assert that this filter has the Authorization priority.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void assertCorrectPriority() throws Exception {
+        Priority a = OAuth2AuthorizationFilter.class
+                .getAnnotation(Priority.class);
+        Assert.assertEquals(Priorities.AUTHORIZATION, a.value());
+    }
+
+    /**
+     * Assert that a valid set of scopes resolves.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void assertValidScopes() throws Exception {
+        OAuth2AuthorizationFilter filter =
+                new OAuth2AuthorizationFilter(new String[]{"valid"});
+        filter.filter(requestContext);
+    }
+
+    /**
+     * Assert that a resource with no annotated scopes throws.
+     *
+     * @throws Exception Should be thrown.
+     */
+    @Test(expected = OAuth2ForbiddenException.class)
+    public void assertResourceWithNoScopes() throws Exception {
+        OAuth2AuthorizationFilter filter = new OAuth2AuthorizationFilter();
+        filter.filter(requestContext);
+    }
+
+    /**
+     * If we, for some reason, get a resource with no security context, throw.
+     *
+     * @throws Exception Should be thrown.
+     */
+    @Test(expected = OAuth2ForbiddenException.class)
+    public void assertNoSecurityContext() throws Exception {
+        doReturn(null).when(requestContext).getSecurityContext();
+
+        OAuth2AuthorizationFilter filter = new OAuth2AuthorizationFilter();
+        filter.filter(requestContext);
+    }
+
+    /**
+     * Assert that a scoped token that doesn't match fails.
+     *
+     * @throws Exception Should be thrown.
+     */
+    @Test(expected = OAuth2ForbiddenException.class)
+    public void assertWithMismatchedScopes() throws Exception {
+        OAuth2AuthorizationFilter filter =
+                new OAuth2AuthorizationFilter(new String[]{"invalid"});
+        filter.filter(requestContext);
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/filter/package-info.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/filter/package-info.java
@@ -16,23 +16,7 @@
  *
  */
 
-package net.krotscheck.kangaroo.authz.admin.v1.filter;
-
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-import javax.ws.rs.NameBinding;
-
 /**
- * This annotation should be used to indicate that a resource is
- * authorized/authenticated via OAuth2 Tokens.
- *
- * @author Michael Krotscheck
+ * Unit tests for the Authn/Authz filters.
  */
-@Target({ElementType.TYPE, ElementType.METHOD})
-@Retention(value = RetentionPolicy.RUNTIME)
-@NameBinding
-public @interface OAuth2 {
-
-}
+package net.krotscheck.kangaroo.authz.admin.v1.auth.filter;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/package-info.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Unit tests for the Authz Feature.
+ */
+package net.krotscheck.kangaroo.authz.admin.v1.auth;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/filter/OAuth2AuthenticationFilterTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/filter/OAuth2AuthenticationFilterTest.java
@@ -22,27 +22,17 @@ import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthTokenType;
 import net.krotscheck.kangaroo.authz.admin.Scope;
-import net.krotscheck.kangaroo.authz.admin.v1.filter.OAuth2AuthorizationFilter.Binder;
-import net.krotscheck.kangaroo.authz.admin.v1.filter.OAuth2AuthorizationFilter.OAuthTokenContext;
 import net.krotscheck.kangaroo.authz.admin.v1.resource.AbstractResourceTest;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
-import org.glassfish.hk2.api.ActiveDescriptor;
-import org.glassfish.hk2.api.ServiceLocator;
-import org.glassfish.hk2.api.ServiceLocatorFactory;
-import org.glassfish.hk2.utilities.BuilderHelper;
-import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.inject.Singleton;
-import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import java.net.URI;
-import java.util.List;
 import java.util.UUID;
 
 /**
@@ -50,7 +40,7 @@ import java.util.UUID;
  *
  * @author Michael Krotscheck
  */
-public final class OAuth2AuthorizationFilterTest
+public final class OAuth2AuthenticationFilterTest
         extends AbstractResourceTest {
 
     /**
@@ -153,7 +143,7 @@ public final class OAuth2AuthorizationFilterTest
         Response r = target("/user")
                 .request()
                 .get();
-        Assert.assertEquals(Status.FORBIDDEN.getStatusCode(), r.getStatus());
+        Assert.assertEquals(Status.UNAUTHORIZED.getStatusCode(), r.getStatus());
     }
 
     /**
@@ -179,7 +169,7 @@ public final class OAuth2AuthorizationFilterTest
                 .header(HttpHeaders.AUTHORIZATION,
                         String.format("Bearer %s", expiredBearerToken.getId()))
                 .get();
-        Assert.assertEquals(Status.FORBIDDEN.getStatusCode(), r.getStatus());
+        Assert.assertEquals(Status.UNAUTHORIZED.getStatusCode(), r.getStatus());
     }
 
     /**
@@ -192,7 +182,7 @@ public final class OAuth2AuthorizationFilterTest
                 .header(HttpHeaders.AUTHORIZATION,
                         String.format("Bearer %s", UUID.randomUUID()))
                 .get();
-        Assert.assertEquals(Status.FORBIDDEN.getStatusCode(), r.getStatus());
+        Assert.assertEquals(Status.UNAUTHORIZED.getStatusCode(), r.getStatus());
     }
 
     /**
@@ -204,7 +194,7 @@ public final class OAuth2AuthorizationFilterTest
                 .request()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer YUIIUYIY")
                 .get();
-        Assert.assertEquals(Status.FORBIDDEN.getStatusCode(), r.getStatus());
+        Assert.assertEquals(Status.UNAUTHORIZED.getStatusCode(), r.getStatus());
     }
 
     /**
@@ -218,7 +208,7 @@ public final class OAuth2AuthorizationFilterTest
                 .header(HttpHeaders.AUTHORIZATION,
                         String.format("Bearer %s", authToken.getId()))
                 .get();
-        Assert.assertEquals(Status.FORBIDDEN.getStatusCode(), r.getStatus());
+        Assert.assertEquals(Status.UNAUTHORIZED.getStatusCode(), r.getStatus());
     }
 
     /**
@@ -231,7 +221,7 @@ public final class OAuth2AuthorizationFilterTest
                 .header(HttpHeaders.AUTHORIZATION,
                         String.format("HMAC %s", authToken.getId()))
                 .get();
-        Assert.assertEquals(Status.FORBIDDEN.getStatusCode(), r.getStatus());
+        Assert.assertEquals(Status.UNAUTHORIZED.getStatusCode(), r.getStatus());
     }
 
     /**
@@ -243,50 +233,7 @@ public final class OAuth2AuthorizationFilterTest
                 .request()
                 .header(HttpHeaders.AUTHORIZATION, "OMGOMGOMG")
                 .get();
-        Assert.assertEquals(Status.FORBIDDEN.getStatusCode(), r.getStatus());
-    }
-
-    /**
-     * Assert that we can invoke the binder.
-     *
-     * @throws Exception An authenticator exception.
-     */
-    @Test
-    public void testBinder() throws Exception {
-        ServiceLocatorFactory factory = ServiceLocatorFactory.getInstance();
-        ServiceLocator locator = factory.create(getClass().getCanonicalName());
-
-        Binder b = new OAuth2AuthorizationFilter.Binder();
-        ServiceLocatorUtilities.bind(locator, b);
-
-        List<ActiveDescriptor<?>> descriptors =
-                locator.getDescriptors(
-                        BuilderHelper.createContractFilter(
-                                ContainerRequestFilter.class.getName()));
-        Assert.assertEquals(1, descriptors.size());
-
-        ActiveDescriptor descriptor = descriptors.get(0);
-        Assert.assertNotNull(descriptor);
-        // Check scope...
-        Assert.assertEquals(Singleton.class.getCanonicalName(),
-                descriptor.getScope());
-
-        // ... check name.
-        Assert.assertNull(descriptor.getName());
-    }
-
-    /**
-     * Assert that we can invoke the binder.
-     *
-     * @throws Exception An authenticator exception.
-     */
-    @Test
-    public void testContextMethods() throws Exception {
-        OAuthTokenContext context =
-                new OAuthTokenContext(new OAuthToken(), false);
-
-        Assert.assertFalse(context.isSecure());
-        Assert.assertEquals("OAuth2", context.getAuthenticationScheme());
+        Assert.assertEquals(Status.UNAUTHORIZED.getStatusCode(), r.getStatus());
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceBrowseTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceBrowseTest.java
@@ -546,6 +546,6 @@ public abstract class AbstractServiceBrowseTest<T extends AbstractAuthzEntity>
                 .request()
                 .get();
 
-        assertErrorResponse(response, Status.FORBIDDEN);
+        assertErrorResponse(response, Status.UNAUTHORIZED);
     }
 }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceCRUDTest.java
@@ -319,7 +319,7 @@ public abstract class AbstractServiceCRUDTest<T extends AbstractAuthzEntity>
         // Issue the request.
         Response r = getEntity(testingEntity, token);
 
-        assertErrorResponse(r, Status.FORBIDDEN);
+        assertErrorResponse(r, Status.UNAUTHORIZED);
     }
 
     /**
@@ -335,7 +335,7 @@ public abstract class AbstractServiceCRUDTest<T extends AbstractAuthzEntity>
         // Issue the request.
         Response r = getEntity(testingEntity, null);
 
-        assertErrorResponse(r, Status.FORBIDDEN);
+        assertErrorResponse(r, Status.UNAUTHORIZED);
     }
 
     /**
@@ -464,7 +464,7 @@ public abstract class AbstractServiceCRUDTest<T extends AbstractAuthzEntity>
 
         // Issue the request.
         Response r = postEntity(testEntity, getSecondaryContext().getToken());
-        assertErrorResponse(r, Status.FORBIDDEN);
+        assertErrorResponse(r, Status.UNAUTHORIZED);
     }
 
     /**
@@ -523,7 +523,7 @@ public abstract class AbstractServiceCRUDTest<T extends AbstractAuthzEntity>
         // Issue the request.
         Response r = postEntity(testingEntity, (OAuthToken) null);
 
-        assertErrorResponse(r, Status.FORBIDDEN);
+        assertErrorResponse(r, Status.UNAUTHORIZED);
     }
 
     /**
@@ -570,7 +570,7 @@ public abstract class AbstractServiceCRUDTest<T extends AbstractAuthzEntity>
 
         // Issue the request.
         Response r = putEntity(testingEntity, token);
-        assertErrorResponse(r, Status.FORBIDDEN);
+        assertErrorResponse(r, Status.UNAUTHORIZED);
     }
 
     /**
@@ -583,7 +583,7 @@ public abstract class AbstractServiceCRUDTest<T extends AbstractAuthzEntity>
     public final void testPutByUnknown() throws Exception {
         T testingEntity = getEntity(getSecondaryContext());
         Response r = putEntity(testingEntity, (OAuthToken) null);
-        assertErrorResponse(r, Status.FORBIDDEN);
+        assertErrorResponse(r, Status.UNAUTHORIZED);
     }
 
     /**
@@ -652,7 +652,7 @@ public abstract class AbstractServiceCRUDTest<T extends AbstractAuthzEntity>
         // Issue the request.
         Response r = deleteEntity(testingEntity,
                 getSecondaryContext().getToken());
-        assertErrorResponse(r, Status.FORBIDDEN);
+        assertErrorResponse(r, Status.UNAUTHORIZED);
     }
 
     /**
@@ -672,7 +672,7 @@ public abstract class AbstractServiceCRUDTest<T extends AbstractAuthzEntity>
         s.getTransaction().commit();
 
         Response r = deleteEntity(testingEntity, null);
-        assertErrorResponse(r, Status.FORBIDDEN);
+        assertErrorResponse(r, Status.UNAUTHORIZED);
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceSearchTest.java
@@ -632,6 +632,6 @@ public abstract class AbstractServiceSearchTest<T extends AbstractAuthzEntity>
         params.put("q", "single");
 
         Response r = search(params, null);
-        assertErrorResponse(r, Status.FORBIDDEN);
+        assertErrorResponse(r, Status.UNAUTHORIZED);
     }
 }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractSubserviceBrowseTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractSubserviceBrowseTest.java
@@ -527,6 +527,6 @@ public abstract class AbstractSubserviceBrowseTest<K extends AbstractAuthzEntity
                 .request()
                 .get();
 
-        assertErrorResponse(response, Status.FORBIDDEN);
+        assertErrorResponse(response, Status.UNAUTHORIZED);
     }
 }


### PR DESCRIPTION
This patch removes use of the RolesAllowedDynamicFeature in favor
of our own OAuth2 based Dynamic feature. It creates a new annotation,
@ScopesAllowed, which is scanned during application initialzation and
provided with a postmatching filter that knows enough about the resource
to return a meaningful WWW-Authentication: header.

Closes: #142 