### PR TITLE
Permit adding defaults and custom configuration options to ServerFactory

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/ServerFactory.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/ServerFactory.java
@@ -23,6 +23,8 @@ import net.krotscheck.kangaroo.common.config.ConfigurationBinder;
 import net.krotscheck.kangaroo.server.keystore.FSKeystoreProvider;
 import net.krotscheck.kangaroo.server.keystore.GeneratedKeystoreProvider;
 import net.krotscheck.kangaroo.server.keystore.IKeystoreProvider;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
@@ -51,6 +53,83 @@ import java.util.Map.Entry;
 public final class ServerFactory {
 
     /**
+     * Our commandline options.
+     */
+    public static final Options CLI_OPTIONS;
+
+    static {
+        // Initialize the CLI Options.
+        CLI_OPTIONS = new Options();
+
+        Option bindHost = Option.builder("h")
+                .longOpt(Config.HOST.getKey())
+                .argName(Config.HOST.getKey())
+                .hasArg()
+                .desc("The IP address or hostname which this server should "
+                        + "bind to.")
+                .build();
+        Option bindPort = Option.builder("p")
+                .longOpt(Config.PORT.getKey())
+                .argName(Config.PORT.getKey())
+                .hasArg()
+                .desc("The port on which this port should listen.")
+                .build();
+
+        Option keystorePath = Option.builder()
+                .longOpt(Config.KEYSTORE_PATH.getKey())
+                .argName(Config.KEYSTORE_PATH.getKey())
+                .hasArg()
+                .desc("Path to an externally provided keystore.")
+                .build();
+
+        Option keystorePass = Option.builder()
+                .longOpt(Config.KEYSTORE_PASS.getKey())
+                .argName(Config.KEYSTORE_PASS.getKey())
+                .hasArg()
+                .desc("Password for the externally provided keystore.")
+                .build();
+
+        Option keystoreType = Option.builder()
+                .longOpt(Config.KEYSTORE_TYPE.getKey())
+                .argName(Config.KEYSTORE_TYPE.getKey())
+                .hasArg()
+                .desc("JVM KeyStore type to expect. Default PKCS12.")
+                .build();
+
+        Option certAlias = Option.builder()
+                .longOpt(Config.CERT_ALIAS.getKey())
+                .argName(Config.CERT_ALIAS.getKey())
+                .hasArg()
+                .desc("Alias of the HTTPS certificate to use.")
+                .build();
+
+        Option certKeyPass = Option.builder()
+                .longOpt(Config.CERT_KEY_PASS.getKey())
+                .argName(Config.CERT_KEY_PASS.getKey())
+                .hasArg()
+                .desc("Password of the private key for the certificate.")
+                .build();
+
+        Option htmlAppRoot = Option.builder()
+                .longOpt(Config.HTML_APP_ROOT.getKey())
+                .argName(Config.HTML_APP_ROOT.getKey())
+                .hasArg()
+                .desc("Path to the server's HTML5 Application root. We "
+                        + "presume HTML5 routing support in the application "
+                        + "served there.")
+                .build();
+
+        CLI_OPTIONS.addOption(bindHost);
+        CLI_OPTIONS.addOption(bindPort);
+        CLI_OPTIONS.addOption(keystorePath);
+        CLI_OPTIONS.addOption(keystorePass);
+        CLI_OPTIONS.addOption(keystoreType);
+        CLI_OPTIONS.addOption(certAlias);
+        CLI_OPTIONS.addOption(certKeyPass);
+        CLI_OPTIONS.addOption(htmlAppRoot);
+    }
+
+    /**
      * Configuration builder.
      */
     private ConfigurationBuilder configBuilder = new ConfigurationBuilder();
@@ -64,6 +143,26 @@ public final class ServerFactory {
      * Create a new server factory.
      */
     public ServerFactory() {
+        // Add the server's commandline options.
+        withCommandlineOptions(CLI_OPTIONS);
+
+        // Certain values are required, so set those in the default
+        // configuration.
+        Map<String, Object> defaults = new HashMap<>();
+        defaults.put(Config.HOST.getKey(), Config.HOST.getValue());
+        defaults.put(Config.PORT.getKey(), Config.PORT.getValue());
+        configBuilder.withDefaults(defaults);
+    }
+
+    /**
+     * Add additional commandline options to the server.
+     *
+     * @param options The options to add.
+     * @return This builder.
+     */
+    public ServerFactory withCommandlineOptions(final Options options) {
+        configBuilder.withCommandlineOptions(options);
+        return this;
     }
 
     /**

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/ConfigurationBuilderTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/ConfigurationBuilderTest.java
@@ -27,7 +27,9 @@ import org.mockito.Mockito;
 
 import java.io.File;
 import java.net.URL;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 
 /**
  * Unit tests for the ConfigurationBuilder.
@@ -42,6 +44,7 @@ public final class ConfigurationBuilderTest {
     @Test
     public void addCommandlineArgs() {
         Configuration config = new ConfigurationBuilder()
+                .withCommandlineOptions(ServerFactory.CLI_OPTIONS)
                 .addCommandlineArgs(new String[]{
                         "-h=example.com",
                         "-p=9000",
@@ -78,6 +81,7 @@ public final class ConfigurationBuilderTest {
     @Test(expected = RuntimeException.class)
     public void addInvalidCommandlineArgs() {
         new ConfigurationBuilder()
+                .withCommandlineOptions(ServerFactory.CLI_OPTIONS)
                 .addCommandlineArgs(new String[]{
                         "-l=invalid_field"
                 })
@@ -90,20 +94,41 @@ public final class ConfigurationBuilderTest {
     @Test
     public void addNoCommandlineArgs() {
         Configuration config = new ConfigurationBuilder()
+                .withCommandlineOptions(ServerFactory.CLI_OPTIONS)
                 .addCommandlineArgs(new String[]{
                 })
                 .build();
 
-        Assert.assertEquals(config.getString(
-                Config.HOST.getKey()), "127.0.0.1");
-        Assert.assertEquals(config.getInt(
-                Config.PORT.getKey()), 8080);
+        Assert.assertNull(config.getString(Config.HOST.getKey()));
+        Assert.assertNull(config.getString(Config.PORT.getKey()));
         Assert.assertNull(config.getString(Config.KEYSTORE_PATH.getKey()));
         Assert.assertNull(config.getString(Config.KEYSTORE_PASS.getKey()));
         Assert.assertNull(config.getString(Config.KEYSTORE_TYPE.getKey()));
         Assert.assertNull(config.getString(Config.CERT_ALIAS.getKey()));
         Assert.assertNull(config.getString(Config.CERT_KEY_PASS.getKey()));
         Assert.assertNull(config.getString(Config.HTML_APP_ROOT.getKey()));
+    }
+
+    /**
+     * Assert that lack of commandline arguments goes to defaults.
+     */
+    @Test
+    public void addWithDefaults() {
+        Map<String, Object> defaults = new HashMap<>();
+        defaults.put(Config.HOST.getKey(), "example.com");
+        defaults.put(Config.PORT.getKey(), "1000");
+
+        Configuration config = new ConfigurationBuilder()
+                .withDefaults(defaults)
+                .withCommandlineOptions(ServerFactory.CLI_OPTIONS)
+                .addCommandlineArgs(new String[]{
+                })
+                .build();
+
+        Assert.assertEquals("example.com",
+                config.getString(Config.HOST.getKey()));
+        Assert.assertEquals(1000,
+                config.getInt(Config.PORT.getKey()));
     }
 
     /**
@@ -115,6 +140,7 @@ public final class ConfigurationBuilderTest {
                 .getResource("/config/test.properties");
 
         Configuration config = new ConfigurationBuilder()
+                .withCommandlineOptions(ServerFactory.CLI_OPTIONS)
                 .addPropertiesFile(filePath.getPath())
                 .build();
 
@@ -142,13 +168,12 @@ public final class ConfigurationBuilderTest {
     @Test
     public void addNonexistentPropertiesFile() {
         Configuration config = new ConfigurationBuilder()
+                .withCommandlineOptions(ServerFactory.CLI_OPTIONS)
                 .addPropertiesFile("/config/nonexistent.properties")
                 .build();
 
-        Assert.assertEquals(config.getString(
-                Config.HOST.getKey()), "127.0.0.1");
-        Assert.assertEquals(config.getInt(
-                Config.PORT.getKey()), 8080);
+        Assert.assertNull(config.getString(Config.HOST.getKey()));
+        Assert.assertNull(config.getString(Config.PORT.getKey()));
         Assert.assertNull(config.getString(Config.KEYSTORE_PATH.getKey()));
         Assert.assertNull(config.getString(Config.KEYSTORE_PASS.getKey()));
         Assert.assertNull(config.getString(Config.KEYSTORE_TYPE.getKey()));
@@ -168,13 +193,12 @@ public final class ConfigurationBuilderTest {
         Mockito.doReturn(true).when(mockConfigFile).exists();
 
         Configuration config = new ConfigurationBuilder()
+                .withCommandlineOptions(ServerFactory.CLI_OPTIONS)
                 .addPropertiesFile(mockConfigFile)
                 .build();
 
-        Assert.assertEquals(config.getString(
-                Config.HOST.getKey()), "127.0.0.1");
-        Assert.assertEquals(config.getInt(
-                Config.PORT.getKey()), 8080);
+        Assert.assertNull(config.getString(Config.HOST.getKey()));
+        Assert.assertNull(config.getString(Config.PORT.getKey()));
         Assert.assertNull(config.getString(Config.KEYSTORE_PATH.getKey()));
         Assert.assertNull(config.getString(Config.KEYSTORE_PASS.getKey()));
         Assert.assertNull(config.getString(Config.KEYSTORE_TYPE.getKey()));
@@ -189,6 +213,7 @@ public final class ConfigurationBuilderTest {
     @Test
     public void testSystemParameters() {
         Configuration config = new ConfigurationBuilder()
+                .withCommandlineOptions(ServerFactory.CLI_OPTIONS)
                 .build();
 
         SystemConfiguration c = new SystemConfiguration();
@@ -208,6 +233,7 @@ public final class ConfigurationBuilderTest {
     @Test
     public void testEnvParameters() {
         Configuration config = new ConfigurationBuilder()
+                .withCommandlineOptions(ServerFactory.CLI_OPTIONS)
                 .build();
 
         EnvironmentConfiguration c = new EnvironmentConfiguration();


### PR DESCRIPTION
This allows us to add commandline options, as well as default values, to
the ServerFactory under construction.