### PR TITLE
Created BigIntegerType

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/type/BigIntegerType.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/type/BigIntegerType.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate.type;
+
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.usertype.UserType;
+
+import java.io.Serializable;
+import java.math.BigInteger;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * Custom hibernate type that permits storing URI's into varchar columns.
+ *
+ * @author Michael Krotscheck
+ */
+public final class BigIntegerType implements UserType {
+
+    /**
+     * Return the SQL type codes for the columns mapped by this type. The
+     * codes are defined on <tt>java.sql.Types</tt>.
+     *
+     * @return int[] the typecodes
+     * @see Types
+     */
+    @Override
+    public int[] sqlTypes() {
+        return new int[]{Types.BINARY};
+    }
+
+    /**
+     * The class returned by <tt>nullSafeGet()</tt>.
+     *
+     * @return Class
+     */
+    @Override
+    public Class returnedClass() {
+        return BigInteger.class;
+    }
+
+    /**
+     * Compare two instances of the class mapped by this type for persistence
+     * "equality". Equality of the persistent state.
+     *
+     * @param x Left
+     * @param y Right
+     * @return boolean True if they are equal.
+     */
+    @Override
+    public boolean equals(final Object x,
+                          final Object y) throws HibernateException {
+        if (x == null) {
+            return y == null;
+        }
+        return x.equals(y);
+    }
+
+    /**
+     * Get a hashcode for the instance, consistent with persistence "equality".
+     *
+     * @param x The object to hash.
+     */
+    @Override
+    public int hashCode(final Object x) throws HibernateException {
+        return x.hashCode();
+    }
+
+    /**
+     * Retrieve an instance of the mapped class from a JDBC resultset.
+     * Implementors should handle possibility of null values.
+     *
+     * @param rs      A JDBC result set
+     * @param names   The column names
+     * @param session The session implementation.
+     * @param owner   the containing entity  @return Object
+     * @throws HibernateException Thrown if hibernate throws up.
+     * @throws SQLException       Thrown if the type is not mapped properly.
+     */
+    @Override
+    public Object nullSafeGet(final ResultSet rs,
+                              final String[] names,
+                              final SharedSessionContractImplementor session,
+                              final Object owner)
+            throws HibernateException, SQLException {
+        // Read the value as a string, so we can check for null.
+        byte[] idAsBytes = rs.getBytes(names[0]);
+        if (idAsBytes == null) {
+            return null;
+        }
+        return new BigInteger(idAsBytes);
+    }
+
+    /**
+     * Write an instance of the mapped class to a prepared statement.
+     * Implementors should handle possibility of null values. A multi-column
+     * type should be written to parameters starting from <tt>index</tt>.
+     *
+     * @param st      A JDBC prepared statement.
+     * @param value   The object to write.
+     * @param index   Statement parameter index.
+     * @param session The session implementation.
+     * @throws HibernateException Thrown if hibernate throws up.
+     * @throws SQLException       Thrown if the type is not mapped properly.
+     */
+    @Override
+    public void nullSafeSet(final PreparedStatement st,
+                            final Object value,
+                            final int index,
+                            final SharedSessionContractImplementor session)
+            throws HibernateException, SQLException {
+        if (value != null) {
+            BigInteger bigInteger = (BigInteger) value;
+            st.setBytes(index, bigInteger.toByteArray());
+        } else {
+            st.setNull(index, Types.BINARY);
+        }
+    }
+
+    /**
+     * Return a deep copy of the persistent state, stopping at entities and at
+     * collections. It is not necessary to copy immutable objects, or null
+     * values, in which case it is safe to simply return the argument.
+     *
+     * @param value the object to be cloned, which may be null
+     * @return Object a copy
+     */
+    @Override
+    public Object deepCopy(final Object value) throws HibernateException {
+        return value;
+    }
+
+    /**
+     * Are objects of this type mutable?
+     *
+     * @return boolean
+     */
+    @Override
+    public boolean isMutable() {
+        return false;
+    }
+
+    /**
+     * Transform the object into its cacheable representation. At the very
+     * least this method should perform a deep copy if the type is mutable.
+     * That may not be enough for some implementations, however; for example,
+     * associations must be cached as identifier values. (optional operation)
+     *
+     * @param value The object to be cached
+     * @return A cachable representation of the object
+     * @throws HibernateException Thrown if hibernate throws up.
+     */
+    @Override
+    public Serializable disassemble(final Object value)
+            throws HibernateException {
+        BigInteger bigInteger = (BigInteger) value;
+        return bigInteger.toString(16);
+    }
+
+    /**
+     * Reconstruct an object from the cacheable representation. At the very
+     * least this method should perform a deep copy if the type is mutable.
+     * (optional operation)
+     *
+     * @param cached The object to be cached.
+     * @param owner  The owner of the cached object.
+     * @return A reconstructed object from the cachable representation.
+     * @throws HibernateException Thrown if hibernate throws up.
+     */
+    @Override
+    public Object assemble(final Serializable cached,
+                           final Object owner) throws HibernateException {
+        String radixBigint = cached.toString();
+        return new BigInteger(radixBigint, 16);
+    }
+
+    /**
+     * During merge, replace the existing (target) value in the entity we are
+     * merging to with a new (original) value from the detached entity we are
+     * merging. For immutable objects, or null values, it is safe to simply
+     * return the first parameter. For mutable objects, it is safe to return
+     * a copy of the first parameter. For objects with component values, it
+     * might make sense to recursively replace component values.
+     *
+     * @param original the value from the detached entity being merged.
+     * @param target   the value in the managed entity.
+     * @param owner    The owning entity.
+     * @return the value to be merged
+     */
+    @Override
+    public Object replace(final Object original,
+                          final Object target,
+                          final Object owner)
+            throws HibernateException {
+        return original;
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/type/BigIntegerTypeTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/type/BigIntegerTypeTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate.type;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.math.BigInteger;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Types;
+import java.util.Random;
+
+import static org.mockito.Mockito.times;
+
+/**
+ * Unit test for the Bigint-to-byte[] field converter.
+ *
+ * @author Michael Krotscheck
+ */
+public class BigIntegerTypeTest {
+
+    /**
+     * Random byte generator.
+     */
+    private static final Random RND = new Random();
+
+    /**
+     * Assert that we map to the correct types.
+     */
+    @Test
+    public void sqlTypes() {
+        BigIntegerType type = new BigIntegerType();
+
+        int[] types = type.sqlTypes();
+        Assert.assertEquals(1, types.length);
+        Assert.assertEquals(Types.BINARY, types[0]);
+    }
+
+    /**
+     * Assert that the converted type is a BigInteger.
+     */
+    @Test
+    public void returnedClass() {
+        BigIntegerType type = new BigIntegerType();
+
+        Assert.assertEquals(BigInteger.class, type.returnedClass());
+    }
+
+    /**
+     * Assert that comparison works.
+     */
+    @Test
+    public void equals() {
+        BigIntegerType type = new BigIntegerType();
+
+        BigInteger one = new BigInteger(16, RND);
+        BigInteger two = new BigInteger(one.toByteArray());
+        BigInteger three = new BigInteger(16, RND);
+
+        // Basic comparison
+        Assert.assertTrue(type.equals(one, two));
+        Assert.assertFalse(type.equals(three, two));
+        Assert.assertFalse(type.equals(two, three));
+        Assert.assertTrue(type.equals(null, null));
+        Assert.assertFalse(type.equals(null, two));
+        Assert.assertFalse(type.equals(two, null));
+    }
+
+    /**
+     * Assert that hashcode is passed through to the underlying instance.
+     */
+    @Test
+    public void testHashCode() {
+        BigIntegerType type = new BigIntegerType();
+
+        BigInteger one = new BigInteger(16, RND);
+        Assert.assertEquals(one.hashCode(), type.hashCode(one));
+    }
+
+    /**
+     * Assert that we can retrieve the BigInteger.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void nullSafeGet() throws Exception {
+        BigIntegerType type = new BigIntegerType();
+        String[] names = new String[]{"test"};
+        ResultSet rs = Mockito.mock(ResultSet.class);
+
+        BigInteger one = new BigInteger(16, RND);
+        Mockito.doReturn(one.toByteArray()).when(rs).getBytes(names[0]);
+        BigInteger result = (BigInteger)
+                type.nullSafeGet(rs, names, null, null);
+
+        Assert.assertEquals(one, result);
+    }
+
+    /**
+     * Assert that a null value returns null.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void nullSafeGetNull() throws Exception {
+        BigIntegerType type = new BigIntegerType();
+        String[] names = new String[]{"test"};
+        ResultSet rs = Mockito.mock(ResultSet.class);
+        Mockito.doReturn(null).when(rs).getString(names[0]);
+        BigInteger result = (BigInteger)
+                type.nullSafeGet(rs, names, null, null);
+
+        Assert.assertNull(result);
+    }
+
+    /**
+     * Assert that we can set a value.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void nullSafeSet() throws Exception {
+        BigIntegerType type = new BigIntegerType();
+        PreparedStatement st = Mockito.mock(PreparedStatement.class);
+        BigInteger one = new BigInteger(16, RND);
+        type.nullSafeSet(st, one, 0, null);
+        Mockito.verify(st, times(1))
+                .setBytes(0, one.toByteArray());
+    }
+
+    /**
+     * Assert that setting with a null value sets null.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void nullSafeSetNull() throws Exception {
+        BigIntegerType type = new BigIntegerType();
+        PreparedStatement st = Mockito.mock(PreparedStatement.class);
+        type.nullSafeSet(st, null, 0, null);
+        Mockito.verify(st, times(1)).setNull(0, Types.BINARY);
+    }
+
+    /**
+     * Assert that deepCopy returns the same (immutable) instance.
+     */
+    @Test
+    public void deepCopy() {
+        BigIntegerType type = new BigIntegerType();
+        BigInteger one = new BigInteger(16, RND);
+        Assert.assertSame(one, type.deepCopy(one));
+    }
+
+    /**
+     * Assert that ismutable is false.
+     */
+    @Test
+    public void isMutable() {
+        BigIntegerType type = new BigIntegerType();
+        Assert.assertFalse(type.isMutable());
+    }
+
+    /**
+     * Assert that a BigInteger is disassembled into a long.
+     */
+    @Test
+    public void disassemble() {
+        BigIntegerType type = new BigIntegerType();
+
+        BigInteger one = new BigInteger(16, RND);
+        String result = (String) type.disassemble(one);
+        Assert.assertEquals(one.toString(16), result);
+    }
+
+    /**
+     * Assert that a long can be converted into a BigInteger.
+     */
+    @Test
+    public void assemble() {
+        BigIntegerType type = new BigIntegerType();
+
+        BigInteger one = new BigInteger(16, RND);
+        BigInteger result = (BigInteger) type.assemble(one.toString(16),
+                null);
+        Assert.assertTrue(one.equals(result));
+    }
+
+    /**
+     * This type is immutable, replace should only return the first response.
+     */
+    @Test
+    public void replace() {
+        BigIntegerType type = new BigIntegerType();
+
+        BigInteger one = new BigInteger(16, RND);
+        BigInteger two = new BigInteger(16, RND);
+        BigInteger result = (BigInteger) type.replace(one, two, null);
+
+        Assert.assertSame(one, result);
+    }
+
+}


### PR DESCRIPTION
This type annotation permits storing Java BigIntegers into binary fields,
potentially as unique ID's.