### PR TITLE
Commandline configuration is now injected into the HK2 context.

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/config/ConfigurationBinder.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/config/ConfigurationBinder.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.config;
+
+import org.apache.commons.configuration.Configuration;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+/**
+ * A custom, configurable binder that may be used to inject additional
+ * configuration instances into the system. These will be picked up by
+ * the SystemConfiguration injectee.
+ *
+ * @author Michael Krotscheck
+ */
+public final class ConfigurationBinder extends AbstractBinder {
+
+    /**
+     * The configuration to inject.
+     */
+    private final Configuration config;
+
+    /**
+     * Create a new binder around a specific configuration instance.
+     *
+     * @param config The configuration to wrap.
+     */
+    public ConfigurationBinder(final Configuration config) {
+        this.config = config;
+    }
+
+    /**
+     * Inject this configuration into the context.
+     */
+    @Override
+    protected void configure() {
+        bind(config)
+                .to(Configuration.class)
+                .named("kangaroo_external_configuration");
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/ServerFactory.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/ServerFactory.java
@@ -19,6 +19,7 @@
 package net.krotscheck.kangaroo.server;
 
 import com.google.common.base.Strings;
+import net.krotscheck.kangaroo.common.config.ConfigurationBinder;
 import net.krotscheck.kangaroo.server.keystore.FSKeystoreProvider;
 import net.krotscheck.kangaroo.server.keystore.GeneratedKeystoreProvider;
 import net.krotscheck.kangaroo.server.keystore.IKeystoreProvider;
@@ -114,6 +115,7 @@ public final class ServerFactory {
         for (Entry<String, ResourceConfig> route : services.entrySet()) {
             String path = route.getKey();
             ResourceConfig rc = route.getValue();
+            rc.register(new ConfigurationBinder(config));
             String name = route.getValue().getClass().getSimpleName();
 
             WebappContext context = new WebappContext(name, path);

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/config/ConfigurationBinderTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/config/ConfigurationBinderTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.config;
+
+import net.krotscheck.kangaroo.test.KangarooJerseyTest;
+import org.apache.commons.configuration.MapConfiguration;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import java.util.Properties;
+
+/**
+ * Unit tests for the configuration binder.
+ */
+public class ConfigurationBinderTest extends KangarooJerseyTest {
+
+    /**
+     * Build the configured application.
+     *
+     * @return The configured application.
+     */
+    @Override
+    protected ResourceConfig createApplication() {
+        Properties properties = new Properties();
+        properties.setProperty("foo", "bar");
+        MapConfiguration mapConfig = new MapConfiguration(properties);
+
+        ResourceConfig a = new ResourceConfig();
+        a.register(ConfigurationFeature.class);
+        a.register(new ConfigurationBinder(mapConfig));
+        a.register(MockService.class);
+        return a;
+    }
+
+    /**
+     * Quick check to see if we can inject and access the configuration.
+     */
+    @Test
+    public void testBoundExternalValue() {
+        String response = target("/foo").request().get(String.class);
+        Assert.assertEquals("bar", response);
+    }
+
+    /**
+     * A simple endpoint that returns configuration values.
+     *
+     * @author Michael Krotscheck
+     */
+    @Path("/")
+    public static final class MockService {
+
+        /**
+         * The system configuration from which to read status features.
+         */
+        private SystemConfiguration config;
+
+        /**
+         * Create a new instance of the status service.
+         *
+         * @param config Injected system configuration.
+         */
+        @Inject
+        public MockService(final SystemConfiguration config) {
+            this.config = config;
+        }
+
+        /**
+         * Return the value of a specific key.
+         *
+         * @param key The key value to return.
+         * @return HTTP Response object with the current service status.
+         */
+        @GET
+        @Path("{key}")
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response getSpecificValue(@PathParam("key") final String key) {
+            return Response
+                    .status(Status.OK)
+                    .entity(this.config.getString(key))
+                    .build();
+        }
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/hk2/SimpleIterableProvider.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/hk2/SimpleIterableProvider.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.test.hk2;
+
+import org.glassfish.hk2.api.IterableProvider;
+import org.glassfish.hk2.api.ServiceHandle;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A simple iterable provider, for testing purposes.
+ *
+ * @author Michael Krotscheck
+ */
+public final class SimpleIterableProvider<T> implements IterableProvider<T> {
+
+    /**
+     * The content provided by this provider.
+     */
+    private final List<T> content;
+
+    /**
+     * The content to wrap.
+     *
+     * @param content A list of content to wrap.
+     */
+    public SimpleIterableProvider(final List<T> content) {
+        this.content = content;
+    }
+
+    /**
+     * Return the service handle (usually not used).
+     *
+     * @return null
+     */
+    @Override
+    public ServiceHandle<T> getHandle() {
+        return null;
+    }
+
+    /**
+     * Return the size of the content.
+     *
+     * @return The size of the content.
+     */
+    @Override
+    public int getSize() {
+        return content.size();
+    }
+
+    /**
+     * Do nothing.
+     *
+     * @param name Named subselector.
+     * @return null
+     */
+    @Override
+    public IterableProvider<T> named(final String name) {
+        return null;
+    }
+
+    /**
+     * Do nothing.
+     *
+     * @param type Typed subselector.
+     * @return null
+     */
+    @Override
+    public <U> IterableProvider<U> ofType(final Type type) {
+        return null;
+    }
+
+    /**
+     * Do nothing.
+     *
+     * @param qualifiers Annotation subselector.
+     * @return null
+     */
+    @Override
+    public IterableProvider<T> qualifiedWith(final Annotation... qualifiers) {
+        return null;
+    }
+
+    /**
+     * Do nothing.
+     *
+     * @return null
+     */
+    @Override
+    public Iterable<ServiceHandle<T>> handleIterator() {
+        return null;
+    }
+
+    /**
+     * Return an iterator.
+     *
+     * @return Content iterator.
+     */
+    @Override
+    public Iterator<T> iterator() {
+        return content.iterator();
+    }
+
+    /**
+     * Get an instance from the iterator.
+     *
+     * @return
+     */
+    @Override
+    public T get() {
+        return content.iterator().next();
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/hk2/package-info.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/hk2/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Utilities that help faking an HK2 environment.
+ *
+ * @author Michael Krotscheck
+ */
+package net.krotscheck.kangaroo.test.hk2;


### PR DESCRIPTION
This patch sets up an external binder, which may be used to add an
arbitrary number of configuration options to the system's "SystemConfiguration"
instance.