### PR TITLE
CredentialsFactory is now per-request, not singleton.

### DIFF
--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/factory/CredentialsFactory.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/factory/CredentialsFactory.java
@@ -23,19 +23,19 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.glassfish.hk2.api.Factory;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.glassfish.jersey.process.internal.RequestScoped;
 import org.glassfish.jersey.server.ContainerRequest;
 
-import java.nio.charset.Charset;
-import java.util.Base64;
-import java.util.List;
-import java.util.UUID;
 import javax.inject.Inject;
 import javax.inject.Provider;
-import javax.inject.Singleton;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.Form;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MultivaluedMap;
+import java.nio.charset.Charset;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
 
 /**
  * This factory attempts to determine the current client credentials
@@ -284,7 +284,7 @@ public final class CredentialsFactory implements Factory<Credentials> {
         protected void configure() {
             bindFactory(CredentialsFactory.class)
                     .to(Credentials.class)
-                    .in(Singleton.class);
+                    .in(RequestScoped.class);
         }
     }
 }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/AbstractRFC6749Test.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/AbstractRFC6749Test.java
@@ -17,9 +17,16 @@
 
 package net.krotscheck.kangaroo.authz.oauth2.rfc6749;
 
+import net.krotscheck.kangaroo.authz.admin.AdminV1API;
+import net.krotscheck.kangaroo.authz.common.authenticator.test.TestAuthenticator;
 import net.krotscheck.kangaroo.authz.oauth2.OAuthAPI;
 import net.krotscheck.kangaroo.test.jerseyTest.ContainerTest;
+import net.krotscheck.kangaroo.test.jerseyTest.SingletonTestContainerFactory;
+import net.krotscheck.kangaroo.test.runner.SingleInstanceTestRunner;
 import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
+import org.junit.runner.RunWith;
 
 /**
  * Abstract testing class that bootstraps a full OAuthAPI that's ready for
@@ -28,15 +35,51 @@ import org.glassfish.jersey.server.ResourceConfig;
  * @author Michael Krotscheck
  * @see <a href="https://tools.ietf.org/html/rfc6749#section-2.3">https://tools.ietf.org/html/rfc6749#section-2.3</a>
  */
+@RunWith(SingleInstanceTestRunner.class)
 public abstract class AbstractRFC6749Test extends ContainerTest {
 
     /**
-     * Create a small dummy app to test against.
+     * Test container factory.
+     */
+    private SingletonTestContainerFactory testContainerFactory;
+
+    /**
+     * This method overrides the underlying default test container provider,
+     * with one that provides a singleton instance. This allows us to
+     * circumvent the often expensive initialization routines that come from
+     * bootstrapping our services.
      *
-     * @return The constructed application.
+     * @return an instance of {@link TestContainerFactory} class.
+     * @throws TestContainerException if the initialization of
+     *                                {@link TestContainerFactory} instance
+     *                                is not successful.
+     */
+    protected TestContainerFactory getTestContainerFactory()
+            throws TestContainerException {
+        if (this.testContainerFactory == null) {
+            this.testContainerFactory =
+                    new SingletonTestContainerFactory(
+                            super.getTestContainerFactory(),
+                            this.getClass());
+        }
+        return testContainerFactory;
+    }
+
+    /**
+     * The current running test application.
+     */
+    private ResourceConfig testApplication;
+
+    /**
+     * Create the application under test.
+     *
+     * @return A configured api servlet.
      */
     @Override
     protected final ResourceConfig createApplication() {
-        return new OAuthAPI();
+        if (testApplication == null) {
+            testApplication = new OAuthAPI();
+        }
+        return testApplication;
     }
 }


### PR DESCRIPTION
In other words, the second and nth request no longer authenticate
based on the credentials resolved by the first.