### PR TITLE
Modified and Created Date are now managed via interfaces

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/entity/AbstractEntity.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/entity/AbstractEntity.java
@@ -77,7 +77,8 @@ import java.util.UUID;
                 @TokenFilterDef(
                         factory = RemoveDuplicatesTokenFilterFactory.class)
         })
-public abstract class AbstractEntity implements Cloneable {
+public abstract class AbstractEntity implements Cloneable,
+        IModifiedDateEntity, ICreatedDateEntity {
 
     /**
      * The DB ID.

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/entity/ICreatedDateEntity.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/entity/ICreatedDateEntity.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate.entity;
+
+import java.util.Calendar;
+
+/**
+ * This interface describes a database entity that adheres to the
+ * 'createdDate' contract.
+ *
+ * @author Michael Krotscheck
+ */
+public interface ICreatedDateEntity {
+
+    /**
+     * Get the date on which this record was created.
+     *
+     * @return The created date.
+     */
+    Calendar getCreatedDate();
+
+    /**
+     * Set the date on which this record was created.
+     *
+     * @param date The creation date for this entity.
+     */
+    void setCreatedDate(Calendar date);
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/entity/IModifiedDateEntity.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/entity/IModifiedDateEntity.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate.entity;
+
+import java.util.Calendar;
+
+/**
+ * This interface describes a database entity that adheres to the
+ * 'modifiedDate' contract.
+ *
+ * @author Michael Krotscheck
+ */
+public interface IModifiedDateEntity {
+
+    /**
+     * Get the date on which this record was modified.
+     *
+     * @return The created date.
+     */
+    Calendar getModifiedDate();
+
+    /**
+     * Set the date on which this record was modified.
+     *
+     * @param date The creation date for this entity.
+     */
+    void setModifiedDate(Calendar date);
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/listener/CreatedUpdatedListener.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/listener/CreatedUpdatedListener.java
@@ -18,7 +18,8 @@
 
 package net.krotscheck.kangaroo.common.hibernate.listener;
 
-import net.krotscheck.kangaroo.common.hibernate.entity.AbstractEntity;
+import net.krotscheck.kangaroo.common.hibernate.entity.ICreatedDateEntity;
+import net.krotscheck.kangaroo.common.hibernate.entity.IModifiedDateEntity;
 import org.apache.commons.lang3.ArrayUtils;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.hibernate.event.spi.PreInsertEvent;
@@ -53,20 +54,26 @@ public final class CreatedUpdatedListener
     @Override
     public boolean onPreInsert(final PreInsertEvent event) {
         Object entity = event.getEntity();
-        if (entity instanceof AbstractEntity) {
+        Object[] state = event.getState();
+        Calendar now = Calendar.getInstance(timeZone);
+
+        if (entity instanceof ICreatedDateEntity) {
             String[] propertyNames = event.getPersister().getEntityMetamodel()
                     .getPropertyNames();
-            Object[] state = event.getState();
-
-            Calendar now = Calendar.getInstance(timeZone);
-            AbstractEntity persistingEntity = (AbstractEntity) entity;
+            ICreatedDateEntity persistingEntity = (ICreatedDateEntity) entity;
             persistingEntity.setCreatedDate(now);
-            persistingEntity.setModifiedDate(now);
-
             setValue(state, propertyNames, "createdDate",
                     persistingEntity.getCreatedDate());
+        }
+
+        if (entity instanceof IModifiedDateEntity) {
+            String[] propertyNames = event.getPersister().getEntityMetamodel()
+                    .getPropertyNames();
+            IModifiedDateEntity modifiedEntity = (IModifiedDateEntity) entity;
+            modifiedEntity.setModifiedDate(now);
+
             setValue(state, propertyNames, "modifiedDate",
-                    persistingEntity.getModifiedDate());
+                    modifiedEntity.getModifiedDate());
         }
 
         return false;
@@ -81,13 +88,13 @@ public final class CreatedUpdatedListener
     @Override
     public boolean onPreUpdate(final PreUpdateEvent event) {
         Object entity = event.getEntity();
-        if (entity instanceof AbstractEntity) {
+        if (entity instanceof IModifiedDateEntity) {
             String[] propertyNames = event.getPersister().getEntityMetamodel()
                     .getPropertyNames();
             Object[] state = event.getState();
 
             Calendar now = Calendar.getInstance(timeZone);
-            AbstractEntity persistingEntity = (AbstractEntity) entity;
+            IModifiedDateEntity persistingEntity = (IModifiedDateEntity) entity;
             persistingEntity.setModifiedDate(now);
 
             setValue(state, propertyNames, "modifiedDate",


### PR DESCRIPTION
This patch adds the ICreatedDate and IModifiedDate interfaces, and
changes the CreatedUpdated hibernate listener to check for those,
rather than the AbstractEntity. This permits us to implement a similar
contract for non-AbstractEntities, most notably ones that require different
ID generation (such as HttpSession).