### PR TITLE
Switch JerseyTest framework to use real servlets

### DIFF
--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/config/ConfigurationBinderTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/config/ConfigurationBinderTest.java
@@ -18,7 +18,7 @@
 
 package net.krotscheck.kangaroo.common.config;
 
-import net.krotscheck.kangaroo.test.KangarooJerseyTest;
+import net.krotscheck.kangaroo.test.jerseyTest.KangarooJerseyTest;
 import org.apache.commons.configuration.MapConfiguration;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Assert;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/config/ConfigurationFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/config/ConfigurationFeatureTest.java
@@ -17,7 +17,7 @@
 
 package net.krotscheck.kangaroo.common.config;
 
-import net.krotscheck.kangaroo.test.KangarooJerseyTest;
+import net.krotscheck.kangaroo.test.jerseyTest.KangarooJerseyTest;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Assert;
 import org.junit.Test;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/cors/CORSFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/cors/CORSFeatureTest.java
@@ -20,7 +20,7 @@ package net.krotscheck.kangaroo.common.cors;
 
 import com.google.common.collect.Lists;
 import com.google.common.net.HttpHeaders;
-import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.jerseyTest.ContainerTest;
 import org.apache.http.HttpStatus;
 import org.glassfish.hk2.api.IterableProvider;
 import org.glassfish.jersey.server.ResourceConfig;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/cors/CORSFilterTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/cors/CORSFilterTest.java
@@ -19,7 +19,7 @@
 package net.krotscheck.kangaroo.common.cors;
 
 import com.google.common.net.HttpHeaders;
-import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.jerseyTest.ContainerTest;
 import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.ServiceLocatorFactory;
 import org.glassfish.hk2.utilities.BuilderHelper;
@@ -36,7 +36,6 @@ import javax.ws.rs.OPTIONS;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedHashMap;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/exception/ExceptionFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/exception/ExceptionFeatureTest.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder.ErrorResponse;
-import net.krotscheck.kangaroo.test.KangarooJerseyTest;
+import net.krotscheck.kangaroo.test.jerseyTest.KangarooJerseyTest;
 import org.glassfish.jersey.CommonProperties;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Assert;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/HibernateFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/HibernateFeatureTest.java
@@ -18,7 +18,7 @@
 
 package net.krotscheck.kangaroo.common.hibernate;
 
-import net.krotscheck.kangaroo.test.KangarooJerseyTest;
+import net.krotscheck.kangaroo.test.jerseyTest.KangarooJerseyTest;
 import net.krotscheck.kangaroo.test.rule.DatabaseResource;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.hibernate.Session;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/config/HibernateConfigurationTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/config/HibernateConfigurationTest.java
@@ -18,7 +18,7 @@
 
 package net.krotscheck.kangaroo.common.hibernate.config;
 
-import net.krotscheck.kangaroo.test.DatabaseTest;
+import net.krotscheck.kangaroo.test.jerseyTest.DatabaseTest;
 import org.apache.commons.configuration.Configuration;
 import org.junit.After;
 import org.junit.Assert;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/PooledDataSourceFactoryTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/PooledDataSourceFactoryTest.java
@@ -20,7 +20,7 @@ package net.krotscheck.kangaroo.common.hibernate.factory;
 
 import com.mchange.v2.c3p0.PoolBackedDataSource;
 import com.mchange.v2.c3p0.PooledDataSource;
-import net.krotscheck.kangaroo.test.DatabaseTest;
+import net.krotscheck.kangaroo.test.jerseyTest.DatabaseTest;
 import org.hibernate.SessionFactory;
 import org.junit.Assert;
 import org.junit.Test;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/listener/CreatedUpdatedListenerTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/listener/CreatedUpdatedListenerTest.java
@@ -19,7 +19,7 @@
 package net.krotscheck.kangaroo.common.hibernate.listener;
 
 import net.krotscheck.kangaroo.common.hibernate.entity.TestEntity;
-import net.krotscheck.kangaroo.test.DatabaseTest;
+import net.krotscheck.kangaroo.test.jerseyTest.DatabaseTest;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.event.service.spi.EventListenerRegistrationException;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/jackson/JacksonFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/jackson/JacksonFeatureTest.java
@@ -20,7 +20,7 @@ package net.krotscheck.kangaroo.common.jackson;
 import net.krotscheck.kangaroo.common.jackson.mock.MockPojo;
 import net.krotscheck.kangaroo.common.jackson.mock.MockPojoDeserializer;
 import net.krotscheck.kangaroo.common.jackson.mock.MockPojoSerializer;
-import net.krotscheck.kangaroo.test.KangarooJerseyTest;
+import net.krotscheck.kangaroo.test.jerseyTest.KangarooJerseyTest;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Assert;
 import org.junit.Test;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/logging/LoggingFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/logging/LoggingFeatureTest.java
@@ -17,7 +17,7 @@
 
 package net.krotscheck.kangaroo.common.logging;
 
-import net.krotscheck.kangaroo.test.KangarooJerseyTest;
+import net.krotscheck.kangaroo.test.jerseyTest.KangarooJerseyTest;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Assert;
 import org.junit.Test;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/security/SecurityFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/security/SecurityFeatureTest.java
@@ -19,7 +19,7 @@
 package net.krotscheck.kangaroo.common.security;
 
 import com.google.common.net.HttpHeaders;
-import net.krotscheck.kangaroo.test.KangarooJerseyTest;
+import net.krotscheck.kangaroo.test.jerseyTest.KangarooJerseyTest;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Assert;
 import org.junit.Test;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/security/SecurityHeadersFilterTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/security/SecurityHeadersFilterTest.java
@@ -19,7 +19,7 @@
 package net.krotscheck.kangaroo.common.security;
 
 import com.google.common.net.HttpHeaders;
-import net.krotscheck.kangaroo.test.KangarooJerseyTest;
+import net.krotscheck.kangaroo.test.jerseyTest.KangarooJerseyTest;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Assert;
 import org.junit.Test;
@@ -58,11 +58,11 @@ public final class SecurityHeadersFilterTest extends KangarooJerseyTest {
     public void testFilters() {
         Response r = target("/").request().get();
 
-        // We expect 3 headers, two provided by the underlying framework, and
+        // We expect 4 headers, 3 provided by the underlying framework, and
         // one provided by the filter.
         MultivaluedMap<String, Object> headers = r.getHeaders();
 
-        Assert.assertEquals(3, headers.size());
+        Assert.assertEquals(4, headers.size());
 
         // Framework provided tests.
         Assert.assertNotNull(headers.get(HttpHeaders.DATE));

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/status/PoweredByFilterTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/status/PoweredByFilterTest.java
@@ -19,7 +19,7 @@
 package net.krotscheck.kangaroo.common.status;
 
 import com.google.common.net.HttpHeaders;
-import net.krotscheck.kangaroo.test.KangarooJerseyTest;
+import net.krotscheck.kangaroo.test.jerseyTest.KangarooJerseyTest;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Assert;
 import org.junit.Test;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/status/StatusFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/status/StatusFeatureTest.java
@@ -18,7 +18,7 @@
 
 package net.krotscheck.kangaroo.common.status;
 
-import net.krotscheck.kangaroo.test.KangarooJerseyTest;
+import net.krotscheck.kangaroo.test.jerseyTest.KangarooJerseyTest;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Assert;
 import org.junit.Test;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/status/StatusServiceTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/status/StatusServiceTest.java
@@ -18,7 +18,7 @@
 
 package net.krotscheck.kangaroo.common.status;
 
-import net.krotscheck.kangaroo.test.KangarooJerseyTest;
+import net.krotscheck.kangaroo.test.jerseyTest.KangarooJerseyTest;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Assert;
 import org.junit.Test;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/timedtasks/TimedTaskFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/timedtasks/TimedTaskFeatureTest.java
@@ -19,7 +19,7 @@
 package net.krotscheck.kangaroo.common.timedtasks;
 
 import net.krotscheck.kangaroo.common.status.StatusFeature;
-import net.krotscheck.kangaroo.test.KangarooJerseyTest;
+import net.krotscheck.kangaroo.test.jerseyTest.KangarooJerseyTest;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Assert;
 import org.junit.Test;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jerseyTest/ContainerTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jerseyTest/ContainerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Michael Krotscheck
+ * Copyright (c) 2017 Michael Krotscheck
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
@@ -16,7 +16,7 @@
  *
  */
 
-package net.krotscheck.kangaroo.test;
+package net.krotscheck.kangaroo.test.jerseyTest;
 
 import net.krotscheck.kangaroo.test.rule.ActiveSessions;
 import net.krotscheck.kangaroo.test.rule.DatabaseResource;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jerseyTest/DatabaseTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jerseyTest/DatabaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Michael Krotscheck
+ * Copyright (c) 2017 Michael Krotscheck
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
@@ -16,7 +16,7 @@
  *
  */
 
-package net.krotscheck.kangaroo.test;
+package net.krotscheck.kangaroo.test.jerseyTest;
 
 import net.krotscheck.kangaroo.test.rule.ActiveSessions;
 import net.krotscheck.kangaroo.test.rule.DatabaseResource;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jerseyTest/KangarooTestContainerFactory.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jerseyTest/KangarooTestContainerFactory.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.test.jerseyTest;
+
+import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.grizzly.servlet.WebappContext;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.filter.CsrfProtectionFilter;
+import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpContainer;
+import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.spi.TestContainer;
+import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
+import org.glassfish.jersey.test.spi.TestHelper;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.FilterRegistration;
+import javax.servlet.ServletRegistration;
+import javax.servlet.http.HttpServlet;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.core.UriBuilder;
+import java.io.IOException;
+import java.net.URI;
+import java.util.EnumSet;
+import java.util.EventListener;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * This container factory simulates, as closely as possible, a kangaroo
+ * deployment for the provided context.
+ *
+ * @author Michael Krotscheck
+ */
+public final class KangarooTestContainerFactory
+        implements TestContainerFactory {
+
+    /**
+     * Create a test container instance.
+     *
+     * @param baseUri base URI for the test container to run at.
+     * @param context deployment context of the tested JAX-RS / Jersey
+     *                application .
+     * @return New test container configured to run the tested application.
+     * @throws IllegalArgumentException if {@code deploymentContext} is not
+     *                                  supported by this test container
+     *                                  factory.
+     */
+    @Override
+    public TestContainer create(final URI baseUri,
+                                final DeploymentContext context) {
+        if (!(context instanceof ServletDeploymentContext)) {
+            throw new IllegalArgumentException("The deployment context must"
+                    + " be an instance of ServletDeploymentContext.");
+        }
+
+        return new KangarooTestContainer(baseUri,
+                (ServletDeploymentContext) context);
+    }
+
+    /**
+     * This class has methods for instantiating, starting and stopping a
+     * Grizzly-based web server.
+     */
+    private static final class KangarooTestContainer implements TestContainer {
+
+        /**
+         * Logger.
+         */
+        private static final Logger LOGGER =
+                Logger.getLogger(KangarooTestContainer.class.getName());
+
+        /**
+         * The deployment context for this container.
+         */
+        private final ServletDeploymentContext deploymentContext;
+
+        /**
+         * Base URI, provided during initialization.
+         */
+        private URI baseUri;
+
+        /**
+         * The constructed HTTP server.
+         */
+        private HttpServer server;
+
+        /**
+         * Create a new container.
+         *
+         * @param baseUri The base deployment URI.
+         * @param context The deployment context.
+         */
+        private KangarooTestContainer(final URI baseUri,
+                                      final ServletDeploymentContext context) {
+            this.baseUri = UriBuilder.fromUri(baseUri)
+                    .path(context.getContextPath())
+                    .path(context.getServletPath())
+                    .build();
+
+            LOGGER.info("Creating KangarooTestContainer configured"
+                    + " at the base URI "
+                    + TestHelper.zeroPortToAvailablePort(baseUri));
+
+            this.deploymentContext = context;
+            instantiateGrizzlyWebServer();
+        }
+
+        /**
+         * Get any custom client configuration needed for the kangaroo server.
+         *
+         * @return A client configuration.
+         */
+        @Override
+        public ClientConfig getClientConfig() {
+            ClientConfig c = new ClientConfig();
+            c.property(ClientProperties.FOLLOW_REDIRECTS, false);
+            c.register(CsrfProtectionFilter.class);
+            return c;
+        }
+
+        /**
+         * Return the BaseURI. Required by clients.
+         *
+         * @return The base uri.
+         */
+        @Override
+        public URI getBaseUri() {
+            return baseUri;
+        }
+
+        /**
+         * Start the container.
+         */
+        @Override
+        public void start() {
+            if (server.isStarted()) {
+                LOGGER.log(Level.WARNING, "Ignoring start request"
+                        + " - KangarooTestContainer is already started.");
+
+            } else {
+                LOGGER.log(Level.FINE, "Starting KangarooTestContainer...");
+                try {
+                    server.start();
+
+                    if (baseUri.getPort() == 0) {
+                        baseUri = UriBuilder.fromUri(baseUri)
+                                .port(server.getListener("grizzly")
+                                        .getPort())
+                                .build();
+                        LOGGER.log(Level.INFO, "Started KangarooTestContainer"
+                                + " at the base URI " + baseUri);
+                    }
+                } catch (final IOException ioe) {
+                    throw new TestContainerException(ioe);
+                }
+            }
+        }
+
+        /**
+         * Stop the container.
+         */
+        @Override
+        public void stop() {
+            if (server.isStarted()) {
+                LOGGER.log(Level.FINE, "Stopping KangarooTestContainer...");
+                this.server.shutdownNow();
+            } else {
+                LOGGER.log(Level.WARNING, "Ignoring stop request"
+                        + " - KangarooTestContainer is already stopped.");
+            }
+        }
+
+        /**
+         * Create a new instance of the Kangaroo Web Server.
+         */
+        private void instantiateGrizzlyWebServer() {
+
+            String contextPathLocal = deploymentContext.getContextPath();
+            if (!contextPathLocal.isEmpty()
+                    && !contextPathLocal.startsWith("/")) {
+                contextPathLocal = "/" + contextPathLocal;
+            }
+
+            String servletPathLocal = deploymentContext.getServletPath();
+            if (!servletPathLocal.startsWith("/")) {
+                servletPathLocal = "/" + servletPathLocal;
+            }
+            if (servletPathLocal.endsWith("/")) {
+                servletPathLocal += "*";
+            } else {
+                servletPathLocal += "/*";
+            }
+
+            final WebappContext context =
+                    new WebappContext("TestContext", contextPathLocal);
+
+            // Servlet class, and servlet instance can be both null, or
+            // one of them is specified exclusively.
+            final HttpServlet servletInstance =
+                    deploymentContext.getServletInstance();
+            final Class<? extends HttpServlet> servletClass =
+                    deploymentContext.getServletClass();
+
+            if (servletInstance != null || servletClass != null) {
+                final ServletRegistration registration;
+                if (servletInstance != null) {
+                    registration = context
+                            .addServlet(servletInstance.getClass().getName(),
+                                    servletInstance);
+                } else {
+                    registration = context.addServlet(servletClass.getName(),
+                            servletClass);
+                }
+                registration.setInitParameters(
+                        deploymentContext.getInitParams());
+                registration.addMapping(servletPathLocal);
+            }
+
+            for (final Class<? extends EventListener> eventListener
+                    : deploymentContext.getListeners()) {
+                context.addListener(eventListener);
+            }
+
+            final Map<String, String> contextParams =
+                    deploymentContext.getContextParams();
+            for (final String contextParamName : contextParams.keySet()) {
+                context.addContextInitParameter(contextParamName,
+                        contextParams.get(contextParamName));
+            }
+
+            // Filter support
+            if (deploymentContext.getFilters() != null) {
+                for (final ServletDeploymentContext.FilterDescriptor
+                        filterDescriptor : deploymentContext.getFilters()) {
+
+                    final FilterRegistration filterRegistration =
+                            context.addFilter(filterDescriptor.getFilterName(),
+                                    filterDescriptor.getFilterClass());
+
+                    filterRegistration.setInitParameters(
+                            filterDescriptor.getInitParams());
+                    filterRegistration.addMappingForUrlPatterns(
+                            grizzlyDispatcherTypes(filterDescriptor
+                                    .getDispatcherTypes()), true,
+                            servletPathLocal);
+                }
+            }
+
+            try {
+                server = GrizzlyHttpServerFactory.createHttpServer(baseUri,
+                        (GrizzlyHttpContainer) null,
+                        false,
+                        null,
+                        false);
+                context.deploy(server);
+            } catch (final ProcessingException ex) {
+                throw new TestContainerException(ex);
+            }
+        }
+
+        /**
+         * Recreate the dispatchers, so they're not reused.
+         *
+         * @param dispatcherTypes List of dispatchers.
+         * @return Same enumset, different instances.
+         */
+        private EnumSet<DispatcherType> grizzlyDispatcherTypes(
+                final Set<DispatcherType> dispatcherTypes) {
+            final Set<DispatcherType> grizzlyDispatcherTypes = new HashSet<>();
+            for (final javax.servlet.DispatcherType
+                    dispatcherType : dispatcherTypes) {
+                grizzlyDispatcherTypes
+                        .add(DispatcherType.valueOf(dispatcherType.name()));
+            }
+            return EnumSet.copyOf(grizzlyDispatcherTypes);
+        }
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jerseyTest/SingletonTestContainerFactory.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jerseyTest/SingletonTestContainerFactory.java
@@ -16,7 +16,7 @@
  *
  */
 
-package net.krotscheck.kangaroo.authz.admin.v1.test;
+package net.krotscheck.kangaroo.test.jerseyTest;
 
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.test.DeploymentContext;
@@ -39,14 +39,14 @@ import java.util.List;
 public class SingletonTestContainerFactory implements TestContainerFactory {
 
     /**
-     * The number of expected tests.
-     */
-    private int testCount = 0;
-
-    /**
      * Wrapped factory, used to generate instances if we don't have one yet.
      */
     private final TestContainerFactory defaultFactory;
+
+    /**
+     * The number of expected tests.
+     */
+    private int testCount = 0;
 
     /**
      * List of test containers that have been generated during this run.
@@ -73,26 +73,14 @@ public class SingletonTestContainerFactory implements TestContainerFactory {
     }
 
     /**
-     * Create a test container instance.
+     * This utility method extracts all methods annotated with a particular
+     * type. We use it to find all tests in a suite, so we know when to shut
+     * down the singleton.
      *
-     * @param baseUri           base URI for the test container to run at.
-     * @param deploymentContext deployment context of the tested JAX-RS / Jersey application .
-     * @return new test container configured to run the tested application.
-     * @throws IllegalArgumentException if {@code deploymentContext} is not supported
-     *                                  by this test container factory.
+     * @param type       The type to scan.
+     * @param annotation The annotation to look for.
+     * @return A list of all methods with this type.
      */
-    @Override
-    public TestContainer create(final URI baseUri,
-                                final DeploymentContext deploymentContext) {
-        if (currentContainer == null) {
-            TestContainer created = defaultFactory.create(baseUri,
-                    deploymentContext);
-            currentContainer = new SingletonTestContainer(created, testCount);
-        }
-
-        return currentContainer;
-    }
-
     public static List<Method> getMethodsAnnotatedWith(
             final Class<?> type,
             final Class<? extends Annotation> annotation) {
@@ -114,6 +102,27 @@ public class SingletonTestContainerFactory implements TestContainerFactory {
     }
 
     /**
+     * Create a test container instance.
+     *
+     * @param baseUri           base URI for the test container to run at.
+     * @param deploymentContext deployment context of the tested JAX-RS / Jersey application .
+     * @return new test container configured to run the tested application.
+     * @throws IllegalArgumentException if {@code deploymentContext} is not supported
+     *                                  by this test container factory.
+     */
+    @Override
+    public TestContainer create(final URI baseUri,
+                                final DeploymentContext deploymentContext) {
+        if (currentContainer == null) {
+            TestContainer created = defaultFactory.create(baseUri,
+                    deploymentContext);
+            currentContainer = new SingletonTestContainer(created, testCount);
+        }
+
+        return currentContainer;
+    }
+
+    /**
      * Wrapper test container, ensures that a container is only started once.
      */
     private static class SingletonTestContainer implements TestContainer {
@@ -122,21 +131,18 @@ public class SingletonTestContainerFactory implements TestContainerFactory {
          * How often are we expecting this container to be started?
          */
         private final int totalStartsExpected;
-
-        /**
-         * How often has this container been started?
-         */
-        private int startRequests = 0;
-
-        /**
-         * Have we already started this container?
-         */
-        private boolean started = false;
-
         /**
          * The wrapped testcontainer.
          */
         private final TestContainer wrapped;
+        /**
+         * How often has this container been started?
+         */
+        private int startRequests = 0;
+        /**
+         * Have we already started this container?
+         */
+        private boolean started = false;
 
         /**
          * Create a new SingletonTestContainer, wrapping an existing one.

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jerseyTest/package-info.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jerseyTest/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Explicit extensions of the Jersey test framework.
+ */
+package net.krotscheck.kangaroo.test.jerseyTest;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/runner/SingleInstanceTestRunner.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/runner/SingleInstanceTestRunner.java
@@ -27,7 +27,7 @@ import org.junit.runners.model.InitializationError;
  *
  * @author Michael Krotscheck
  */
-public class SingleInstanceTestRunner
+public final class SingleInstanceTestRunner
         extends BlockJUnit4ClassRunner {
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/AdminV1APITest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/AdminV1APITest.java
@@ -18,7 +18,7 @@
 
 package net.krotscheck.kangaroo.authz.admin;
 
-import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.jerseyTest.ContainerTest;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Assert;
 import org.junit.Test;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/OAuth2ScopeDynamicFeatureTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/OAuth2ScopeDynamicFeatureTest.java
@@ -27,7 +27,7 @@ import net.krotscheck.kangaroo.authz.common.database.DatabaseFeature;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.common.config.ConfigurationFeature;
 import net.krotscheck.kangaroo.common.exception.ExceptionFeature;
-import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.jerseyTest.ContainerTest;
 import net.krotscheck.kangaroo.test.HttpUtil;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Assert;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/OAuth2SecurityContextTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/OAuth2SecurityContextTest.java
@@ -21,7 +21,7 @@ package net.krotscheck.kangaroo.authz.admin.v1.auth;
 import net.krotscheck.kangaroo.authz.admin.v1.test.rule.TestDataResource;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
-import net.krotscheck.kangaroo.test.DatabaseTest;
+import net.krotscheck.kangaroo.test.jerseyTest.DatabaseTest;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/exception/WWWChallengeExceptionMapperTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/exception/WWWChallengeExceptionMapperTest.java
@@ -22,7 +22,7 @@ import com.google.common.net.HttpHeaders;
 import net.krotscheck.kangaroo.authz.admin.v1.auth.OAuth2AuthFeature;
 import net.krotscheck.kangaroo.common.exception.ExceptionFeature;
 import net.krotscheck.kangaroo.common.jackson.JacksonFeature;
-import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.jerseyTest.ContainerTest;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Assert;
 import org.junit.Test;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/filter/OAuth2AuthenticationFilterTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/auth/filter/OAuth2AuthenticationFilterTest.java
@@ -28,7 +28,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthTokenType;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
-import net.krotscheck.kangaroo.test.DatabaseTest;
+import net.krotscheck.kangaroo.test.jerseyTest.DatabaseTest;
 import net.krotscheck.kangaroo.test.HttpUtil;
 import net.krotscheck.kangaroo.test.rule.TestDataResource;
 import org.apache.commons.configuration.Configuration;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractResourceTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractResourceTest.java
@@ -28,7 +28,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.ClientRedirect;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientReferrer;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
-import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.jerseyTest.ContainerTest;
 import net.krotscheck.kangaroo.test.HttpUtil;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.lang3.StringUtils;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceBrowseTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceBrowseTest.java
@@ -18,7 +18,7 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
-import net.krotscheck.kangaroo.authz.admin.v1.test.SingletonTestContainerFactory;
+import net.krotscheck.kangaroo.test.jerseyTest.SingletonTestContainerFactory;
 import net.krotscheck.kangaroo.common.response.ApiParam;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceCRUDTest.java
@@ -19,7 +19,7 @@
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
 import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorType;
-import net.krotscheck.kangaroo.authz.admin.v1.test.SingletonTestContainerFactory;
+import net.krotscheck.kangaroo.test.jerseyTest.SingletonTestContainerFactory;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceSearchTest.java
@@ -18,7 +18,7 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
-import net.krotscheck.kangaroo.authz.admin.v1.test.SingletonTestContainerFactory;
+import net.krotscheck.kangaroo.test.jerseyTest.SingletonTestContainerFactory;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractSubserviceBrowseTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractSubserviceBrowseTest.java
@@ -18,7 +18,7 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
-import net.krotscheck.kangaroo.authz.admin.v1.test.SingletonTestContainerFactory;
+import net.krotscheck.kangaroo.test.jerseyTest.SingletonTestContainerFactory;
 import net.krotscheck.kangaroo.common.response.ApiParam;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractSubserviceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractSubserviceCRUDTest.java
@@ -18,13 +18,10 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
-import net.krotscheck.kangaroo.authz.admin.v1.test.SingletonTestContainerFactory;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
 import net.krotscheck.kangaroo.test.runner.ParameterizedSingleInstanceTestRunner.ParameterizedSingleInstanceTestRunnerFactory;
-import org.glassfish.jersey.test.spi.TestContainerException;
-import org.glassfish.jersey.test.spi.TestContainerFactory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/servlet/FirstRunContainerLifecycleListenerTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/servlet/FirstRunContainerLifecycleListenerTest.java
@@ -22,7 +22,7 @@ import net.krotscheck.kangaroo.authz.admin.v1.servlet.FirstRunContainerLifecycle
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.common.hibernate.config.HibernateConfiguration;
 import net.krotscheck.kangaroo.common.hibernate.migration.DatabaseMigrationState;
-import net.krotscheck.kangaroo.test.DatabaseTest;
+import net.krotscheck.kangaroo.test.jerseyTest.DatabaseTest;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.MapConfiguration;
 import org.glassfish.hk2.api.ActiveDescriptor;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/servlet/ServletConfigFactoryTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/servlet/ServletConfigFactoryTest.java
@@ -20,7 +20,7 @@ package net.krotscheck.kangaroo.authz.admin.v1.servlet;
 
 import net.krotscheck.kangaroo.authz.admin.v1.servlet.ServletConfigFactory.Binder;
 import net.krotscheck.kangaroo.common.hibernate.config.HibernateConfiguration;
-import net.krotscheck.kangaroo.test.DatabaseTest;
+import net.krotscheck.kangaroo.test.jerseyTest.DatabaseTest;
 import org.apache.commons.configuration.Configuration;
 import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.Factory;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/AuthenticatorFeatureTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/AuthenticatorFeatureTest.java
@@ -20,7 +20,7 @@ package net.krotscheck.kangaroo.authz.common.authenticator;
 
 import net.krotscheck.kangaroo.authz.common.database.DatabaseFeature;
 import net.krotscheck.kangaroo.common.hibernate.HibernateFeature;
-import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.jerseyTest.ContainerTest;
 import org.apache.http.HttpStatus;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.jersey.server.ResourceConfig;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/password/PasswordAuthenticatorTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/password/PasswordAuthenticatorTest.java
@@ -27,7 +27,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.UserIdentity;
 import net.krotscheck.kangaroo.authz.oauth2.exception.RFC6749.InvalidRequestException;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
-import net.krotscheck.kangaroo.test.DatabaseTest;
+import net.krotscheck.kangaroo.test.jerseyTest.DatabaseTest;
 import net.krotscheck.kangaroo.test.rule.TestDataResource;
 import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.ServiceLocator;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/test/TestAuthenticatorTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/test/TestAuthenticatorTest.java
@@ -26,7 +26,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
 import net.krotscheck.kangaroo.authz.common.database.entity.UserIdentity;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
-import net.krotscheck.kangaroo.test.DatabaseTest;
+import net.krotscheck.kangaroo.test.jerseyTest.DatabaseTest;
 import net.krotscheck.kangaroo.test.rule.TestDataResource;
 import org.glassfish.hk2.api.ActiveDescriptor;
 import org.glassfish.hk2.api.ServiceLocator;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/cors/AuthzCORSFeatureTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/cors/AuthzCORSFeatureTest.java
@@ -25,7 +25,7 @@ import net.krotscheck.kangaroo.authz.admin.v1.test.rule.TestDataResource;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
 import net.krotscheck.kangaroo.common.response.ApiParam;
-import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.jerseyTest.ContainerTest;
 import net.krotscheck.kangaroo.test.HttpUtil;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Assert;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/cors/HibernateCORSCacheLoaderTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/cors/HibernateCORSCacheLoaderTest.java
@@ -19,7 +19,7 @@
 package net.krotscheck.kangaroo.authz.common.cors;
 
 import net.krotscheck.kangaroo.authz.admin.v1.test.rule.TestDataResource;
-import net.krotscheck.kangaroo.test.DatabaseTest;
+import net.krotscheck.kangaroo.test.jerseyTest.DatabaseTest;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/DatabaseFeatureTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/DatabaseFeatureTest.java
@@ -19,7 +19,7 @@
 package net.krotscheck.kangaroo.authz.common.database;
 
 import net.krotscheck.kangaroo.common.hibernate.listener.CreatedUpdatedListener;
-import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.jerseyTest.ContainerTest;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.hibernate.event.spi.PreInsertEventListener;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/OAuthAPITest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/OAuthAPITest.java
@@ -18,7 +18,7 @@
 package net.krotscheck.kangaroo.authz.oauth2;
 
 import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder.ErrorResponse;
-import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.jerseyTest.ContainerTest;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Assert;
 import org.junit.Test;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/filter/ClientAuthorizationFilterTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/filter/ClientAuthorizationFilterTest.java
@@ -27,7 +27,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.Client;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
 import net.krotscheck.kangaroo.authz.oauth2.annotation.OAuthFilterChain;
 import net.krotscheck.kangaroo.authz.oauth2.factory.CredentialsFactory.Credentials;
-import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.jerseyTest.ContainerTest;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.hibernate.Session;
 import org.junit.After;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/resource/AuthorizationServiceTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/resource/AuthorizationServiceTest.java
@@ -23,7 +23,7 @@ import net.krotscheck.kangaroo.authz.oauth2.OAuthAPI;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
 import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder.ErrorResponse;
-import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.jerseyTest.ContainerTest;
 import net.krotscheck.kangaroo.test.HttpUtil;
 import net.krotscheck.kangaroo.test.rule.TestDataResource;
 import org.glassfish.jersey.server.ResourceConfig;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/resource/TokenServiceTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/resource/TokenServiceTest.java
@@ -24,7 +24,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.OAuthTokenType;
 import net.krotscheck.kangaroo.authz.oauth2.OAuthAPI;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
-import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.jerseyTest.ContainerTest;
 import net.krotscheck.kangaroo.test.rule.TestDataResource;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.hibernate.Session;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/resource/grant/ClientCredentialsGrantHandlerTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/resource/grant/ClientCredentialsGrantHandlerTest.java
@@ -25,7 +25,7 @@ import net.krotscheck.kangaroo.authz.oauth2.resource.TokenResponseEntity;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
 import net.krotscheck.kangaroo.common.exception.KangarooException;
-import net.krotscheck.kangaroo.test.DatabaseTest;
+import net.krotscheck.kangaroo.test.jerseyTest.DatabaseTest;
 import net.krotscheck.kangaroo.test.rule.TestDataResource;
 import org.hibernate.Session;
 import org.junit.Assert;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/resource/grant/RefreshTokenGrantHandlerTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/resource/grant/RefreshTokenGrantHandlerTest.java
@@ -28,7 +28,7 @@ import net.krotscheck.kangaroo.authz.oauth2.exception.RFC6749.InvalidScopeExcept
 import net.krotscheck.kangaroo.authz.oauth2.resource.TokenResponseEntity;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
-import net.krotscheck.kangaroo.test.DatabaseTest;
+import net.krotscheck.kangaroo.test.jerseyTest.DatabaseTest;
 import net.krotscheck.kangaroo.test.rule.TestDataResource;
 import org.hibernate.Session;
 import org.junit.Assert;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/AbstractRFC6749Test.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/AbstractRFC6749Test.java
@@ -18,7 +18,7 @@
 package net.krotscheck.kangaroo.authz.oauth2.rfc6749;
 
 import net.krotscheck.kangaroo.authz.oauth2.OAuthAPI;
-import net.krotscheck.kangaroo.test.ContainerTest;
+import net.krotscheck.kangaroo.test.jerseyTest.ContainerTest;
 import org.glassfish.jersey.server.ResourceConfig;
 
 /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/tasks/TokenCleanupTaskTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/tasks/TokenCleanupTaskTest.java
@@ -23,7 +23,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthTokenType;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
-import net.krotscheck.kangaroo.test.DatabaseTest;
+import net.krotscheck.kangaroo.test.jerseyTest.DatabaseTest;
 import net.krotscheck.kangaroo.test.rule.TestDataResource;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;


### PR DESCRIPTION
This patch makes a variety of updates to our test framework, so we can
more closely simulate a "real" deployment of the kangaroo servlet deployment.
These include:
- KangarooJerseyTest now deploys the test context into a grizzly servlet container.
- Created new package for jerseyTest related classes.
- Moved singleton test container into kangaroo-common.