### PR TITLE
Register the admin UID and the client UID in application config.

### DIFF
--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/servlet/Config.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/servlet/Config.java
@@ -36,6 +36,16 @@ public final class Config {
     public static final String APPLICATION_ID = "application_id";
 
     /**
+     * Configuration key for the initial client id.
+     */
+    public static final String APPLICATION_CLIENT_ID = "application_client_id";
+
+    /**
+     * Configuration key for the system admin id.
+     */
+    public static final String APPLICATION_ADMIN_ID = "application_admin_id";
+
+    /**
      * Utility class, private constructor.
      */
     private Config() {

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/servlet/FirstRunContainerLifecycleListener.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/servlet/FirstRunContainerLifecycleListener.java
@@ -184,7 +184,16 @@ public final class FirstRunContainerLifecycleListener
                 servletApp.getId()));
         logger.debug(String.format("Admin User ID: %s",
                 adminUser.getId()));
+        logger.debug(String.format("WebUI Client ID: %s",
+                servletClient.getId()));
         logger.debug("Application created. Let's rock!");
+
+        servletConfig.addProperty(Config.APPLICATION_ID,
+                servletApp.getId());
+        servletConfig.addProperty(Config.APPLICATION_CLIENT_ID,
+                servletClient.getId());
+        servletConfig.addProperty(Config.APPLICATION_ADMIN_ID,
+                adminUser.getId());
 
         // Refresh the servlet app, populating all persisted references.
         s.refresh(servletApp);
@@ -195,9 +204,8 @@ public final class FirstRunContainerLifecycleListener
 
     /**
      * Invoked at the {@link Container container} start-up. This method is
-     * invoked even
-     * when application is reloaded and new instance of application has
-     * started.
+     * invoked even when application is reloaded and new instance of
+     * application has started.
      *
      * @param container container that has been started.
      */
@@ -205,10 +213,8 @@ public final class FirstRunContainerLifecycleListener
     public void onStartup(final Container container) {
         Boolean firstRun = servletConfig.getBoolean(Config.FIRST_RUN, false);
         if (!firstRun) {
-            Application app = bootstrapApplication();
-
+            bootstrapApplication();
             servletConfig.addProperty(Config.FIRST_RUN, true);
-            servletConfig.addProperty(Config.APPLICATION_ID, app.getId());
         }
     }
 

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/servlet/ConfigTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/servlet/ConfigTest.java
@@ -18,7 +18,6 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.servlet;
 
-import net.krotscheck.kangaroo.authz.admin.v1.servlet.Config;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -52,7 +51,13 @@ public final class ConfigTest {
      */
     @Test
     public void testConfigurationConstants() {
-        Assert.assertEquals("application_id", Config.APPLICATION_ID);
-        Assert.assertEquals("first_run", Config.FIRST_RUN);
+        Assert.assertEquals("application_client_id",
+                Config.APPLICATION_CLIENT_ID);
+        Assert.assertEquals("application_admin_id",
+                Config.APPLICATION_ADMIN_ID);
+        Assert.assertEquals("application_id",
+                Config.APPLICATION_ID);
+        Assert.assertEquals("first_run",
+                Config.FIRST_RUN);
     }
 }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/servlet/FirstRunContainerLifecycleListenerTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/servlet/FirstRunContainerLifecycleListenerTest.java
@@ -20,6 +20,8 @@ package net.krotscheck.kangaroo.authz.admin.v1.servlet;
 
 import net.krotscheck.kangaroo.authz.admin.v1.servlet.FirstRunContainerLifecycleListener.Binder;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
+import net.krotscheck.kangaroo.authz.common.database.entity.Client;
+import net.krotscheck.kangaroo.authz.common.database.entity.User;
 import net.krotscheck.kangaroo.common.hibernate.config.HibernateConfiguration;
 import net.krotscheck.kangaroo.common.hibernate.migration.DatabaseMigrationState;
 import net.krotscheck.kangaroo.test.jersey.DatabaseTest;
@@ -87,15 +89,35 @@ public final class FirstRunContainerLifecycleListenerTest
                         new DatabaseMigrationState());
         l.onStartup(mockContainer);
 
+        // Grab the session.
+        Session s = getSession();
+
         // Make sure we have an application ID.
         String appId = testConfig.getString(Config.APPLICATION_ID);
         UUID appUuid = UUID.fromString(appId);
         Assert.assertNotNull(appUuid);
 
         // Ensure that the app id can be resolved.
-        Session s = getSession();
         Application application = s.get(Application.class, appUuid);
         Assert.assertNotNull(application);
+
+        // Make sure we have an application client ID
+        String clientId = testConfig.getString(Config.APPLICATION_CLIENT_ID);
+        UUID clientUuid = UUID.fromString(clientId);
+        Assert.assertNotNull(clientUuid);
+
+        // Ensure that the client id can be resolved.
+        Client client = s.get(Client.class, clientUuid);
+        Assert.assertNotNull(client);
+
+        // Make sure we have an application user ID
+        String adminId = testConfig.getString(Config.APPLICATION_ADMIN_ID);
+        UUID adminUuid = UUID.fromString(adminId);
+        Assert.assertNotNull(adminUuid);
+
+        // Ensure that the client id can be resolved.
+        User user = s.get(User.class, adminUuid);
+        Assert.assertNotNull(user);
 
         // Cleanup
         testConfig.clear();


### PR DESCRIPTION
This permits providing these pieces as data from API clients.