### PR TITLE
Assert that user identities are assigned to tokens

### DIFF
--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/authorize/AuthCodeHandler.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/authorize/AuthCodeHandler.java
@@ -153,6 +153,7 @@ public final class AuthCodeHandler implements IAuthorizeHandler {
         t.setExpiresIn(s.getAuthenticator().getClient()
                 .getAuthorizationCodeExpiresIn());
         t.setRedirect(s.getClientRedirect());
+        t.setIdentity(i);
 
         // Persist and get an ID.
         session.save(t);

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/token/AuthorizationCodeGrantHandler.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/token/AuthorizationCodeGrantHandler.java
@@ -116,6 +116,7 @@ public final class AuthorizationCodeGrantHandler
         newAuthToken.setTokenType(OAuthTokenType.Bearer);
         newAuthToken.setExpiresIn(client.getAccessTokenExpireIn());
         newAuthToken.setScopes(authCode.getScopes());
+        newAuthToken.setIdentity(authCode.getIdentity());
 
         OAuthToken newRefreshToken = new OAuthToken();
         newRefreshToken.setClient(client);
@@ -123,6 +124,7 @@ public final class AuthorizationCodeGrantHandler
         newRefreshToken.setExpiresIn(client.getRefreshTokenExpireIn());
         newRefreshToken.setScopes(authCode.getScopes());
         newRefreshToken.setAuthToken(newAuthToken);
+        newRefreshToken.setIdentity(authCode.getIdentity());
 
         session.save(newAuthToken);
         session.save(newRefreshToken);

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/token/OwnerCredentialsGrantHandler.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/token/OwnerCredentialsGrantHandler.java
@@ -130,6 +130,7 @@ public final class OwnerCredentialsGrantHandler
         refreshToken.setExpiresIn(client.getRefreshTokenExpireIn());
         refreshToken.setScopes(token.getScopes());
         refreshToken.setAuthToken(token);
+        refreshToken.setIdentity(identity);
 
         session.save(token);
         session.save(refreshToken);

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/token/RefreshTokenGrantHandler.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/token/RefreshTokenGrantHandler.java
@@ -113,12 +113,14 @@ public final class RefreshTokenGrantHandler implements ITokenRequestHandler {
         newAuthToken.setTokenType(OAuthTokenType.Bearer);
         newAuthToken.setExpiresIn(client.getAccessTokenExpireIn());
         newAuthToken.setScopes(requestedScopes);
+        newAuthToken.setIdentity(refreshToken.getIdentity());
 
         OAuthToken newRefreshToken = new OAuthToken();
         newRefreshToken.setClient(client);
         newRefreshToken.setTokenType(OAuthTokenType.Refresh);
         newRefreshToken.setExpiresIn(client.getRefreshTokenExpireIn());
         newRefreshToken.setScopes(requestedScopes);
+        newRefreshToken.setIdentity(refreshToken.getIdentity());
         newRefreshToken.setAuthToken(newAuthToken);
 
         session.save(newAuthToken);

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/Section410AuthorizationCodeGrantTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/Section410AuthorizationCodeGrantTest.java
@@ -19,7 +19,6 @@ package net.krotscheck.kangaroo.authz.oauth2.rfc6749;
 
 import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorType;
 import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder.ErrorResponse;
-import net.krotscheck.kangaroo.authz.common.database.entity.ClientConfig;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthTokenType;
@@ -74,12 +73,16 @@ public final class Section410AuthorizationCodeGrantTest
                             .client(ClientType.AuthorizationGrant)
                             .authenticator(AuthenticatorType.Test)
                             .redirect("http://valid.example.com/redirect")
+                            .user()
+                            .identity()
                             .build();
                     bareContext = ApplicationBuilder
                             .newApplication(session)
                             .scope("debug")
                             .client(ClientType.AuthorizationGrant)
                             .authenticator(AuthenticatorType.Test)
+                            .user()
+                            .identity()
                             .build();
                     noScopeRoleContext = ApplicationBuilder
                             .newApplication(session)
@@ -941,12 +944,7 @@ public final class Section410AuthorizationCodeGrantTest
 
         // Validate the query parameters received.
         TokenResponseEntity entity = r.readEntity(TokenResponseEntity.class);
-        Assert.assertNotNull(entity.getAccessToken());
-        Assert.assertNotNull(entity.getRefreshToken());
-        Assert.assertEquals(
-                Long.valueOf(ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT),
-                entity.getExpiresIn());
-        Assert.assertEquals(OAuthTokenType.Bearer, entity.getTokenType());
+        assertValidBearerToken(entity, true);
     }
 
     /**
@@ -1125,12 +1123,7 @@ public final class Section410AuthorizationCodeGrantTest
 
         // Validate the query parameters received.
         TokenResponseEntity entity = r.readEntity(TokenResponseEntity.class);
-        Assert.assertNotNull(entity.getAccessToken());
-        Assert.assertNotNull(entity.getRefreshToken());
-        Assert.assertEquals(OAuthTokenType.Bearer, entity.getTokenType());
-        Assert.assertEquals(
-                Long.valueOf(ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT),
-                entity.getExpiresIn());
+        assertValidBearerToken(entity, true);
         Assert.assertNull(entity.getScope());
     }
 
@@ -1260,13 +1253,7 @@ public final class Section410AuthorizationCodeGrantTest
 
         // Validate the query parameters received.
         TokenResponseEntity entity = r.readEntity(TokenResponseEntity.class);
-        Assert.assertNotNull(entity.getAccessToken());
-        Assert.assertNotNull(entity.getRefreshToken());
-        Assert.assertEquals(
-                Long.valueOf(ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT),
-                entity.getExpiresIn());
-        Assert.assertNull(entity.getScope());
-        Assert.assertEquals(OAuthTokenType.Bearer, entity.getTokenType());
+        assertValidBearerToken(entity, true);
     }
 
     /**
@@ -1655,13 +1642,8 @@ public final class Section410AuthorizationCodeGrantTest
 
         // Validate the query parameters received.
         TokenResponseEntity entity = r.readEntity(TokenResponseEntity.class);
-        Assert.assertNotNull(entity.getAccessToken());
-        Assert.assertNotNull(entity.getRefreshToken());
-        Assert.assertEquals(
-                Long.valueOf(ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT),
-                entity.getExpiresIn());
+        assertValidBearerToken(entity, true);
         Assert.assertNull(entity.getScope());
-        Assert.assertEquals(OAuthTokenType.Bearer, entity.getTokenType());
     }
 
     /**
@@ -1694,13 +1676,8 @@ public final class Section410AuthorizationCodeGrantTest
 
         // Validate the query parameters received.
         TokenResponseEntity entity = r.readEntity(TokenResponseEntity.class);
-        Assert.assertNotNull(entity.getAccessToken());
-        Assert.assertNotNull(entity.getRefreshToken());
-        Assert.assertEquals(
-                Long.valueOf(ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT),
-                entity.getExpiresIn());
+        assertValidBearerToken(entity, true);
         Assert.assertNull(entity.getScope());
-        Assert.assertEquals(OAuthTokenType.Bearer, entity.getTokenType());
     }
 
     /**
@@ -1798,13 +1775,8 @@ public final class Section410AuthorizationCodeGrantTest
 
         // Validate the query parameters received.
         TokenResponseEntity entity = r.readEntity(TokenResponseEntity.class);
-        Assert.assertNotNull(entity.getAccessToken());
-        Assert.assertNotNull(entity.getRefreshToken());
-        Assert.assertEquals(
-                Long.valueOf(ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT),
-                entity.getExpiresIn());
+        assertValidBearerToken(entity, true);
         Assert.assertNull(entity.getScope());
-        Assert.assertEquals(OAuthTokenType.Bearer, entity.getTokenType());
     }
 
     /**
@@ -1921,13 +1893,8 @@ public final class Section410AuthorizationCodeGrantTest
 
         // Validate the query parameters received.
         TokenResponseEntity entity = tr.readEntity(TokenResponseEntity.class);
-        Assert.assertNotNull(entity.getAccessToken());
-        Assert.assertNotNull(entity.getRefreshToken());
-        Assert.assertEquals(
-                Long.valueOf(ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT),
-                entity.getExpiresIn());
+        assertValidBearerToken(entity, true);
         Assert.assertEquals("debug", entity.getScope());
         Assert.assertEquals(state2, entity.getState());
-        Assert.assertEquals(OAuthTokenType.Bearer, entity.getTokenType());
     }
 }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/Section420ImplicitGrantTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/Section420ImplicitGrantTest.java
@@ -163,12 +163,8 @@ public final class Section420ImplicitGrantTest
         // Extract the query parameters in the fragment
         MultivaluedMap<String, String> params =
                 HttpUtil.parseQueryParams(location.getFragment());
-        assertTrue(params.containsKey("access_token"));
-        assertEquals("Bearer", params.getFirst("token_type"));
-        assertEquals(ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
-                Integer.valueOf(params.getFirst("expires_in")));
+        assertValidBearerToken(params, true);
         assertFalse(params.containsKey("scope"));
-        assertFalse(params.containsKey("state"));
     }
 
     /**
@@ -245,10 +241,7 @@ public final class Section420ImplicitGrantTest
         // Extract the query parameters in the fragment
         MultivaluedMap<String, String> params =
                 HttpUtil.parseQueryParams(location.getFragment());
-        assertTrue(params.containsKey("access_token"));
-        assertEquals("Bearer", params.getFirst("token_type"));
-        assertEquals(ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
-                Integer.valueOf(params.getFirst("expires_in")));
+        assertValidBearerToken(params, true);
         assertEquals("debug", params.getFirst("scope"));
         assertFalse(params.containsKey("state"));
     }
@@ -306,10 +299,7 @@ public final class Section420ImplicitGrantTest
         // Extract the query parameters in the fragment
         MultivaluedMap<String, String> params =
                 HttpUtil.parseQueryParams(location.getFragment());
-        assertTrue(params.containsKey("access_token"));
-        assertEquals("Bearer", params.getFirst("token_type"));
-        assertEquals(ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
-                Integer.valueOf(params.getFirst("expires_in")));
+        assertValidBearerToken(params, true);
         assertFalse(params.containsKey("scope"));
         assertFalse(params.containsKey("state"));
     }
@@ -340,10 +330,7 @@ public final class Section420ImplicitGrantTest
         // Extract the query parameters in the fragment
         MultivaluedMap<String, String> params =
                 HttpUtil.parseQueryParams(location.getFragment());
-        assertTrue(params.containsKey("access_token"));
-        assertEquals("Bearer", params.getFirst("token_type"));
-        assertEquals(ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
-                Integer.valueOf(params.getFirst("expires_in")));
+        assertValidBearerToken(params, true);
         assertEquals("debug", params.getFirst("scope"));
         assertEquals(state, params.getFirst("state"));
     }
@@ -373,10 +360,7 @@ public final class Section420ImplicitGrantTest
         // Extract the query parameters in the fragment
         MultivaluedMap<String, String> params =
                 HttpUtil.parseQueryParams(location.getFragment());
-        assertTrue(params.containsKey("access_token"));
-        assertEquals("Bearer", params.getFirst("token_type"));
-        assertEquals(ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
-                Integer.valueOf(params.getFirst("expires_in")));
+        assertValidBearerToken(params, true);
         assertEquals("debug", params.getFirst("scope"));
         assertFalse(params.containsKey("state"));
     }
@@ -408,10 +392,7 @@ public final class Section420ImplicitGrantTest
         // Extract the query parameters in the fragment
         MultivaluedMap<String, String> params =
                 HttpUtil.parseQueryParams(location.getFragment());
-        assertTrue(params.containsKey("access_token"));
-        assertEquals("Bearer", params.getFirst("token_type"));
-        assertEquals(ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
-                Integer.valueOf(params.getFirst("expires_in")));
+        assertValidBearerToken(params, true);
         assertFalse(params.containsKey("scope"));
         assertFalse(params.containsKey("state"));
     }
@@ -516,10 +497,7 @@ public final class Section420ImplicitGrantTest
         // Extract the query parameters in the fragment
         MultivaluedMap<String, String> params =
                 HttpUtil.parseQueryParams(secondLocation.getFragment());
-        assertTrue(params.containsKey("access_token"));
-        assertEquals("Bearer", params.getFirst("token_type"));
-        assertEquals(ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
-                Integer.valueOf(params.getFirst("expires_in")));
+        assertValidBearerToken(params, true);
         assertFalse(params.containsKey("scope"));
         assertFalse(params.containsKey("state"));
     }
@@ -652,10 +630,7 @@ public final class Section420ImplicitGrantTest
         // Extract the query parameters in the fragment
         MultivaluedMap<String, String> params =
                 HttpUtil.parseQueryParams(secondLocation.getFragment());
-        assertTrue(params.containsKey("access_token"));
-        assertEquals("Bearer", params.getFirst("token_type"));
-        assertEquals(ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
-                Integer.valueOf(params.getFirst("expires_in")));
+        assertValidBearerToken(params, true);
         assertFalse(params.containsKey("scope"));
         assertFalse(params.containsKey("state"));
     }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/Section430OwnerPasswordTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/Section430OwnerPasswordTest.java
@@ -18,14 +18,12 @@
 package net.krotscheck.kangaroo.authz.oauth2.rfc6749;
 
 import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorType;
-import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder.ErrorResponse;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;
-import net.krotscheck.kangaroo.authz.common.database.entity.ClientConfig;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
-import net.krotscheck.kangaroo.authz.common.database.entity.OAuthTokenType;
 import net.krotscheck.kangaroo.authz.oauth2.resource.TokenResponseEntity;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder.ErrorResponse;
 import net.krotscheck.kangaroo.test.HttpUtil;
 import net.krotscheck.kangaroo.test.rule.TestDataResource;
 import org.hibernate.Session;
@@ -52,6 +50,26 @@ import static org.junit.Assert.assertNull;
 public final class Section430OwnerPasswordTest
         extends AbstractRFC6749Test {
 
+    /**
+     * User name used for valid requests.
+     */
+    private static String username = "valid_user";
+    /**
+     * The password used for valid requests.
+     */
+    private static String password = "valid_password";
+    /**
+     * The environment builder for the regular client.
+     */
+    private static ApplicationContext builder;
+    /**
+     * The environment builder for the authentication client.
+     */
+    private static ApplicationContext authBuilder;
+    /**
+     * The auth header string for each test.
+     */
+    private static String authHeader;
     /**
      * Test data loading for this test.
      */
@@ -85,31 +103,6 @@ public final class Section430OwnerPasswordTest
             };
 
     /**
-     * User name used for valid requests.
-     */
-    private static String username = "valid_user";
-
-    /**
-     * The password used for valid requests.
-     */
-    private static String password = "valid_password";
-
-    /**
-     * The environment builder for the regular client.
-     */
-    private static ApplicationContext builder;
-
-    /**
-     * The environment builder for the authentication client.
-     */
-    private static ApplicationContext authBuilder;
-
-    /**
-     * The auth header string for each test.
-     */
-    private static String authHeader;
-
-    /**
      * Assert that a simple token request works.
      */
     @Test
@@ -131,12 +124,8 @@ public final class Section430OwnerPasswordTest
 
         // Validate the query parameters received.
         TokenResponseEntity entity = r.readEntity(TokenResponseEntity.class);
-        assertNotNull(entity.getAccessToken());
-        assertNotNull(entity.getRefreshToken());
-        assertEquals((int) ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
-                entity.getExpiresIn().intValue());
+        assertValidBearerToken(entity, true);
         assertNull(entity.getScope());
-        assertEquals(OAuthTokenType.Bearer, entity.getTokenType());
     }
 
     /**
@@ -241,12 +230,8 @@ public final class Section430OwnerPasswordTest
 
         // Validate the query parameters received.
         TokenResponseEntity entity = r.readEntity(TokenResponseEntity.class);
-        assertNotNull(entity.getAccessToken());
-        assertNotNull(entity.getRefreshToken());
-        assertEquals((int) ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
-                entity.getExpiresIn().intValue());
+        assertValidBearerToken(entity, true);
         assertEquals("debug", entity.getScope());
-        assertEquals(OAuthTokenType.Bearer, entity.getTokenType());
     }
 
     /**
@@ -365,12 +350,8 @@ public final class Section430OwnerPasswordTest
 
         // Validate the query parameters received.
         TokenResponseEntity entity = r.readEntity(TokenResponseEntity.class);
-        assertNotNull(entity.getAccessToken());
-        assertNotNull(entity.getRefreshToken());
-        assertEquals((int) ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
-                entity.getExpiresIn().intValue());
+        assertValidBearerToken(entity, true);
         assertEquals("debug", entity.getScope());
-        assertEquals(OAuthTokenType.Bearer, entity.getTokenType());
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/Section440ClientCredentialsTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/Section440ClientCredentialsTest.java
@@ -114,12 +114,8 @@ public final class Section440ClientCredentialsTest
 
         // Validate the query parameters received.
         TokenResponseEntity entity = r.readEntity(TokenResponseEntity.class);
-        assertNotNull(entity.getAccessToken());
-        assertNull(entity.getRefreshToken());
-        assertEquals((long) ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
-                (long) entity.getExpiresIn());
+        assertValidBearerToken(entity, false);
         assertNull(entity.getScope());
-        assertEquals(OAuthTokenType.Bearer, entity.getTokenType());
     }
 
     /**
@@ -223,11 +219,7 @@ public final class Section440ClientCredentialsTest
 
         // Validate the query parameters received.
         TokenResponseEntity entity = r.readEntity(TokenResponseEntity.class);
-        assertNotNull(entity.getAccessToken());
-        assertNull(entity.getRefreshToken());
-        assertEquals((long) ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
-                (long) entity.getExpiresIn());
-        assertEquals(OAuthTokenType.Bearer, entity.getTokenType());
+        assertValidBearerToken(entity, false);
         assertEquals("debug", entity.getScope());
     }
 

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/Section600RefreshTokenTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/Section600RefreshTokenTest.java
@@ -129,12 +129,8 @@ public final class Section600RefreshTokenTest
 
         // Validate the query parameters received.
         TokenResponseEntity entity = r.readEntity(TokenResponseEntity.class);
-        assertNotNull(entity.getAccessToken());
-        assertNotNull(entity.getRefreshToken());
-        assertEquals((long) ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
-                (long) entity.getExpiresIn());
+        assertValidBearerToken(entity, false);
         assertNull(entity.getScope());
-        assertEquals(OAuthTokenType.Bearer, entity.getTokenType());
     }
 
     /**
@@ -165,12 +161,8 @@ public final class Section600RefreshTokenTest
 
         // Validate the query parameters received.
         TokenResponseEntity entity = r.readEntity(TokenResponseEntity.class);
-        assertNotNull(entity.getAccessToken());
-        assertNotNull(entity.getRefreshToken());
-        assertEquals((long) ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
-                (long) entity.getExpiresIn());
+        assertValidBearerToken(entity, false);
         assertNull(entity.getScope());
-        assertEquals(OAuthTokenType.Bearer, entity.getTokenType());
     }
 
     /**
@@ -233,12 +225,8 @@ public final class Section600RefreshTokenTest
 
         // Validate the query parameters received.
         TokenResponseEntity entity = r.readEntity(TokenResponseEntity.class);
-        assertNotNull(entity.getAccessToken());
-        assertNotNull(entity.getRefreshToken());
-        assertEquals((long) ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
-                (long) entity.getExpiresIn());
+        assertValidBearerToken(entity, false);
         assertNull(entity.getScope());
-        assertEquals(OAuthTokenType.Bearer, entity.getTokenType());
     }
 
     /**
@@ -459,12 +447,8 @@ public final class Section600RefreshTokenTest
 
         // Validate the query parameters received.
         TokenResponseEntity entity = r.readEntity(TokenResponseEntity.class);
-        assertNotNull(entity.getAccessToken());
-        assertNotNull(entity.getRefreshToken());
-        assertEquals((long) ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
-                (long) entity.getExpiresIn());
+        assertValidBearerToken(entity, false);
         assertNull(entity.getScope());
-        assertEquals(OAuthTokenType.Bearer, entity.getTokenType());
 
         // Now do the whole thing again.
         Response r2 = target("/token").request().post(postEntity);
@@ -510,12 +494,8 @@ public final class Section600RefreshTokenTest
 
         // Validate the query parameters received.
         TokenResponseEntity entity = r.readEntity(TokenResponseEntity.class);
-        assertNotNull(entity.getAccessToken());
-        assertNotNull(entity.getRefreshToken());
-        assertEquals((long) ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
-                (long) entity.getExpiresIn());
+        assertValidBearerToken(entity, false);
         assertEquals("debug debug2", entity.getScope());
-        assertEquals(OAuthTokenType.Bearer, entity.getTokenType());
     }
 
     /**
@@ -549,12 +529,8 @@ public final class Section600RefreshTokenTest
 
         // Validate the query parameters received.
         TokenResponseEntity entity = r.readEntity(TokenResponseEntity.class);
-        assertNotNull(entity.getAccessToken());
-        assertNotNull(entity.getRefreshToken());
-        assertEquals((long) ClientConfig.ACCESS_TOKEN_EXPIRES_DEFAULT,
-                (long) entity.getExpiresIn());
+        assertValidBearerToken(entity, false);
         assertEquals("debug2", entity.getScope());
-        assertEquals(OAuthTokenType.Bearer, entity.getTokenType());
     }
 
     /**


### PR DESCRIPTION
This patch adds the necessary tests to ensure that OAuth tokens have
the user identity attached to them.