### PR TITLE
Switched from 'ram' provider to 'local-heap'.

### DIFF
--- a/kangaroo-common/src/test/resources/hibernate.cfg.xml
+++ b/kangaroo-common/src/test/resources/hibernate.cfg.xml
@@ -48,7 +48,7 @@
     <property name="hibernate.c3p0.idle_test_period">3000</property>
 
     <!-- Hibernate Search Configuration -->
-    <property name="search.default.directory_provider">ram</property>
+    <property name="search.default.directory_provider">local-heap</property>
     <property name="search.default.optimizer.operation_limit">1000</property>
     <property name="search.default.optimizer.transaction_limit">100</property>
     <property name="search.lucene_version">LUCENE_CURRENT</property>

--- a/kangaroo-server-authz/src/main/resources/hibernate.cfg.xml
+++ b/kangaroo-server-authz/src/main/resources/hibernate.cfg.xml
@@ -48,7 +48,7 @@
     <property name="hibernate.c3p0.idle_test_period">3000</property>
 
     <!-- Hibernate Search Configuration -->
-    <property name="search.default.directory_provider">ram</property>
+    <property name="search.default.directory_provider">local-heap</property>
     <property name="search.default.optimizer.operation_limit">1000</property>
     <property name="search.default.optimizer.transaction_limit">100</property>
     <property name="search.lucene_version">LUCENE_CURRENT</property>


### PR DESCRIPTION
'ram' has been deprecated as an indicator.