### PR TITLE
ValidationUtil now only grants those scopes that exit

### DIFF
--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/util/ValidationUtil.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/util/ValidationUtil.java
@@ -288,10 +288,9 @@ public final class ValidationUtil {
         // Make sure all requested scopes are in the map.
         SortedMap<String, ApplicationScope> results = new TreeMap<>();
         for (String scope : requestedScopes) {
-            if (!validScopes.containsKey(scope)) {
-                throw new InvalidScopeException();
+            if (validScopes.containsKey(scope)) {
+                results.put(scope, validScopes.get(scope));
             }
-            results.put(scope, validScopes.get(scope));
         }
         return results;
     }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/util/ValidationUtilTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/util/ValidationUtilTest.java
@@ -487,9 +487,12 @@ public final class ValidationUtilTest {
      *
      * @throws Exception Should be thrown when the validation fails.
      */
-    @Test(expected = InvalidScopeException.class)
+    @Test
     public void testInvalidScope() throws Exception {
-        ValidationUtil.validateScope(new String[]{"invalid"}, validScopes);
+        SortedMap<String, ApplicationScope> scopes =
+                ValidationUtil.validateScope(new String[]{"invalid"},
+                        validScopes);
+        Assert.assertEquals(0, scopes.size());
     }
 
     /**
@@ -557,7 +560,7 @@ public final class ValidationUtilTest {
      *
      * @throws Exception Should be thrown when the validation fails.
      */
-    @Test(expected = InvalidScopeException.class)
+    @Test
     public void testEmptyValidScopes() throws Exception {
         SortedMap<String, ApplicationScope> scopes =
                 ValidationUtil.validateScope(new String[]{"debug1"},
@@ -618,11 +621,11 @@ public final class ValidationUtilTest {
     }
 
     /**
-     * Assert that a role with mismatching scopes fails.
+     * Assert that a role with mismatching scopes is filtered down.
      *
-     * @throws Exception Should be thrown when the validation fails.
+     * @throws Exception Should not be thrown.
      */
-    @Test(expected = InvalidScopeException.class)
+    @Test
     public void testValidateScopeStringMismatchScopesInRole() throws Exception {
         SortedMap<String, ApplicationScope> roleScopes = new TreeMap<>();
 
@@ -635,9 +638,12 @@ public final class ValidationUtilTest {
         roleScopes.put(debug2Scope.getName(), debug2Scope);
 
         Role r = new Role();
+
         r.setScopes(roleScopes);
 
-        ValidationUtil.validateScope("debug1 debug3", r);
+        SortedMap<String, ApplicationScope> scopes =
+                ValidationUtil.validateScope("debug1 debug3", r);
+        Assert.assertEquals(1, scopes.size());
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/resource/token/ClientCredentialsGrantHandlerTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/resource/token/ClientCredentialsGrantHandlerTest.java
@@ -167,9 +167,9 @@ public final class ClientCredentialsGrantHandlerTest extends DatabaseTest {
     }
 
     /**
-     * Assert that requesting a scope that is not permitted fails.
+     * Assert that requesting a scope that is not permitted is not granted.
      */
-    @Test(expected = KangarooException.class)
+    @Test
     public void testInvalidScope() {
         MultivaluedMap<String, String> testData = new MultivaluedHashMap<>();
         testData.putSingle("client_id",
@@ -183,7 +183,14 @@ public final class ClientCredentialsGrantHandlerTest extends DatabaseTest {
         Client testClient = getSession()
                 .get(Client.class, context.getClient().getId());
 
-        handler.handle(testClient, testData);
+        TokenResponseEntity token = handler.handle(testClient,
+                testData);
+        Assert.assertEquals(OAuthTokenType.Bearer, token.getTokenType());
+        Assert.assertEquals((long) ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
+                (long) token.getExpiresIn());
+        Assert.assertNull(token.getRefreshToken());
+        Assert.assertEquals("debug", token.getScope());
+        Assert.assertNotNull(token.getAccessToken());
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/Section410AuthorizationCodeGrantTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/Section410AuthorizationCodeGrantTest.java
@@ -492,7 +492,7 @@ public final class Section410AuthorizationCodeGrantTest
     }
 
     /**
-     * Assert that a request with an invalid scope errors.
+     * Assert that a request with an invalid scope does not grant said scope.
      */
     @Test
     public void testAuthorizeScopeInvalid() {
@@ -503,11 +503,14 @@ public final class Section410AuthorizationCodeGrantTest
                 .request()
                 .get();
 
+        // Follow the redirect
+        Response second = followRedirect(r);
+
         // Assert various response-specific parameters.
-        Assert.assertEquals(Status.FOUND.getStatusCode(), r.getStatus());
+        Assert.assertEquals(Status.FOUND.getStatusCode(), second.getStatus());
 
         // Validate the redirect location
-        URI location = r.getLocation();
+        URI location = second.getLocation();
         Assert.assertEquals("http", location.getScheme());
         Assert.assertEquals("valid.example.com", location.getHost());
         Assert.assertEquals("/redirect", location.getPath());
@@ -516,9 +519,9 @@ public final class Section410AuthorizationCodeGrantTest
         // Validate the query parameters received.
         MultivaluedMap<String, String> params =
                 HttpUtil.parseQueryParams(location);
-        Assert.assertTrue(params.containsKey("error"));
-        Assert.assertEquals("invalid_scope", params.getFirst("error"));
-        Assert.assertTrue(params.containsKey("error_description"));
+        Assert.assertTrue(params.containsKey("code"));
+        Assert.assertFalse(params.containsKey("state"));
+        Assert.assertFalse(params.containsKey("scope"));
     }
 
     /**


### PR DESCRIPTION
We're switching the behavior here, causing our ValidationUtil to
return the list of valid scopes that may be issued to a user, and filtering
out those that may not. This allows us to create 'blanket' authz requests
for all available scopes, and get back the subset that has actually been granted
to the user.