### PR TITLE
Created HttpSession entity

### DIFF
--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/HttpSession.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/HttpSession.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.common.database.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.commons.lang3.NotImplementedException;
+import org.glassfish.grizzly.http.server.Session;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.hibernate.annotations.Parameter;
+import org.hibernate.annotations.Type;
+
+import javax.persistence.Basic;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+import java.util.TimeZone;
+
+/**
+ * This hibernate entity describes an HTTP session that maintains 'refresh
+ * token' references on behalf of the user. It's used to permit renewing a
+ * user's token, without forcing them to log in multiple times.
+ *
+ * @author Michael Krotscheck
+ */
+@Entity
+@Table(name = "http_sessions")
+public final class HttpSession extends Session {
+
+    /**
+     * A 64-byte id that identifies this particular session.
+     */
+    @Id
+    @Type(type = "net.krotscheck.kangaroo.common.hibernate.type"
+            + ".BigIntegerType")
+    @GenericGenerator(name = "secure_random_bytes",
+            parameters = @Parameter(name = "byteCount", value = "64"),
+            strategy = "net.krotscheck.kangaroo.authz.common.database.util"
+                    + ".SecureRandomIdGenerator")
+    @GeneratedValue(generator = "secure_random_bytes")
+    @Column(name = "id", unique = true, nullable = false, updatable = false)
+    private BigInteger id = null;
+
+    /**
+     * OAuth tokens attached to this session.
+     */
+    @OneToMany(
+            fetch = FetchType.LAZY,
+            mappedBy = "httpSession",
+            cascade = {CascadeType.REMOVE, CascadeType.MERGE},
+            orphanRemoval = true
+    )
+    @JsonIgnore
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private List<OAuthToken> refreshTokens = new ArrayList<>();
+
+    /**
+     * The date this record was created.
+     */
+    @Column(name = "creationTime")
+    @Type(type = "net.krotscheck.kangaroo.common.hibernate.type"
+            + ".CalendarTimestampType")
+    private Calendar creationTime =
+            Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+
+    /**
+     * Is this session new.
+     */
+    @Transient
+    private boolean isNew = false;
+
+    /**
+     * Timeout.
+     */
+    @Basic(optional = false)
+    @Column(name = "sessionTimeout", nullable = false)
+    private long sessionTimeout = -1;
+
+    /**
+     * Last accessed timestamp.
+     */
+    @Column(name = "timestamp")
+    @Type(type = "net.krotscheck.kangaroo.common.hibernate.type"
+            + ".CalendarTimestampType")
+    private Calendar timestamp =
+            Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+
+    /**
+     * Create a new session instance.
+     */
+    public HttpSession() {
+        super();
+    }
+
+    /**
+     * Is the current Session valid?
+     *
+     * @return true if valid.
+     */
+    @Override
+    @Transient
+    @JsonIgnore
+    public boolean isValid() {
+        Calendar now = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        Calendar expireDate = (Calendar) timestamp.clone();
+        expireDate.add(Calendar.SECOND,
+                ((Long) getSessionTimeout()).intValue());
+        return now.before(expireDate);
+    }
+
+    /**
+     * Set this object as validated.
+     *
+     * @param isValid
+     */
+    @Override
+    public void setValid(final boolean isValid) {
+        Calendar now = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        if (!isValid) {
+            now.add(Calendar.SECOND, -((Long) getSessionTimeout()).intValue());
+            setTimestamp(now.getTimeInMillis());
+        } else {
+            this.setTimestamp(now.getTimeInMillis());
+        }
+    }
+
+    /**
+     * Returns <code>true</code> if the client does not yet know about the
+     * session or if the client chooses not to join the session.  For
+     * example, if the server used only cookie-based sessions, and
+     * the client had disabled the use of cookies, then a session would
+     * be new on each request.
+     *
+     * @return <code>true</code> if the
+     * server has created a session,
+     * but the client has not yet joined
+     */
+    @Override
+    public boolean isNew() {
+        return isNew;
+    }
+
+    /**
+     * Set whether the browser already knows about this session.
+     *
+     * @param isNew Whether the session is new.
+     */
+    public void setNew(final boolean isNew) {
+        this.isNew = isNew;
+    }
+
+    /**
+     * Add an attribute to this session. This is a no-op, as the system only
+     * permits attaching refresh tokens to the session.
+     *
+     * @param key   The key.
+     * @param value The value.
+     */
+    @Override
+    public void setAttribute(final String key, final Object value) {
+        throw new NotImplementedException("Please use setRefreshTokens");
+    }
+
+    /**
+     * Return an attribute. This is a no-op, please access the collection
+     * directly.
+     *
+     * @param key The key to check.
+     * @return Always null.
+     */
+    @Override
+    public Object getAttribute(final String key) {
+        throw new NotImplementedException("Please use getRefreshTokens");
+    }
+
+    /**
+     * Remove an attribute. This is a no-op, please access the collection
+     * directly.
+     *
+     * @param key The key to remove.
+     * @return Always false.
+     */
+    @Override
+    public Object removeAttribute(final String key) {
+        throw new NotImplementedException("Please use getRefreshTokens");
+    }
+
+    /**
+     * Returns the time when this session was created, measured
+     * in milliseconds since midnight January 1, 1970 GMT.
+     *
+     * @return a <code>long</code> specifying when this session was created,
+     * expressed in  milliseconds since 1/1/1970 GMT
+     */
+    @Override
+    public long getCreationTime() {
+        return creationTime.getTimeInMillis();
+    }
+
+    /**
+     * Set the creation time for this session.
+     *
+     * @param creationTime The new creation time, expressed in milliseconds GMT.
+     */
+    public void setCreationTime(final long creationTime) {
+        this.creationTime.setTimeInMillis(creationTime);
+    }
+
+    /**
+     * Return a long representing the maximum idle time (in milliseconds) a
+     * session can be.
+     *
+     * @return a long representing the maximum idle time (in milliseconds) a
+     * session can be.
+     */
+    @Override
+    public long getSessionTimeout() {
+        return sessionTimeout;
+    }
+
+    /**
+     * Set a long representing the maximum idle time (in milliseconds) a
+     * session can be.
+     *
+     * @param sessionTimeout a long representing the maximum idle time
+     *                       (in milliseconds) a session can be.
+     */
+    @Override
+    public void setSessionTimeout(final long sessionTimeout) {
+        this.sessionTimeout = sessionTimeout;
+    }
+
+    /**
+     * @return the timestamp when this session was accessed the last time
+     */
+    @Override
+    public long getTimestamp() {
+        return timestamp.getTimeInMillis();
+    }
+
+    /**
+     * Set the timestamp when this session was accessed the last time.
+     *
+     * @param timestamp a long representing when the session was accessed the
+     *                  last time
+     */
+    @Override
+    public void setTimestamp(final long timestamp) {
+        this.timestamp.setTimeInMillis(timestamp);
+    }
+
+    /**
+     * Return a {@link List} of refreshTokens.
+     *
+     * @return the refresh tokens associated with this session.
+     */
+    public List<OAuthToken> getRefreshTokens() {
+        return refreshTokens;
+    }
+
+    /**
+     * Set the list of tokens.
+     *
+     * @param refreshTokens The refresh tokens attached to this session.
+     */
+    public void setRefreshTokens(final List<OAuthToken> refreshTokens) {
+        this.refreshTokens = new ArrayList<>(refreshTokens);
+    }
+
+    /**
+     * Set the ID.
+     *
+     * @return The ID for this session.
+     */
+    public BigInteger getId() {
+        return id;
+    }
+
+    /**
+     * Get the ID.
+     *
+     * @param id The ID for this session.
+     */
+    public void setId(final BigInteger id) {
+        this.id = id;
+    }
+
+    /**
+     * @return the session identifier for this session.
+     */
+    @Override
+    @Transient
+    public String getIdInternal() {
+        return id.toString(16);
+    }
+
+    /**
+     * Updates the "last accessed" timestamp with the current time.
+     *
+     * @return the time stamp
+     */
+    @Override
+    @Transient
+    public long access() {
+        final long localTimeStamp = System.currentTimeMillis();
+        timestamp.setTimeInMillis(localTimeStamp);
+        isNew = false;
+        return localTimeStamp;
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/OAuthToken.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/OAuthToken.java
@@ -103,6 +103,19 @@ public final class OAuthToken extends AbstractAuthzEntity implements Principal {
     private OAuthToken authToken;
 
     /**
+     * The HTTP session that contains this token, usually only used for
+     * refresh tokens.
+     */
+    @ManyToOne(
+            fetch = FetchType.LAZY,
+            cascade = {CascadeType.REMOVE, CascadeType.MERGE}
+    )
+    @JoinColumn(name = "httpSession", nullable = true, updatable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JsonIgnore
+    private HttpSession httpSession;
+
+    /**
      * The token type.
      */
     @Enumerated(EnumType.STRING)
@@ -141,6 +154,24 @@ public final class OAuthToken extends AbstractAuthzEntity implements Principal {
     @MapKey(name = "name")
     @SortNatural
     private SortedMap<String, ApplicationScope> scopes = new TreeMap<>();
+
+    /**
+     * Get the attached HTTP Session.
+     *
+     * @return The http session.
+     */
+    public HttpSession getHttpSession() {
+        return httpSession;
+    }
+
+    /**
+     * Set the attached HTTP Session.
+     *
+     * @param httpSession The http session.
+     */
+    public void setHttpSession(final HttpSession httpSession) {
+        this.httpSession = httpSession;
+    }
 
     /**
      * Get the user identity to which this token was issued.

--- a/kangaroo-server-authz/src/main/resources/hibernate.cfg.xml
+++ b/kangaroo-server-authz/src/main/resources/hibernate.cfg.xml
@@ -68,6 +68,7 @@
     <mapping class="net.krotscheck.kangaroo.authz.common.database.entity.Role"/>
     <mapping class="net.krotscheck.kangaroo.authz.common.database.entity.User"/>
     <mapping class="net.krotscheck.kangaroo.authz.common.database.entity.UserIdentity"/>
+    <mapping class="net.krotscheck.kangaroo.authz.common.database.entity.HttpSession"/>
 
     <mapping class="net.krotscheck.kangaroo.common.hibernate.entity.ConfigurationEntry"/>
 

--- a/kangaroo-server-authz/src/main/resources/liquibase/db.changelog-authz-1.0.0.yaml
+++ b/kangaroo-server-authz/src/main/resources/liquibase/db.changelog-authz-1.0.0.yaml
@@ -55,6 +55,29 @@ databaseChangeLog:
           constraintName: uq_configuration_section_configKey
           tableName: configuration
 
+      # The HTTP Browser Session table.
+      - createTable:
+          tableName: http_sessions
+          columns:
+            - column:
+                name: id
+                type: BINARY(64)
+                constraints:
+                  primaryKey: true
+                  nullable: false
+                  primaryKeyName: pk_http_sessions_id
+            - column:
+                name: creationTime
+                type: bigint
+            - column:
+                name: timestamp
+                type: bigint
+            - column:
+                name: sessionTimeout
+                type: int
+                constraints:
+                  nullable: false
+
       # The Application table, the root resource from which everything else
       # is derived.
       - createTable:
@@ -805,6 +828,11 @@ databaseChangeLog:
                 constraints:
                   nullable: true
             - column:
+                name: httpSession
+                type: BINARY(64)
+                constraints:
+                  nullable: true
+            - column:
                 name: client
                 type: BINARY(16)
                 constraints:
@@ -848,6 +876,14 @@ databaseChangeLog:
           onUpdate: CASCADE
           referencedColumnNames: id
           referencedTableName: oauth_tokens
+      - addForeignKeyConstraint:
+          baseColumnNames: httpSession
+          baseTableName: oauth_tokens
+          constraintName: fk_oauth_tokens_http_sessions_httpSession
+          onDelete: SET NULL
+          onUpdate: CASCADE
+          referencedColumnNames: id
+          referencedTableName: http_sessions
 
       # OAuth Tokens have a limited list of scopes.
       - createTable:
@@ -937,5 +973,7 @@ databaseChangeLog:
             tableName: application_scopes
         - dropTable:
             tableName: applications
+        - dropTable:
+            tableName: http_sessions
         - dropTable:
             tableName: configuration

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/HttpSessionTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/HttpSessionTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.common.database.entity;
+
+import net.krotscheck.kangaroo.test.jerseyTest.DatabaseTest;
+import org.apache.commons.lang3.NotImplementedException;
+import org.hibernate.Session;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+import java.util.TimeZone;
+
+/**
+ * Assert that the HTTP session data is sanely persisted.
+ *
+ * @author Michael Krotscheck
+ */
+public final class HttpSessionTest extends DatabaseTest {
+
+    /**
+     * Assert that simple database persistence is possible.
+     */
+    @Test
+    public void testSimplePersistence() {
+        HttpSession httpSession = new HttpSession();
+        httpSession.setCreationTime(1000);
+
+        Assert.assertEquals(-1, httpSession.getSessionTimeout());
+        httpSession.setSessionTimeout(1000);
+
+        httpSession.setTimestamp(2000);
+
+        Assert.assertNull(httpSession.getId());
+
+        Session s = getSession();
+        s.beginTransaction();
+        s.save(httpSession);
+        s.getTransaction().commit();
+
+        Assert.assertNotNull(httpSession.getId());
+        Assert.assertEquals(httpSession.getIdInternal(),
+                httpSession.getId().toString(16));
+        Assert.assertEquals(1000, httpSession.getCreationTime());
+        Assert.assertEquals(1000, httpSession.getSessionTimeout());
+        Assert.assertEquals(2000, httpSession.getTimestamp());
+    }
+
+    /**
+     * Assert that modifying the isValid parameter works as expected.
+     */
+    @Test
+    public void testIsValid() {
+        Calendar now = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        now.add(Calendar.SECOND, -500);
+
+        HttpSession httpSession = new HttpSession();
+        httpSession.setCreationTime(now.getTimeInMillis());
+        httpSession.setTimestamp(now.getTimeInMillis());
+        httpSession.setSessionTimeout(1000);
+
+        Assert.assertTrue(httpSession.isValid());
+
+        httpSession.setValid(false);
+        Assert.assertFalse(httpSession.isValid());
+
+        httpSession.setValid(true);
+        Assert.assertTrue(httpSession.isValid());
+    }
+
+    /**
+     * Assert that the isNew parameter works as expected.
+     */
+    @Test
+    public void testIsNew() {
+        HttpSession httpSession = new HttpSession();
+        Assert.assertFalse(httpSession.isNew());
+        httpSession.setNew(true);
+        Assert.assertTrue(httpSession.isNew());
+        httpSession.setNew(false);
+        Assert.assertFalse(httpSession.isNew());
+    }
+
+    /**
+     * Assert that assertSetAttribute throws.
+     */
+    @Test(expected = NotImplementedException.class)
+    public void assertSetAttribute() {
+        HttpSession httpSession = new HttpSession();
+        httpSession.setAttribute("test", "value");
+    }
+
+    /**
+     * Assert that assertGetAttribute throws.
+     */
+    @Test(expected = NotImplementedException.class)
+    public void assertGetAttribute() {
+        HttpSession httpSession = new HttpSession();
+        httpSession.getAttribute("test");
+    }
+
+    /**
+     * Assert that assertSetAttribute throws.
+     */
+    @Test(expected = NotImplementedException.class)
+    public void assertRemoveAttribute() {
+        HttpSession httpSession = new HttpSession();
+        httpSession.removeAttribute("test");
+    }
+
+    /**
+     * Assert get refresh tokens.
+     */
+    @Test
+    public void assertGetSetRefreshTokens() {
+        HttpSession httpSession = new HttpSession();
+        List<OAuthToken> refreshTokens = new ArrayList<>();
+        refreshTokens.add(new OAuthToken());
+
+        Assert.assertEquals(0, httpSession.getRefreshTokens().size());
+        httpSession.setRefreshTokens(refreshTokens);
+        Assert.assertEquals(refreshTokens, httpSession.getRefreshTokens());
+        Assert.assertNotSame(refreshTokens, httpSession.getRefreshTokens());
+    }
+
+    /**
+     * Assert get id.
+     */
+    @Test
+    public void assertGetSetId() {
+        HttpSession httpSession = new HttpSession();
+
+        Assert.assertNull(httpSession.getId());
+
+        BigInteger id = BigInteger.TEN;
+        httpSession.setId(id);
+        Assert.assertEquals(id, httpSession.getId());
+    }
+
+    /**
+     * Assert calling the access() method updates the timestamp.
+     */
+    @Test
+    public void assertAccess() {
+        HttpSession httpSession = new HttpSession();
+        httpSession.setNew(true);
+        httpSession.setTimestamp(2000);
+        httpSession.access();
+
+        Assert.assertEquals(httpSession.getTimestamp(),
+                System.currentTimeMillis());
+        Assert.assertFalse(httpSession.isNew());
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/OAuthTokenTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/OAuthTokenTest.java
@@ -70,6 +70,19 @@ public final class OAuthTokenTest {
     }
 
     /**
+     * Assert that we can get and set the token's http session
+     */
+    @Test
+    public void testGetSetHttpSession() {
+        OAuthToken token = new OAuthToken();
+        HttpSession session = new HttpSession();
+
+        Assert.assertNull(token.getHttpSession());
+        token.setHttpSession(session);
+        Assert.assertEquals(session, token.getHttpSession());
+    }
+
+    /**
      * Assert that we can get and set the token's client.
      */
     @Test


### PR DESCRIPTION
HTTP sessions are used by the Implicit type handler in lieu of a refresh
token. Here, we create a HibernateEntity which matches the Grizzly Session
instance specification, so we can maintain state via the database. This
session's function is to act solely as a reference for refresh tokens,
and it makes use of the SecureRandomIdGenerator to ensure sufficient
randomness.