### PR TITLE
Add manually overriding the HttpServer's configuration via lambdas.

### DIFF
--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/ServerFactoryTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/ServerFactoryTest.java
@@ -239,6 +239,26 @@ public class ServerFactoryTest {
     }
 
     /**
+     * Test that we can invoke configuration steps on the server.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testConfigureServer() throws Exception {
+        Path appRoot = Paths.get("src/test/resources/html/index");
+
+        ServerFactory f = new ServerFactory()
+                .configureServer(s -> {
+                    s.getServerConfiguration().setSessionTimeoutSeconds(1000);
+                });
+
+        HttpServer s = f.build();
+
+        Assert.assertEquals(1000,
+                s.getServerConfiguration().getSessionTimeoutSeconds());
+    }
+
+    /**
      * Test building with an HTML app that doesn't have an index file.
      *
      * @throws Exception Should not be thrown.

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jersey/KangarooJerseyTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jersey/KangarooJerseyTest.java
@@ -18,6 +18,7 @@
 
 package net.krotscheck.kangaroo.test.jersey;
 
+import org.glassfish.grizzly.http.server.ServerConfiguration;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.filter.CsrfProtectionFilter;
@@ -69,8 +70,14 @@ public abstract class KangarooJerseyTest extends JerseyTest {
      */
     @Override
     protected TestContainerFactory getTestContainerFactory() {
-        return new org.glassfish.jersey.test.grizzly
-                .GrizzlyWebTestContainerFactory();
+        KangarooTestContainerFactory factory =
+                new KangarooTestContainerFactory();
+        factory.configureServer((server) -> {
+            ServerConfiguration c = server.getServerConfiguration();
+            c.setSessionTimeoutSeconds(1000);
+        });
+
+        return factory;
     }
 
     /**

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jersey/KangarooTestContainerFactory.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jersey/KangarooTestContainerFactory.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.test.jersey;
+
+import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.grizzly.servlet.WebappContext;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.filter.CsrfProtectionFilter;
+import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpContainer;
+import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.spi.TestContainer;
+import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
+import org.glassfish.jersey.test.spi.TestHelper;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.FilterRegistration;
+import javax.servlet.ServletRegistration;
+import javax.servlet.http.HttpServlet;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.core.UriBuilder;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.EventListener;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * This container factory simulates, as closely as possible, a kangaroo
+ * deployment for the provided context.
+ *
+ * @author Michael Krotscheck
+ */
+public final class KangarooTestContainerFactory
+        implements TestContainerFactory {
+
+    /**
+     * List of operations that should be applied to all servers when they are
+     * constructed.
+     */
+    private List<ServerOperator> serverLambdas = new ArrayList<>();
+
+    /**
+     * Create a test container instance.
+     *
+     * @param baseUri base URI for the test container to run at.
+     * @param context deployment context of the tested JAX-RS / Jersey
+     *                application .
+     * @return New test container configured to run the tested application.
+     * @throws IllegalArgumentException if {@code deploymentContext} is not
+     *                                  supported by this test container
+     *                                  factory.
+     */
+    @Override
+    public TestContainer create(final URI baseUri,
+                                final DeploymentContext context) {
+        if (!(context instanceof ServletDeploymentContext)) {
+            throw new IllegalArgumentException("The deployment context must"
+                    + " be an instance of ServletDeploymentContext.");
+        }
+
+        KangarooTestContainer container = new KangarooTestContainer(baseUri,
+                (ServletDeploymentContext) context);
+        serverLambdas.forEach(l -> l.operation(container.getServer()));
+        return container;
+    }
+
+    /**
+     * Apply an operation to the server when it's constructed. This can mean
+     * additional filters, SessionHandlers, etc.
+     *
+     * @param o The lambda to apply
+     */
+    public void configureServer(final ServerOperator o) {
+        this.serverLambdas.add(o);
+    }
+
+    /**
+     * Operator interface, for ad-hoc server configuration.
+     */
+    public interface ServerOperator {
+
+        /**
+         * Operation handler.
+         *
+         * @param server The server.
+         */
+        void operation(HttpServer server);
+    }
+
+    /**
+     * This class has methods for instantiating, starting and stopping a
+     * Grizzly-based web server.
+     */
+    private static final class KangarooTestContainer implements TestContainer {
+
+        /**
+         * Logger.
+         */
+        private static final Logger LOGGER =
+                Logger.getLogger(KangarooTestContainer.class.getName());
+
+        /**
+         * The deployment context for this container.
+         */
+        private final ServletDeploymentContext deploymentContext;
+
+        /**
+         * Base URI, provided during initialization.
+         */
+        private URI baseUri;
+
+        /**
+         * The constructed HTTP server.
+         */
+        private HttpServer server;
+
+        /**
+         * Create a new container.
+         *
+         * @param baseUri The base deployment URI.
+         * @param context The deployment context.
+         */
+        private KangarooTestContainer(final URI baseUri,
+                                      final ServletDeploymentContext context) {
+            this.baseUri = UriBuilder.fromUri(baseUri)
+                    .path(context.getContextPath())
+                    .path(context.getServletPath())
+                    .build();
+
+            LOGGER.info("Creating KangarooTestContainer configured"
+                    + " at the base URI "
+                    + TestHelper.zeroPortToAvailablePort(baseUri));
+
+            this.deploymentContext = context;
+            instantiateGrizzlyWebServer();
+        }
+
+        /**
+         * Retrieve the server that will be run during the test suite, in
+         * case it needs additional configuration.
+         *
+         * @return The constructed server.
+         */
+        public HttpServer getServer() {
+            return server;
+        }
+
+        /**
+         * Get any custom client configuration needed for the kangaroo server.
+         *
+         * @return A client configuration.
+         */
+        @Override
+        public ClientConfig getClientConfig() {
+            ClientConfig c = new ClientConfig();
+            c.property(ClientProperties.FOLLOW_REDIRECTS, false);
+            c.register(CsrfProtectionFilter.class);
+            return c;
+        }
+
+        /**
+         * Return the BaseURI. Required by clients.
+         *
+         * @return The base uri.
+         */
+        @Override
+        public URI getBaseUri() {
+            return baseUri;
+        }
+
+        /**
+         * Start the container.
+         */
+        @Override
+        public void start() {
+            if (server.isStarted()) {
+                LOGGER.log(Level.WARNING, "Ignoring start request"
+                        + " - KangarooTestContainer is already started.");
+
+            } else {
+                LOGGER.log(Level.FINE, "Starting KangarooTestContainer...");
+                try {
+                    server.start();
+
+                    if (baseUri.getPort() == 0) {
+                        baseUri = UriBuilder.fromUri(baseUri)
+                                .port(server.getListener("grizzly")
+                                        .getPort())
+                                .build();
+                        LOGGER.log(Level.INFO, "Started KangarooTestContainer"
+                                + " at the base URI " + baseUri);
+                    }
+                } catch (final IOException ioe) {
+                    throw new TestContainerException(ioe);
+                }
+            }
+        }
+
+        /**
+         * Stop the container.
+         */
+        @Override
+        public void stop() {
+            if (server.isStarted()) {
+                LOGGER.log(Level.FINE, "Stopping KangarooTestContainer...");
+                this.server.shutdownNow();
+            } else {
+                LOGGER.log(Level.WARNING, "Ignoring stop request"
+                        + " - KangarooTestContainer is already stopped.");
+            }
+        }
+
+        /**
+         * Create a new instance of the Kangaroo Web Server.
+         */
+        private void instantiateGrizzlyWebServer() {
+
+            String contextPathLocal = deploymentContext.getContextPath();
+            if (!contextPathLocal.isEmpty()
+                    && !contextPathLocal.startsWith("/")) {
+                contextPathLocal = "/" + contextPathLocal;
+            }
+
+            String servletPathLocal = deploymentContext.getServletPath();
+            if (!servletPathLocal.startsWith("/")) {
+                servletPathLocal = "/" + servletPathLocal;
+            }
+            if (servletPathLocal.endsWith("/")) {
+                servletPathLocal += "*";
+            } else {
+                servletPathLocal += "/*";
+            }
+
+            final WebappContext context =
+                    new WebappContext("TestContext", contextPathLocal);
+
+            // Servlet class, and servlet instance can be both null, or
+            // one of them is specified exclusively.
+            final HttpServlet servletInstance =
+                    deploymentContext.getServletInstance();
+            final Class<? extends HttpServlet> servletClass =
+                    deploymentContext.getServletClass();
+
+            if (servletInstance != null || servletClass != null) {
+                final ServletRegistration registration;
+                if (servletInstance != null) {
+                    registration = context
+                            .addServlet(servletInstance.getClass().getName(),
+                                    servletInstance);
+                } else {
+                    registration = context.addServlet(servletClass.getName(),
+                            servletClass);
+                }
+                registration.setInitParameters(
+                        deploymentContext.getInitParams());
+                registration.addMapping(servletPathLocal);
+            }
+
+            for (final Class<? extends EventListener> eventListener
+                    : deploymentContext.getListeners()) {
+                context.addListener(eventListener);
+            }
+
+            final Map<String, String> contextParams =
+                    deploymentContext.getContextParams();
+            for (final String contextParamName : contextParams.keySet()) {
+                context.addContextInitParameter(contextParamName,
+                        contextParams.get(contextParamName));
+            }
+
+            // Filter support
+            if (deploymentContext.getFilters() != null) {
+                for (final ServletDeploymentContext.FilterDescriptor
+                        filterDescriptor : deploymentContext.getFilters()) {
+
+                    final FilterRegistration filterRegistration =
+                            context.addFilter(filterDescriptor.getFilterName(),
+                                    filterDescriptor.getFilterClass());
+
+                    filterRegistration.setInitParameters(
+                            filterDescriptor.getInitParams());
+                    filterRegistration.addMappingForUrlPatterns(
+                            grizzlyDispatcherTypes(filterDescriptor
+                                    .getDispatcherTypes()), true,
+                            servletPathLocal);
+                }
+            }
+
+            try {
+                server = GrizzlyHttpServerFactory.createHttpServer(baseUri,
+                        (GrizzlyHttpContainer) null,
+                        false,
+                        null,
+                        false);
+                context.deploy(server);
+            } catch (final ProcessingException ex) {
+                throw new TestContainerException(ex);
+            }
+        }
+
+        /**
+         * Recreate the dispatchers, so they're not reused.
+         *
+         * @param dispatcherTypes List of dispatchers.
+         * @return Same enumset, different instances.
+         */
+        private EnumSet<DispatcherType> grizzlyDispatcherTypes(
+                final Set<DispatcherType> dispatcherTypes) {
+            final Set<DispatcherType> grizzlyDispatcherTypes = new HashSet<>();
+            for (final javax.servlet.DispatcherType
+                    dispatcherType : dispatcherTypes) {
+                grizzlyDispatcherTypes
+                        .add(DispatcherType.valueOf(dispatcherType.name()));
+            }
+            return EnumSet.copyOf(grizzlyDispatcherTypes);
+        }
+    }
+}


### PR DESCRIPTION
This patch creates a KangarootestContainerFactory, to replace the
GrizzlyWebTestContainerFactory, which provides the ability to
configure the HttpServer before a test run. The same functionality
has been added to the ServerFactory.

This is required, because Grizzly overrides any session management configuration
provided by the SessionManager.