### PR TITLE
Switched list responses from a plain array, to a wrapped objects.

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/response/ListResponseBuilder.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/response/ListResponseBuilder.java
@@ -17,20 +17,36 @@
 
 package net.krotscheck.kangaroo.common.response;
 
-import java.util.List;
+import net.krotscheck.kangaroo.common.hibernate.entity.AbstractEntity;
+
 import javax.ws.rs.core.Response;
+import java.util.List;
 
 /**
  * Convenience utility to build our common list response objects.
  *
+ * @param <T> The data type returned.
  * @author Michael Krotscheck
  */
-public final class ListResponseBuilder {
+public final class ListResponseBuilder<T extends AbstractEntity> {
 
     /**
      * The wrapped builder.
      */
     private Response.ResponseBuilder builder = Response.ok();
+
+    /**
+     * The response entity that will be sent with the response.
+     */
+    private ListResponseEntity<T> responseEntity
+            = new ListResponseEntity<>();
+
+    /**
+     * Private constructor.
+     */
+    private ListResponseBuilder() {
+        this.builder.entity(responseEntity);
+    }
 
     /**
      * Create a new personal response builder.
@@ -47,8 +63,8 @@ public final class ListResponseBuilder {
      * @param results Some results.
      * @return The builder.
      */
-    public ListResponseBuilder addResult(final List<?> results) {
-        builder.entity(results);
+    public ListResponseBuilder addResult(final List<T> results) {
+        responseEntity.setResults(results);
         return this;
     }
 
@@ -59,6 +75,7 @@ public final class ListResponseBuilder {
      * @return The builder.
      */
     public ListResponseBuilder limit(final Number limit) {
+        responseEntity.setLimit(limit);
         builder.header(ApiParam.LIMIT_HEADER, limit.longValue());
         return this;
     }
@@ -70,6 +87,7 @@ public final class ListResponseBuilder {
      * @return The builder.
      */
     public ListResponseBuilder total(final Number total) {
+        responseEntity.setTotal(total);
         builder.header(ApiParam.TOTAL_HEADER, total.longValue());
         return this;
     }
@@ -81,8 +99,7 @@ public final class ListResponseBuilder {
      * @return The builder.
      */
     public ListResponseBuilder total(final Object total) {
-        builder.header(ApiParam.TOTAL_HEADER, Long.valueOf(total.toString()));
-        return this;
+        return this.total(Long.valueOf(total.toString()));
     }
 
     /**
@@ -92,6 +109,7 @@ public final class ListResponseBuilder {
      * @return The builder.
      */
     public ListResponseBuilder offset(final Number offset) {
+        responseEntity.setOffset(offset);
         builder.header(ApiParam.OFFSET_HEADER, offset.longValue());
         return this;
     }
@@ -103,6 +121,7 @@ public final class ListResponseBuilder {
      * @return The builder.
      */
     public ListResponseBuilder sort(final String sort) {
+        responseEntity.setSort(sort);
         builder.header(ApiParam.SORT_HEADER, sort);
         return this;
     }
@@ -114,6 +133,7 @@ public final class ListResponseBuilder {
      * @return The builder.
      */
     public ListResponseBuilder order(final SortOrder order) {
+        responseEntity.setOrder(order);
         builder.header(ApiParam.ORDER_HEADER, order.toString());
         return this;
     }

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/response/ListResponseEntity.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/response/ListResponseEntity.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.response;
+
+import net.krotscheck.kangaroo.common.hibernate.entity.AbstractEntity;
+
+import java.util.List;
+
+/**
+ * This POJO describes an API list response. As it is insecure for us to
+ * return raw arrays of data (See OWASP), we instead wrap the list response
+ * in this pojo.
+ *
+ * @param <T> The data type returned.
+ * @author Michael Krotscheck
+ */
+public final class ListResponseEntity<T extends AbstractEntity> {
+
+    /**
+     * The total # of records available.
+     */
+    private Number total;
+
+    /**
+     * The page offset.
+     */
+    private Number offset;
+
+    /**
+     * The page size limit.
+     */
+    private Number limit;
+
+    /**
+     * The sort key.
+     */
+    private String sort;
+
+    /**
+     * The sort order.
+     */
+    private SortOrder order;
+
+    /**
+     * The results.
+     */
+    private List<T> results;
+
+    /**
+     * The total # of records available.
+     *
+     * @return The total # of records available.
+     */
+    public Number getTotal() {
+        return total;
+    }
+
+    /**
+     * Set the total.
+     *
+     * @param total The new total.
+     */
+    protected void setTotal(final Number total) {
+        this.total = total;
+    }
+
+    /**
+     * The page offset.
+     *
+     * @return The page offset.
+     */
+    public Number getOffset() {
+        return offset;
+    }
+
+    /**
+     * Set the offset.
+     *
+     * @param offset The new offset.
+     */
+    protected void setOffset(final Number offset) {
+        this.offset = offset;
+    }
+
+    /**
+     * The page size limit.
+     *
+     * @return The page size limit.
+     */
+    public Number getLimit() {
+        return limit;
+    }
+
+    /**
+     * Set the limit.
+     *
+     * @param limit The new limit.
+     */
+    protected void setLimit(final Number limit) {
+        this.limit = limit;
+    }
+
+    /**
+     * The sort key.
+     *
+     * @return The sort key.
+     */
+    public String getSort() {
+        return sort;
+    }
+
+    /**
+     * Set the sort.
+     *
+     * @param sort The new sort.
+     */
+    protected void setSort(final String sort) {
+        this.sort = sort;
+    }
+
+    /**
+     * The sort order.
+     *
+     * @return The sort order.
+     */
+    public SortOrder getOrder() {
+        return order;
+    }
+
+    /**
+     * Set the order.
+     *
+     * @param order The new order.
+     */
+    protected void setOrder(final SortOrder order) {
+        this.order = order;
+    }
+
+    /**
+     * The results.
+     *
+     * @return The results.
+     */
+    public List<T> getResults() {
+        return results;
+    }
+
+    /**
+     * Set the results.
+     *
+     * @param results The new results.
+     */
+    protected void setResults(final List<T> results) {
+        this.results = results;
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/response/ListResponseBuilderTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/response/ListResponseBuilderTest.java
@@ -41,7 +41,8 @@ public final class ListResponseBuilderTest {
         ListResponseBuilder b = ListResponseBuilder.builder();
         b.addResult(entity);
         Response response = b.build();
-        Assert.assertEquals(entity, response.getEntity());
+        ListResponseEntity e = (ListResponseEntity) response.getEntity();
+        Assert.assertEquals(entity, e.getResults());
     }
 
     /**

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/response/ListResponseEntityTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/response/ListResponseEntityTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.response;
+
+import net.krotscheck.kangaroo.common.hibernate.entity.TestEntity;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Unit tests for the list response entity.
+ *
+ * @author Michael Krotscheck
+ */
+public final class ListResponseEntityTest {
+
+    /**
+     * Test setting the total.
+     */
+    @Test
+    public void getSetTotal() {
+        ListResponseEntity<TestEntity> e = new ListResponseEntity<>();
+
+        assertNull(e.getTotal());
+        e.setTotal(10);
+        assertEquals(10, e.getTotal());
+    }
+
+    /**
+     * Test setting offset.
+     */
+    @Test
+    public void getSetOffset() {
+        ListResponseEntity<TestEntity> e = new ListResponseEntity<>();
+
+        assertNull(e.getOffset());
+        e.setOffset(10);
+        assertEquals(10, e.getOffset());
+    }
+
+    /**
+     * Test setting the limit.
+     */
+    @Test
+    public void getSetLimit() {
+        ListResponseEntity<TestEntity> e = new ListResponseEntity<>();
+
+        assertNull(e.getLimit());
+        e.setLimit(10);
+        assertEquals(10, e.getLimit());
+    }
+
+    /**
+     * Test setting the sort.
+     */
+    @Test
+    public void getSetSort() {
+        ListResponseEntity<TestEntity> e = new ListResponseEntity<>();
+
+        assertNull(e.getSort());
+        e.setSort("foo");
+        assertEquals("foo", e.getSort());
+    }
+
+    /**
+     * Test setting the order.
+     */
+    @Test
+    public void getSetOrder() {
+        ListResponseEntity<TestEntity> e = new ListResponseEntity<>();
+
+        assertNull(e.getOrder());
+        e.setOrder(SortOrder.ASC);
+        assertEquals(SortOrder.ASC, e.getOrder());
+    }
+
+    /**
+     * Test setting the results.
+     */
+    @Test
+    public void getSetResults() {
+        ListResponseEntity<TestEntity> e = new ListResponseEntity<>();
+        List<TestEntity> list = new ArrayList<>();
+
+        assertNull(e.getResults());
+        e.setResults(list);
+        assertEquals(list, e.getResults());
+    }
+
+}
+    

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/filter/OAuth2AuthenticationFilterTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/filter/OAuth2AuthenticationFilterTest.java
@@ -18,17 +18,20 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.filter;
 
+import net.krotscheck.kangaroo.authz.admin.Scope;
+import net.krotscheck.kangaroo.authz.admin.v1.resource.AbstractResourceTest;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthTokenType;
-import net.krotscheck.kangaroo.authz.admin.Scope;
-import net.krotscheck.kangaroo.authz.admin.v1.resource.AbstractResourceTest;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.common.hibernate.entity.AbstractEntity;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -44,24 +47,38 @@ public final class OAuth2AuthenticationFilterTest
         extends AbstractResourceTest {
 
     /**
+     * Convenience generic type for response decoding.
+     */
+    private static final GenericType<ListResponseEntity<AbstractEntity>> LIST_TYPE =
+            new GenericType<ListResponseEntity<AbstractEntity>>() {
+
+            };
+    /**
      * A valid, non-expired, bearer token.
      */
     private OAuthToken validBearerToken;
-
     /**
      * A valid, non-expired, bearer token with no appropriate scope.
      */
     private OAuthToken noScopeBearerToken;
-
     /**
      * An expired bearer token.
      */
     private OAuthToken expiredBearerToken;
-
     /**
      * A non-bearer token.
      */
     private OAuthToken authToken;
+
+    /**
+     * Return the appropriate list type for this test suite.
+     *
+     * @return The list type, used for test decoding.
+     */
+    @Override
+    protected GenericType<ListResponseEntity<AbstractEntity>> getListType() {
+        return LIST_TYPE;
+    }
 
     /**
      * Return the token scope required for admin access on this test.

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceCRUDTest.java
@@ -54,7 +54,7 @@ import java.util.UUID;
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(ParameterizedSingleInstanceTestRunnerFactory.class)
 public abstract class AbstractServiceCRUDTest<T extends AbstractAuthzEntity>
-        extends AbstractResourceTest {
+        extends AbstractResourceTest<T> {
 
     /**
      * Class reference for this class' type, used in casting.

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceTest.java
@@ -27,6 +27,9 @@ import net.krotscheck.kangaroo.authz.common.database.entity.User;
 import net.krotscheck.kangaroo.authz.oauth2.exception.RFC6749.InvalidScopeException;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.common.hibernate.entity.AbstractEntity;
+import net.krotscheck.kangaroo.common.hibernate.entity.TestEntity;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import net.krotscheck.kangaroo.test.rule.TestDataResource;
 import org.apache.commons.configuration.Configuration;
 import org.glassfish.jersey.internal.inject.InjectionManager;
@@ -42,6 +45,7 @@ import org.mockito.Mockito;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
@@ -56,9 +60,28 @@ import java.util.UUID;
 public final class AbstractServiceTest extends AbstractResourceTest {
 
     /**
+     * Convenience generic type for response decoding.
+     */
+    private static final GenericType<ListResponseEntity<AbstractEntity>> LIST_TYPE =
+            new GenericType<ListResponseEntity<AbstractEntity>>() {
+
+            };
+
+    /**
+     * Return the appropriate list type for this test suite.
+     *
+     * @return The list type, used for test decoding.
+     */
+    @Override
+    protected GenericType<ListResponseEntity<AbstractEntity>> getListType() {
+        return LIST_TYPE;
+    }
+
+    /**
      * A user application from which we can issue tokens.
      */
     private static ApplicationContext userApp;
+
     /**
      * Test data loading for this test.
      */

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ApplicationServiceBrowseTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ApplicationServiceBrowseTest.java
@@ -18,12 +18,13 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
+import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
-import net.krotscheck.kangaroo.authz.admin.Scope;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.hibernate.Criteria;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -47,8 +48,8 @@ public final class ApplicationServiceBrowseTest
     /**
      * Convenience generic type for response decoding.
      */
-    private static final GenericType<List<Application>> LIST_TYPE =
-            new GenericType<List<Application>>() {
+    private static final GenericType<ListResponseEntity<Application>> LIST_TYPE =
+            new GenericType<ListResponseEntity<Application>>() {
 
             };
 
@@ -71,8 +72,48 @@ public final class ApplicationServiceBrowseTest
      * @return The list type, used for test decoding.
      */
     @Override
-    protected GenericType<List<Application>> getListType() {
+    protected GenericType<ListResponseEntity<Application>> getListType() {
         return LIST_TYPE;
+    }
+
+    /**
+     * Test parameters.
+     *
+     * @return A list of parameters used to initialize the test class.
+     */
+    @Parameterized.Parameters
+    public static Collection parameters() {
+        return Arrays.asList(
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.APPLICATION_ADMIN,
+                        false
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.APPLICATION,
+                        false
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.APPLICATION_ADMIN,
+                        true
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.APPLICATION,
+                        true
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.APPLICATION_ADMIN,
+                        false
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.APPLICATION,
+                        false
+                });
     }
 
     /**
@@ -151,45 +192,5 @@ public final class ApplicationServiceBrowseTest
     @Override
     protected URI getUrlForEntity(final AbstractAuthzEntity entity) {
         return getUrlForId(entity.getId().toString());
-    }
-
-    /**
-     * Test parameters.
-     *
-     * @return A list of parameters used to initialize the test class.
-     */
-    @Parameterized.Parameters
-    public static Collection parameters() {
-        return Arrays.asList(
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.APPLICATION_ADMIN,
-                        false
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.APPLICATION,
-                        false
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.APPLICATION_ADMIN,
-                        true
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.APPLICATION,
-                        true
-                },
-                new Object[]{
-                        ClientType.ClientCredentials,
-                        Scope.APPLICATION_ADMIN,
-                        false
-                },
-                new Object[]{
-                        ClientType.ClientCredentials,
-                        Scope.APPLICATION,
-                        false
-                });
     }
 }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ApplicationServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ApplicationServiceCRUDTest.java
@@ -26,6 +26,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.Role;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
@@ -34,6 +35,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
@@ -52,6 +54,14 @@ public final class ApplicationServiceCRUDTest
         extends AbstractServiceCRUDTest<Application> {
 
     /**
+     * Convenience generic type for response decoding.
+     */
+    private static final GenericType<ListResponseEntity<Application>> LIST_TYPE =
+            new GenericType<ListResponseEntity<Application>>() {
+
+            };
+
+    /**
      * Create a new instance of this parameterized test.
      *
      * @param clientType    The type of  client.
@@ -65,6 +75,62 @@ public final class ApplicationServiceCRUDTest
                                       final Boolean shouldSucceed) {
         super(Application.class, clientType, tokenScope, createUser,
                 shouldSucceed);
+    }
+
+    /**
+     * Test parameters.
+     *
+     * @return A list of parameters used to initialize the test class.
+     */
+    @Parameterized.Parameters
+    public static Collection parameters() {
+        return Arrays.asList(
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.APPLICATION_ADMIN,
+                        false,
+                        true
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.APPLICATION,
+                        false,
+                        true
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.APPLICATION_ADMIN,
+                        true,
+                        true
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.APPLICATION,
+                        true,
+                        false
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.APPLICATION_ADMIN,
+                        false,
+                        true
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.APPLICATION,
+                        false,
+                        false
+                });
+    }
+
+    /**
+     * Return the appropriate list type for this test suite.
+     *
+     * @return The list type, used for test decoding.
+     */
+    @Override
+    protected GenericType<ListResponseEntity<Application>> getListType() {
+        return LIST_TYPE;
     }
 
     /**
@@ -149,52 +215,6 @@ public final class ApplicationServiceCRUDTest
             return getUrlForId(null);
         }
         return getUrlForId(entity.getId().toString());
-    }
-
-    /**
-     * Test parameters.
-     *
-     * @return A list of parameters used to initialize the test class.
-     */
-    @Parameterized.Parameters
-    public static Collection parameters() {
-        return Arrays.asList(
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.APPLICATION_ADMIN,
-                        false,
-                        true
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.APPLICATION,
-                        false,
-                        true
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.APPLICATION_ADMIN,
-                        true,
-                        true
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.APPLICATION,
-                        true,
-                        false
-                },
-                new Object[]{
-                        ClientType.ClientCredentials,
-                        Scope.APPLICATION_ADMIN,
-                        false,
-                        true
-                },
-                new Object[]{
-                        ClientType.ClientCredentials,
-                        Scope.APPLICATION,
-                        false,
-                        false
-                });
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ApplicationServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ApplicationServiceSearchTest.java
@@ -18,11 +18,12 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
+import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
-import net.krotscheck.kangaroo.authz.admin.Scope;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -45,8 +46,8 @@ public final class ApplicationServiceSearchTest
     /**
      * Convenience generic type for response decoding.
      */
-    private static final GenericType<List<Application>> LIST_TYPE =
-            new GenericType<List<Application>>() {
+    private static final GenericType<ListResponseEntity<Application>> LIST_TYPE =
+            new GenericType<ListResponseEntity<Application>>() {
 
             };
 
@@ -69,8 +70,48 @@ public final class ApplicationServiceSearchTest
      * @return The list type, used for test decoding.
      */
     @Override
-    protected GenericType<List<Application>> getListType() {
+    protected GenericType<ListResponseEntity<Application>> getListType() {
         return LIST_TYPE;
+    }
+
+    /**
+     * Test parameters.
+     *
+     * @return A list of parameters used to initialize the test class.
+     */
+    @Parameterized.Parameters
+    public static Collection parameters() {
+        return Arrays.asList(
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.APPLICATION_ADMIN,
+                        false
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.APPLICATION,
+                        false
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.APPLICATION_ADMIN,
+                        true
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.APPLICATION,
+                        true
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.APPLICATION_ADMIN,
+                        false
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.APPLICATION,
+                        false
+                });
     }
 
     /**
@@ -138,45 +179,5 @@ public final class ApplicationServiceSearchTest
     @Override
     protected URI getUrlForEntity(final AbstractAuthzEntity entity) {
         return getUrlForId(entity.getId().toString());
-    }
-
-    /**
-     * Test parameters.
-     *
-     * @return A list of parameters used to initialize the test class.
-     */
-    @Parameterized.Parameters
-    public static Collection parameters() {
-        return Arrays.asList(
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.APPLICATION_ADMIN,
-                        false
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.APPLICATION,
-                        false
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.APPLICATION_ADMIN,
-                        true
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.APPLICATION,
-                        true
-                },
-                new Object[]{
-                        ClientType.ClientCredentials,
-                        Scope.APPLICATION_ADMIN,
-                        false
-                },
-                new Object[]{
-                        ClientType.ClientCredentials,
-                        Scope.APPLICATION,
-                        false
-                });
     }
 }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AuthenticatorServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AuthenticatorServiceCRUDTest.java
@@ -18,18 +18,20 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
+import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorType;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Authenticator;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
-import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.hibernate.Session;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
@@ -45,6 +47,14 @@ import java.util.UUID;
  */
 public final class AuthenticatorServiceCRUDTest
         extends AbstractServiceCRUDTest<Authenticator> {
+
+    /**
+     * Convenience generic type for response decoding.
+     */
+    private static final GenericType<ListResponseEntity<Authenticator>> LIST_TYPE =
+            new GenericType<ListResponseEntity<Authenticator>>() {
+
+            };
 
     /**
      * Create a new instance of this parameterized test.
@@ -107,6 +117,16 @@ public final class AuthenticatorServiceCRUDTest
                         false
                 }
         });
+    }
+
+    /**
+     * Return the appropriate list type for this test suite.
+     *
+     * @return The list type, used for test decoding.
+     */
+    @Override
+    protected GenericType<ListResponseEntity<Authenticator>> getListType() {
+        return LIST_TYPE;
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AuthenticatorServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AuthenticatorServiceSearchTest.java
@@ -18,6 +18,7 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
+import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorType;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Authenticator;
@@ -25,7 +26,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.Client;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
-import net.krotscheck.kangaroo.authz.admin.Scope;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,8 +57,8 @@ public final class AuthenticatorServiceSearchTest
     /**
      * Convenience generic type for response decoding.
      */
-    private static final GenericType<List<Authenticator>> LIST_TYPE =
-            new GenericType<List<Authenticator>>() {
+    private static final GenericType<ListResponseEntity<Authenticator>> LIST_TYPE =
+            new GenericType<ListResponseEntity<Authenticator>>() {
 
             };
 
@@ -80,8 +81,48 @@ public final class AuthenticatorServiceSearchTest
      * @return The list type, used for test decoding.
      */
     @Override
-    protected GenericType<List<Authenticator>> getListType() {
+    protected GenericType<ListResponseEntity<Authenticator>> getListType() {
         return LIST_TYPE;
+    }
+
+    /**
+     * Test parameters.
+     *
+     * @return The parameters passed to this test during every run.
+     */
+    @Parameterized.Parameters
+    public static Collection parameters() {
+        return Arrays.asList(
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.AUTHENTICATOR_ADMIN,
+                        false
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.AUTHENTICATOR,
+                        false
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.AUTHENTICATOR_ADMIN,
+                        true
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.AUTHENTICATOR,
+                        true
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.AUTHENTICATOR_ADMIN,
+                        false
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.AUTHENTICATOR,
+                        false
+                });
     }
 
     /**
@@ -157,46 +198,6 @@ public final class AuthenticatorServiceSearchTest
     }
 
     /**
-     * Test parameters.
-     *
-     * @return The parameters passed to this test during every run.
-     */
-    @Parameterized.Parameters
-    public static Collection parameters() {
-        return Arrays.asList(
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.AUTHENTICATOR_ADMIN,
-                        false
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.AUTHENTICATOR,
-                        false
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.AUTHENTICATOR_ADMIN,
-                        true
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.AUTHENTICATOR,
-                        true
-                },
-                new Object[]{
-                        ClientType.ClientCredentials,
-                        Scope.AUTHENTICATOR_ADMIN,
-                        false
-                },
-                new Object[]{
-                        ClientType.ClientCredentials,
-                        Scope.AUTHENTICATOR,
-                        false
-                });
-    }
-
-    /**
      * Test that we can filter a search by an client ID.
      */
     @Test
@@ -241,14 +242,12 @@ public final class AuthenticatorServiceSearchTest
         } else if (!isAccessible(c, token)) {
             assertErrorResponse(r, Status.BAD_REQUEST);
         } else {
-            List<Authenticator> results = r.readEntity(getListType());
-            Assert.assertEquals(expectedOffset.toString(),
-                    r.getHeaderString("Offset"));
-            Assert.assertEquals(expectedLimit.toString(),
-                    r.getHeaderString("Limit"));
-            Assert.assertEquals(expectedTotal.toString(),
-                    r.getHeaderString("Total"));
-            Assert.assertEquals(expectedResultSize, results.size());
+
+            assertListResponse(r,
+                    expectedResultSize,
+                    expectedOffset,
+                    expectedLimit,
+                    expectedTotal);
         }
     }
 
@@ -321,14 +320,11 @@ public final class AuthenticatorServiceSearchTest
         } else {
             Assert.assertTrue(expectedTotal > 0);
 
-            List<Authenticator> results = r.readEntity(getListType());
-            Assert.assertEquals(expectedOffset.toString(),
-                    r.getHeaderString("Offset"));
-            Assert.assertEquals(expectedLimit.toString(),
-                    r.getHeaderString("Limit"));
-            Assert.assertEquals(expectedTotal.toString(),
-                    r.getHeaderString("Total"));
-            Assert.assertEquals(expectedResultSize, results.size());
+            assertListResponse(r,
+                    expectedResultSize,
+                    expectedOffset,
+                    expectedLimit,
+                    expectedTotal);
         }
     }
 

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientRedirectServiceBrowseTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientRedirectServiceBrowseTest.java
@@ -18,17 +18,17 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
+import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientRedirect;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
-import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
-
 import org.hibernate.criterion.Restrictions;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -54,8 +54,8 @@ public final class ClientRedirectServiceBrowseTest
     /**
      * Generic type declaration for list decoding.
      */
-    private static final GenericType<List<ClientRedirect>> LIST_TYPE =
-            new GenericType<List<ClientRedirect>>() {
+    private static final GenericType<ListResponseEntity<ClientRedirect>> LIST_TYPE =
+            new GenericType<ListResponseEntity<ClientRedirect>>() {
 
             };
 
@@ -70,6 +70,46 @@ public final class ClientRedirectServiceBrowseTest
                                            final String tokenScope,
                                            final Boolean createUser) {
         super(clientType, tokenScope, createUser);
+    }
+
+    /**
+     * Test parameters.
+     *
+     * @return The list of parameters.
+     */
+    @Parameterized.Parameters
+    public static Collection parameters() {
+        return Arrays.asList(
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT_ADMIN,
+                        false
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT,
+                        false
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT_ADMIN,
+                        true
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT,
+                        true
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.CLIENT_ADMIN,
+                        false
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.CLIENT,
+                        false
+                });
     }
 
     /**
@@ -98,7 +138,7 @@ public final class ClientRedirectServiceBrowseTest
      * @return The list type.
      */
     @Override
-    protected GenericType<List<ClientRedirect>> getListType() {
+    protected GenericType<ListResponseEntity<ClientRedirect>> getListType() {
         return LIST_TYPE;
     }
 
@@ -157,46 +197,6 @@ public final class ClientRedirectServiceBrowseTest
                 .filter(c -> c.equals(parentEntity))
                 .flatMap(c -> c.getRedirects().stream())
                 .collect(Collectors.toList());
-    }
-
-    /**
-     * Test parameters.
-     *
-     * @return The list of parameters.
-     */
-    @Parameterized.Parameters
-    public static Collection parameters() {
-        return Arrays.asList(
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.CLIENT_ADMIN,
-                        false
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.CLIENT,
-                        false
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.CLIENT_ADMIN,
-                        true
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.CLIENT,
-                        true
-                },
-                new Object[]{
-                        ClientType.ClientCredentials,
-                        Scope.CLIENT_ADMIN,
-                        false
-                },
-                new Object[]{
-                        ClientType.ClientCredentials,
-                        Scope.CLIENT,
-                        false
-                });
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientRedirectServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientRedirectServiceCRUDTest.java
@@ -25,12 +25,14 @@ import net.krotscheck.kangaroo.authz.common.database.entity.Client;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientRedirect;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hibernate.Session;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
@@ -44,6 +46,14 @@ import java.util.UUID;
  */
 public final class ClientRedirectServiceCRUDTest
         extends AbstractSubserviceCRUDTest<Client, ClientRedirect> {
+
+    /**
+     * Convenience generic type for response decoding.
+     */
+    private static final GenericType<ListResponseEntity<ClientRedirect>> LIST_TYPE =
+            new GenericType<ListResponseEntity<ClientRedirect>>() {
+
+            };
 
     /**
      * Create a new instance of this parameterized test.
@@ -105,6 +115,16 @@ public final class ClientRedirectServiceCRUDTest
                         false,
                         false
                 });
+    }
+
+    /**
+     * Return the appropriate list type for this test suite.
+     *
+     * @return The list type, used for test decoding.
+     */
+    @Override
+    protected GenericType<ListResponseEntity<ClientRedirect>> getListType() {
+        return LIST_TYPE;
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientReferrerServiceBrowseTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientReferrerServiceBrowseTest.java
@@ -18,17 +18,17 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
+import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientReferrer;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
-import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
-
 import org.hibernate.criterion.Restrictions;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -54,8 +54,8 @@ public final class ClientReferrerServiceBrowseTest
     /**
      * Generic type declaration for list decoding.
      */
-    private static final GenericType<List<ClientReferrer>> LIST_TYPE =
-            new GenericType<List<ClientReferrer>>() {
+    private static final GenericType<ListResponseEntity<ClientReferrer>> LIST_TYPE =
+            new GenericType<ListResponseEntity<ClientReferrer>>() {
 
             };
 
@@ -70,6 +70,46 @@ public final class ClientReferrerServiceBrowseTest
                                            final String tokenScope,
                                            final Boolean createUser) {
         super(clientType, tokenScope, createUser);
+    }
+
+    /**
+     * Test parameters.
+     *
+     * @return The list of parameters.
+     */
+    @Parameterized.Parameters
+    public static Collection parameters() {
+        return Arrays.asList(
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT_ADMIN,
+                        false
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT,
+                        false
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT_ADMIN,
+                        true
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT,
+                        true
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.CLIENT_ADMIN,
+                        false
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.CLIENT,
+                        false
+                });
     }
 
     /**
@@ -98,7 +138,7 @@ public final class ClientReferrerServiceBrowseTest
      * @return The list type.
      */
     @Override
-    protected GenericType<List<ClientReferrer>> getListType() {
+    protected GenericType<ListResponseEntity<ClientReferrer>> getListType() {
         return LIST_TYPE;
     }
 
@@ -157,46 +197,6 @@ public final class ClientReferrerServiceBrowseTest
                 .filter(c -> c.equals(parentEntity))
                 .flatMap(c -> c.getReferrers().stream())
                 .collect(Collectors.toList());
-    }
-
-    /**
-     * Test parameters.
-     *
-     * @return The list of parameters.
-     */
-    @Parameterized.Parameters
-    public static Collection parameters() {
-        return Arrays.asList(
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.CLIENT_ADMIN,
-                        false
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.CLIENT,
-                        false
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.CLIENT_ADMIN,
-                        true
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.CLIENT,
-                        true
-                },
-                new Object[]{
-                        ClientType.ClientCredentials,
-                        Scope.CLIENT_ADMIN,
-                        false
-                },
-                new Object[]{
-                        ClientType.ClientCredentials,
-                        Scope.CLIENT,
-                        false
-                });
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientReferrerServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientReferrerServiceCRUDTest.java
@@ -18,18 +18,20 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
+import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientReferrer;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
-import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hibernate.Session;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
@@ -43,6 +45,14 @@ import java.util.UUID;
  */
 public final class ClientReferrerServiceCRUDTest
         extends AbstractSubserviceCRUDTest<Client, ClientReferrer> {
+
+    /**
+     * Convenience generic type for response decoding.
+     */
+    private static final GenericType<ListResponseEntity<ClientReferrer>> LIST_TYPE =
+            new GenericType<ListResponseEntity<ClientReferrer>>() {
+
+            };
 
     /**
      * Create a new instance of this parameterized test.
@@ -104,6 +114,16 @@ public final class ClientReferrerServiceCRUDTest
                         false,
                         false
                 });
+    }
+
+    /**
+     * Return the appropriate list type for this test suite.
+     *
+     * @return The list type, used for test decoding.
+     */
+    @Override
+    protected GenericType<ListResponseEntity<ClientReferrer>> getListType() {
+        return LIST_TYPE;
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientServiceCRUDTest.java
@@ -18,17 +18,19 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
+import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
-import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
@@ -44,6 +46,14 @@ import java.util.UUID;
  */
 public final class ClientServiceCRUDTest
         extends AbstractServiceCRUDTest<Client> {
+
+    /**
+     * Convenience generic type for response decoding.
+     */
+    private static final GenericType<ListResponseEntity<Client>> LIST_TYPE =
+            new GenericType<ListResponseEntity<Client>>() {
+
+            };
 
     /**
      * Create a new instance of this parameterized test.
@@ -104,6 +114,16 @@ public final class ClientServiceCRUDTest
                         false,
                         false
                 });
+    }
+
+    /**
+     * Return the appropriate list type for this test suite.
+     *
+     * @return The list type, used for test decoding.
+     */
+    @Override
+    protected GenericType<ListResponseEntity<Client>> getListType() {
+        return LIST_TYPE;
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientServiceSearchTest.java
@@ -18,13 +18,14 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
+import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
-import net.krotscheck.kangaroo.authz.admin.Scope;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.hibernate.Session;
 import org.junit.Assert;
 import org.junit.Test;
@@ -56,8 +57,8 @@ public final class ClientServiceSearchTest
     /**
      * Convenience generic type for response decoding.
      */
-    private static final GenericType<List<Client>> LIST_TYPE =
-            new GenericType<List<Client>>() {
+    private static final GenericType<ListResponseEntity<Client>> LIST_TYPE =
+            new GenericType<ListResponseEntity<Client>>() {
 
             };
 
@@ -75,12 +76,52 @@ public final class ClientServiceSearchTest
     }
 
     /**
+     * Test parameters.
+     *
+     * @return The parameters passed to this test during every run.
+     */
+    @Parameterized.Parameters
+    public static Collection parameters() {
+        return Arrays.asList(
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT_ADMIN,
+                        false
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT,
+                        false
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT_ADMIN,
+                        true
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.CLIENT,
+                        true
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.CLIENT_ADMIN,
+                        false
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.CLIENT,
+                        false
+                });
+    }
+
+    /**
      * Return the appropriate list type for this test suite.
      *
      * @return The list type, used for test decoding.
      */
     @Override
-    protected GenericType<List<Client>> getListType() {
+    protected GenericType<ListResponseEntity<Client>> getListType() {
         return LIST_TYPE;
     }
 
@@ -161,46 +202,6 @@ public final class ClientServiceSearchTest
     }
 
     /**
-     * Test parameters.
-     *
-     * @return The parameters passed to this test during every run.
-     */
-    @Parameterized.Parameters
-    public static Collection parameters() {
-        return Arrays.asList(
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.CLIENT_ADMIN,
-                        false
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.CLIENT,
-                        false
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.CLIENT_ADMIN,
-                        true
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.CLIENT,
-                        true
-                },
-                new Object[]{
-                        ClientType.ClientCredentials,
-                        Scope.CLIENT_ADMIN,
-                        false
-                },
-                new Object[]{
-                        ClientType.ClientCredentials,
-                        Scope.CLIENT,
-                        false
-                });
-    }
-
-    /**
      * Test that we can filter a search by an application ID.
      */
     @Test
@@ -237,14 +238,11 @@ public final class ClientServiceSearchTest
         } else {
             Assert.assertTrue(expectedTotal > 0);
 
-            List<Client> results = r.readEntity(getListType());
-            Assert.assertEquals(expectedOffset.toString(),
-                    r.getHeaderString("Offset"));
-            Assert.assertEquals(expectedLimit.toString(),
-                    r.getHeaderString("Limit"));
-            Assert.assertEquals(expectedTotal.toString(),
-                    r.getHeaderString("Total"));
-            Assert.assertEquals(expectedResultSize, results.size());
+            assertListResponse(r,
+                    expectedResultSize,
+                    expectedOffset,
+                    expectedLimit,
+                    expectedTotal);
         }
     }
 

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ConfigServiceTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ConfigServiceTest.java
@@ -22,11 +22,14 @@ import net.krotscheck.kangaroo.authz.admin.v1.resource.ConfigService.Configurati
 import net.krotscheck.kangaroo.authz.admin.v1.servlet.Config;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
+import net.krotscheck.kangaroo.common.hibernate.entity.AbstractEntity;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.apache.commons.configuration.Configuration;
 import org.hibernate.Session;
 import org.junit.Assert;
 import org.junit.Test;
 
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.util.UUID;
@@ -37,6 +40,24 @@ import static org.junit.Assert.assertTrue;
  * Unit tests for the configuration service.
  */
 public final class ConfigServiceTest extends AbstractResourceTest {
+
+    /**
+     * Convenience generic type for response decoding.
+     */
+    private static final GenericType<ListResponseEntity<AbstractEntity>> LIST_TYPE =
+            new GenericType<ListResponseEntity<AbstractEntity>>() {
+
+            };
+
+    /**
+     * Return the appropriate list type for this test suite.
+     *
+     * @return The list type, used for test decoding.
+     */
+    @Override
+    protected GenericType<ListResponseEntity<AbstractEntity>> getListType() {
+        return LIST_TYPE;
+    }
 
     /**
      * This service is world accessible.

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/OAuthTokenServiceBrowseTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/OAuthTokenServiceBrowseTest.java
@@ -18,15 +18,15 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
+import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
 import net.krotscheck.kangaroo.authz.common.database.entity.UserIdentity;
-import net.krotscheck.kangaroo.authz.admin.Scope;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.hibernate.Criteria;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -55,8 +55,8 @@ public final class OAuthTokenServiceBrowseTest
     /**
      * Generic type declaration for list decoding.
      */
-    private static final GenericType<List<OAuthToken>> LIST_TYPE =
-            new GenericType<List<OAuthToken>>() {
+    private static final GenericType<ListResponseEntity<OAuthToken>> LIST_TYPE =
+            new GenericType<ListResponseEntity<OAuthToken>>() {
 
             };
 
@@ -71,6 +71,46 @@ public final class OAuthTokenServiceBrowseTest
                                        final String tokenScope,
                                        final Boolean createUser) {
         super(clientType, tokenScope, createUser);
+    }
+
+    /**
+     * Test parameters.
+     *
+     * @return The list of parameters.
+     */
+    @Parameterized.Parameters
+    public static Collection parameters() {
+        return Arrays.asList(
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.TOKEN_ADMIN,
+                        false
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.TOKEN,
+                        false
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.TOKEN_ADMIN,
+                        true
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.TOKEN,
+                        true
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.TOKEN_ADMIN,
+                        false
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.TOKEN,
+                        false
+                });
     }
 
     /**
@@ -99,7 +139,7 @@ public final class OAuthTokenServiceBrowseTest
      * @return The list type.
      */
     @Override
-    protected GenericType<List<OAuthToken>> getListType() {
+    protected GenericType<ListResponseEntity<OAuthToken>> getListType() {
         return LIST_TYPE;
     }
 
@@ -141,46 +181,6 @@ public final class OAuthTokenServiceBrowseTest
                 .flatMap(a -> a.getClients().stream())
                 .flatMap(c -> c.getTokens().stream())
                 .collect(Collectors.toList());
-    }
-
-    /**
-     * Test parameters.
-     *
-     * @return The list of parameters.
-     */
-    @Parameterized.Parameters
-    public static Collection parameters() {
-        return Arrays.asList(
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.TOKEN_ADMIN,
-                        false
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.TOKEN,
-                        false
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.TOKEN_ADMIN,
-                        true
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.TOKEN,
-                        true
-                },
-                new Object[]{
-                        ClientType.ClientCredentials,
-                        Scope.TOKEN_ADMIN,
-                        false
-                },
-                new Object[]{
-                        ClientType.ClientCredentials,
-                        Scope.TOKEN,
-                        false
-                });
     }
 
     /**
@@ -233,14 +233,11 @@ public final class OAuthTokenServiceBrowseTest
             assertErrorResponse(r, Status.BAD_REQUEST.getStatusCode(),
                     "invalid_scope");
         } else if (isAccessible(c, getAdminToken())) {
-            List<OAuthToken> results = r.readEntity(getListType());
-            Assert.assertEquals(expectedOffset.toString(),
-                    r.getHeaderString("Offset"));
-            Assert.assertEquals(expectedLimit.toString(),
-                    r.getHeaderString("Limit"));
-            Assert.assertEquals(expectedTotal.toString(),
-                    r.getHeaderString("Total"));
-            Assert.assertEquals(expectedResultSize, results.size());
+            assertListResponse(r,
+                    expectedResultSize,
+                    expectedOffset,
+                    expectedLimit,
+                    expectedTotal);
         } else {
             assertErrorResponse(r, Status.BAD_REQUEST);
         }
@@ -273,14 +270,11 @@ public final class OAuthTokenServiceBrowseTest
             assertErrorResponse(r, Status.BAD_REQUEST.getStatusCode(),
                     "invalid_scope");
         } else if (isAccessible(identity, getAdminToken())) {
-            List<OAuthToken> results = r.readEntity(getListType());
-            Assert.assertEquals(expectedOffset.toString(),
-                    r.getHeaderString("Offset"));
-            Assert.assertEquals(expectedLimit.toString(),
-                    r.getHeaderString("Limit"));
-            Assert.assertEquals(expectedTotal.toString(),
-                    r.getHeaderString("Total"));
-            Assert.assertEquals(expectedResultSize, results.size());
+            assertListResponse(r,
+                    expectedResultSize,
+                    expectedOffset,
+                    expectedLimit,
+                    expectedTotal);
         } else {
             assertErrorResponse(r, Status.BAD_REQUEST);
         }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/OAuthTokenServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/OAuthTokenServiceCRUDTest.java
@@ -18,6 +18,7 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
+import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorType;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
@@ -27,13 +28,14 @@ import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthTokenType;
 import net.krotscheck.kangaroo.authz.common.database.entity.UserIdentity;
-import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.hibernate.Session;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
@@ -50,6 +52,14 @@ import java.util.stream.Collectors;
  */
 public final class OAuthTokenServiceCRUDTest
         extends AbstractServiceCRUDTest<OAuthToken> {
+
+    /**
+     * Convenience generic type for response decoding.
+     */
+    private static final GenericType<ListResponseEntity<OAuthToken>> LIST_TYPE =
+            new GenericType<ListResponseEntity<OAuthToken>>() {
+
+            };
 
     /**
      * Create a new instance of this parameterized test.
@@ -159,6 +169,16 @@ public final class OAuthTokenServiceCRUDTest
                         false,
                         false
                 });
+    }
+
+    /**
+     * Return the appropriate list type for this test suite.
+     *
+     * @return The list type, used for test decoding.
+     */
+    @Override
+    protected GenericType<ListResponseEntity<OAuthToken>> getListType() {
+        return LIST_TYPE;
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/OAuthTokenServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/OAuthTokenServiceSearchTest.java
@@ -18,6 +18,7 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
+import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;
@@ -26,7 +27,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthTokenType;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
 import net.krotscheck.kangaroo.authz.common.database.entity.UserIdentity;
-import net.krotscheck.kangaroo.authz.admin.Scope;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -57,8 +58,8 @@ public final class OAuthTokenServiceSearchTest
     /**
      * Convenience generic type for response decoding.
      */
-    private static final GenericType<List<OAuthToken>> LIST_TYPE =
-            new GenericType<List<OAuthToken>>() {
+    private static final GenericType<ListResponseEntity<OAuthToken>> LIST_TYPE =
+            new GenericType<ListResponseEntity<OAuthToken>>() {
 
             };
 
@@ -76,12 +77,52 @@ public final class OAuthTokenServiceSearchTest
     }
 
     /**
+     * Test parameters.
+     *
+     * @return The parameters passed to this test during every run.
+     */
+    @Parameterized.Parameters
+    public static Collection parameters() {
+        return Arrays.asList(
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.TOKEN_ADMIN,
+                        false
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.TOKEN,
+                        false
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.TOKEN_ADMIN,
+                        true
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.TOKEN,
+                        true
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.TOKEN_ADMIN,
+                        false
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.TOKEN,
+                        false
+                });
+    }
+
+    /**
      * Return the appropriate list type for this test suite.
      *
      * @return The list type, used for test decoding.
      */
     @Override
-    protected GenericType<List<OAuthToken>> getListType() {
+    protected GenericType<ListResponseEntity<OAuthToken>> getListType() {
         return LIST_TYPE;
     }
 
@@ -157,46 +198,6 @@ public final class OAuthTokenServiceSearchTest
     }
 
     /**
-     * Test parameters.
-     *
-     * @return The parameters passed to this test during every run.
-     */
-    @Parameterized.Parameters
-    public static Collection parameters() {
-        return Arrays.asList(
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.TOKEN_ADMIN,
-                        false
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.TOKEN,
-                        false
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.TOKEN_ADMIN,
-                        true
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.TOKEN,
-                        true
-                },
-                new Object[]{
-                        ClientType.ClientCredentials,
-                        Scope.TOKEN_ADMIN,
-                        false
-                },
-                new Object[]{
-                        ClientType.ClientCredentials,
-                        Scope.TOKEN,
-                        false
-                });
-    }
-
-    /**
      * Test that we can filter a search by an user ID.
      */
     @Test
@@ -240,14 +241,11 @@ public final class OAuthTokenServiceSearchTest
         } else {
             Assert.assertTrue(expectedTotal > 0);
 
-            List<OAuthToken> results = r.readEntity(getListType());
-            Assert.assertEquals(expectedOffset.toString(),
-                    r.getHeaderString("Offset"));
-            Assert.assertEquals(expectedLimit.toString(),
-                    r.getHeaderString("Limit"));
-            Assert.assertEquals(expectedTotal.toString(),
-                    r.getHeaderString("Total"));
-            Assert.assertEquals(expectedResultSize, results.size());
+            assertListResponse(r,
+                    expectedResultSize,
+                    expectedOffset,
+                    expectedLimit,
+                    expectedTotal);
         }
     }
 
@@ -326,14 +324,11 @@ public final class OAuthTokenServiceSearchTest
         } else {
             Assert.assertTrue(expectedTotal > 0);
 
-            List<OAuthToken> results = r.readEntity(getListType());
-            Assert.assertEquals(expectedOffset.toString(),
-                    r.getHeaderString("Offset"));
-            Assert.assertEquals(expectedLimit.toString(),
-                    r.getHeaderString("Limit"));
-            Assert.assertEquals(expectedTotal.toString(),
-                    r.getHeaderString("Total"));
-            Assert.assertEquals(expectedResultSize, results.size());
+            assertListResponse(r,
+                    expectedResultSize,
+                    expectedOffset,
+                    expectedLimit,
+                    expectedTotal);
         }
     }
 
@@ -408,14 +403,11 @@ public final class OAuthTokenServiceSearchTest
         } else {
             Assert.assertTrue(expectedTotal > 0);
 
-            List<OAuthToken> results = r.readEntity(getListType());
-            Assert.assertEquals(expectedOffset.toString(),
-                    r.getHeaderString("Offset"));
-            Assert.assertEquals(expectedLimit.toString(),
-                    r.getHeaderString("Limit"));
-            Assert.assertEquals(expectedTotal.toString(),
-                    r.getHeaderString("Total"));
-            Assert.assertEquals(expectedResultSize, results.size());
+            assertListResponse(r,
+                    expectedResultSize,
+                    expectedOffset,
+                    expectedLimit,
+                    expectedTotal);
         }
     }
 
@@ -487,14 +479,11 @@ public final class OAuthTokenServiceSearchTest
         } else {
             Assert.assertTrue(expectedTotal > 0);
 
-            List<OAuthToken> results = r.readEntity(getListType());
-            Assert.assertEquals(expectedOffset.toString(),
-                    r.getHeaderString("Offset"));
-            Assert.assertEquals(expectedLimit.toString(),
-                    r.getHeaderString("Limit"));
-            Assert.assertEquals(expectedTotal.toString(),
-                    r.getHeaderString("Total"));
-            Assert.assertEquals(expectedResultSize, results.size());
+            assertListResponse(r,
+                    expectedResultSize,
+                    expectedOffset,
+                    expectedLimit,
+                    expectedTotal);
         }
     }
 

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleServiceCRUDTest.java
@@ -18,14 +18,15 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
+import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.ApplicationScope;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.Role;
-import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import net.krotscheck.kangaroo.test.HttpUtil;
 import org.apache.commons.lang.RandomStringUtils;
 import org.hibernate.Session;
@@ -33,6 +34,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -50,6 +52,14 @@ import java.util.stream.Collectors;
  */
 public final class RoleServiceCRUDTest
         extends AbstractServiceCRUDTest<Role> {
+
+    /**
+     * Convenience generic type for response decoding.
+     */
+    private static final GenericType<ListResponseEntity<Role>> LIST_TYPE =
+            new GenericType<ListResponseEntity<Role>>() {
+
+            };
 
     /**
      * Create a new instance of this parameterized test.
@@ -110,6 +120,16 @@ public final class RoleServiceCRUDTest
                         false,
                         false
                 });
+    }
+
+    /**
+     * Return the appropriate list type for this test suite.
+     *
+     * @return The list type, used for test decoding.
+     */
+    @Override
+    protected GenericType<ListResponseEntity<Role>> getListType() {
+        return LIST_TYPE;
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleServiceSearchTest.java
@@ -18,13 +18,14 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
+import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.Role;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
-import net.krotscheck.kangaroo.authz.admin.Scope;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,8 +56,8 @@ public final class RoleServiceSearchTest
     /**
      * Convenience generic type for response decoding.
      */
-    private static final GenericType<List<Role>> LIST_TYPE =
-            new GenericType<List<Role>>() {
+    private static final GenericType<ListResponseEntity<Role>> LIST_TYPE =
+            new GenericType<ListResponseEntity<Role>>() {
 
             };
 
@@ -74,12 +75,52 @@ public final class RoleServiceSearchTest
     }
 
     /**
+     * Test parameters.
+     *
+     * @return The parameters passed to this test during every run.
+     */
+    @Parameterized.Parameters
+    public static Collection parameters() {
+        return Arrays.asList(
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.ROLE_ADMIN,
+                        false
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.ROLE,
+                        false
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.ROLE_ADMIN,
+                        true
+                },
+                new Object[]{
+                        ClientType.Implicit,
+                        Scope.ROLE,
+                        true
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.ROLE_ADMIN,
+                        false
+                },
+                new Object[]{
+                        ClientType.ClientCredentials,
+                        Scope.ROLE,
+                        false
+                });
+    }
+
+    /**
      * Return the appropriate list type for this test suite.
      *
      * @return The list type, used for test decoding.
      */
     @Override
-    protected GenericType<List<Role>> getListType() {
+    protected GenericType<ListResponseEntity<Role>> getListType() {
         return LIST_TYPE;
     }
 
@@ -154,46 +195,6 @@ public final class RoleServiceSearchTest
     }
 
     /**
-     * Test parameters.
-     *
-     * @return The parameters passed to this test during every run.
-     */
-    @Parameterized.Parameters
-    public static Collection parameters() {
-        return Arrays.asList(
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.ROLE_ADMIN,
-                        false
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.ROLE,
-                        false
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.ROLE_ADMIN,
-                        true
-                },
-                new Object[]{
-                        ClientType.Implicit,
-                        Scope.ROLE,
-                        true
-                },
-                new Object[]{
-                        ClientType.ClientCredentials,
-                        Scope.ROLE_ADMIN,
-                        false
-                },
-                new Object[]{
-                        ClientType.ClientCredentials,
-                        Scope.ROLE,
-                        false
-                });
-    }
-
-    /**
      * Test that we can filter a search by an application ID.
      */
     @Test
@@ -231,14 +232,11 @@ public final class RoleServiceSearchTest
         } else {
             Assert.assertTrue(expectedTotal > 1);
 
-            List<Role> results = r.readEntity(getListType());
-            Assert.assertEquals(expectedOffset.toString(),
-                    r.getHeaderString("Offset"));
-            Assert.assertEquals(expectedLimit.toString(),
-                    r.getHeaderString("Limit"));
-            Assert.assertEquals(expectedTotal.toString(),
-                    r.getHeaderString("Total"));
-            Assert.assertEquals(expectedResultSize, results.size());
+            assertListResponse(r,
+                    expectedResultSize,
+                    expectedOffset,
+                    expectedLimit,
+                    expectedTotal);
         }
     }
 

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ScopeServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ScopeServiceCRUDTest.java
@@ -18,15 +18,16 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
-import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder.ErrorResponse;
+import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.ApplicationScope;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
-import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder.ErrorResponse;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hibernate.Session;
 import org.junit.Assert;
@@ -34,6 +35,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
@@ -52,6 +54,14 @@ public final class ScopeServiceCRUDTest
         extends AbstractServiceCRUDTest<ApplicationScope> {
 
     /**
+     * Convenience generic type for response decoding.
+     */
+    private static final GenericType<ListResponseEntity<ApplicationScope>> LIST_TYPE =
+            new GenericType<ListResponseEntity<ApplicationScope>>() {
+
+            };
+
+    /**
      * Create a new instance of this parameterized test.
      *
      * @param clientType    The type of  client.
@@ -65,26 +75,6 @@ public final class ScopeServiceCRUDTest
                                 final Boolean shouldSucceed) {
         super(ApplicationScope.class, clientType, tokenScope, createUser,
                 shouldSucceed);
-    }
-
-    /**
-     * Return the token scope required for admin access on this test.
-     *
-     * @return The correct scope string.
-     */
-    @Override
-    protected String getAdminScope() {
-        return Scope.SCOPE_ADMIN;
-    }
-
-    /**
-     * Return the token scope required for generic user access.
-     *
-     * @return The correct scope string.
-     */
-    @Override
-    protected String getRegularScope() {
-        return Scope.SCOPE;
     }
 
     /**
@@ -131,6 +121,36 @@ public final class ScopeServiceCRUDTest
                         false,
                         false
                 });
+    }
+
+    /**
+     * Return the appropriate list type for this test suite.
+     *
+     * @return The list type, used for test decoding.
+     */
+    @Override
+    protected GenericType<ListResponseEntity<ApplicationScope>> getListType() {
+        return LIST_TYPE;
+    }
+
+    /**
+     * Return the token scope required for admin access on this test.
+     *
+     * @return The correct scope string.
+     */
+    @Override
+    protected String getAdminScope() {
+        return Scope.SCOPE_ADMIN;
+    }
+
+    /**
+     * Return the token scope required for generic user access.
+     *
+     * @return The correct scope string.
+     */
+    @Override
+    protected String getRegularScope() {
+        return Scope.SCOPE;
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ScopeServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ScopeServiceSearchTest.java
@@ -18,13 +18,14 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
+import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.ApplicationScope;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
-import net.krotscheck.kangaroo.authz.admin.Scope;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,6 +52,14 @@ import java.util.stream.Collectors;
 @RunWith(Parameterized.class)
 public final class ScopeServiceSearchTest
         extends AbstractServiceSearchTest<ApplicationScope> {
+
+    /**
+     * Convenience generic type for response decoding.
+     */
+    private static final GenericType<ListResponseEntity<ApplicationScope>> LIST_TYPE =
+            new GenericType<ListResponseEntity<ApplicationScope>>() {
+
+            };
 
     /**
      * Create a new instance of this parameterized test.
@@ -104,14 +113,6 @@ public final class ScopeServiceSearchTest
                         false
                 });
     }
-
-    /**
-     * Convenience generic type for response decoding.
-     */
-    private static final GenericType<List<ApplicationScope>> LIST_TYPE =
-            new GenericType<List<ApplicationScope>>() {
-
-            };
 
     /**
      * Return the token scope required for admin access on this test.
@@ -195,16 +196,11 @@ public final class ScopeServiceSearchTest
                 .contains(Scope.SCOPE_ADMIN)) {
             Assert.assertTrue(expectedTotal > 0);
 
-            List<ApplicationScope> results = r.readEntity(LIST_TYPE);
-
-            Assert.assertEquals(200, r.getStatus());
-            Assert.assertEquals(expectedTotal.toString(),
-                    r.getHeaderString("Total"));
-            Assert.assertEquals(expectedOffset.toString(),
-                    r.getHeaderString("Offset"));
-            Assert.assertEquals(expectedLimit.toString(),
-                    r.getHeaderString("Limit"));
-            Assert.assertEquals(expectedResultSize, results.size());
+            assertListResponse(r,
+                    expectedResultSize,
+                    expectedOffset,
+                    expectedLimit,
+                    expectedTotal);
         }
     }
 
@@ -232,7 +228,7 @@ public final class ScopeServiceSearchTest
      * @return The list type, used for test decoding.
      */
     @Override
-    protected GenericType<List<ApplicationScope>> getListType() {
+    protected GenericType<ListResponseEntity<ApplicationScope>> getListType() {
         return LIST_TYPE;
     }
 

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserIdentityServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserIdentityServiceCRUDTest.java
@@ -18,19 +18,21 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
+import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorType;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Authenticator;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
 import net.krotscheck.kangaroo.authz.common.database.entity.UserIdentity;
-import net.krotscheck.kangaroo.authz.admin.Scope;
-import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
 import net.krotscheck.kangaroo.authz.common.util.PasswordUtil;
+import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
@@ -47,6 +49,14 @@ import java.util.stream.Collectors;
  */
 public final class UserIdentityServiceCRUDTest
         extends AbstractServiceCRUDTest<UserIdentity> {
+
+    /**
+     * Convenience generic type for response decoding.
+     */
+    private static final GenericType<ListResponseEntity<UserIdentity>> LIST_TYPE =
+            new GenericType<ListResponseEntity<UserIdentity>>() {
+
+            };
 
     /**
      * Create a new instance of this parameterized test.
@@ -108,6 +118,16 @@ public final class UserIdentityServiceCRUDTest
                         false,
                         false
                 });
+    }
+
+    /**
+     * Return the appropriate list type for this test suite.
+     *
+     * @return The list type, used for test decoding.
+     */
+    @Override
+    protected GenericType<ListResponseEntity<UserIdentity>> getListType() {
+        return LIST_TYPE;
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserIdentityServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserIdentityServiceSearchTest.java
@@ -18,6 +18,7 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
+import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorType;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Authenticator;
@@ -25,7 +26,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
 import net.krotscheck.kangaroo.authz.common.database.entity.UserIdentity;
-import net.krotscheck.kangaroo.authz.admin.Scope;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
@@ -54,8 +55,8 @@ public final class UserIdentityServiceSearchTest
     /**
      * Convenience generic type for response decoding.
      */
-    private static final GenericType<List<UserIdentity>> LIST_TYPE =
-            new GenericType<List<UserIdentity>>() {
+    private static final GenericType<ListResponseEntity<UserIdentity>> LIST_TYPE =
+            new GenericType<ListResponseEntity<UserIdentity>>() {
 
             };
 
@@ -119,7 +120,7 @@ public final class UserIdentityServiceSearchTest
      * @return The list type, used for test decoding.
      */
     @Override
-    protected GenericType<List<UserIdentity>> getListType() {
+    protected GenericType<ListResponseEntity<UserIdentity>> getListType() {
         return LIST_TYPE;
     }
 
@@ -237,14 +238,11 @@ public final class UserIdentityServiceSearchTest
         } else {
             Assert.assertTrue(expectedTotal > 0);
 
-            List<UserIdentity> results = r.readEntity(getListType());
-            Assert.assertEquals(expectedOffset.toString(),
-                    r.getHeaderString("Offset"));
-            Assert.assertEquals(expectedLimit.toString(),
-                    r.getHeaderString("Limit"));
-            Assert.assertEquals(expectedTotal.toString(),
-                    r.getHeaderString("Total"));
-            Assert.assertEquals(expectedResultSize, results.size());
+            assertListResponse(r,
+                    expectedResultSize,
+                    expectedOffset,
+                    expectedLimit,
+                    expectedTotal);
         }
     }
 
@@ -317,14 +315,11 @@ public final class UserIdentityServiceSearchTest
         } else {
             Assert.assertTrue(expectedTotal > 0);
 
-            List<UserIdentity> results = r.readEntity(getListType());
-            Assert.assertEquals(expectedOffset.toString(),
-                    r.getHeaderString("Offset"));
-            Assert.assertEquals(expectedLimit.toString(),
-                    r.getHeaderString("Limit"));
-            Assert.assertEquals(expectedTotal.toString(),
-                    r.getHeaderString("Total"));
-            Assert.assertEquals(expectedResultSize, results.size());
+            assertListResponse(r,
+                    expectedResultSize,
+                    expectedOffset,
+                    expectedLimit,
+                    expectedTotal);
         }
     }
 

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserServiceBrowseTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserServiceBrowseTest.java
@@ -25,6 +25,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.Role;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
 import net.krotscheck.kangaroo.authz.admin.Scope;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.hibernate.Criteria;
 import org.junit.Assert;
 import org.junit.Test;
@@ -56,8 +57,8 @@ public final class UserServiceBrowseTest
     /**
      * Generic type declaration for list decoding.
      */
-    private static final GenericType<List<User>> LIST_TYPE =
-            new GenericType<List<User>>() {
+    private static final GenericType<ListResponseEntity<User>> LIST_TYPE =
+            new GenericType<ListResponseEntity<User>>() {
 
             };
 
@@ -100,7 +101,7 @@ public final class UserServiceBrowseTest
      * @return The list type.
      */
     @Override
-    protected GenericType<List<User>> getListType() {
+    protected GenericType<ListResponseEntity<User>> getListType() {
         return LIST_TYPE;
     }
 
@@ -241,14 +242,11 @@ public final class UserServiceBrowseTest
             assertErrorResponse(r, Status.BAD_REQUEST.getStatusCode(),
                     "invalid_scope");
         } else if (isAccessible(filtered, getAdminToken())) {
-            List<User> results = r.readEntity(getListType());
-            Assert.assertEquals(expectedOffset.toString(),
-                    r.getHeaderString("Offset"));
-            Assert.assertEquals(expectedLimit.toString(),
-                    r.getHeaderString("Limit"));
-            Assert.assertEquals(expectedTotal.toString(),
-                    r.getHeaderString("Total"));
-            Assert.assertEquals(expectedResultSize, results.size());
+            assertListResponse(r,
+                    expectedResultSize,
+                    expectedOffset,
+                    expectedLimit,
+                    expectedTotal);
         } else {
             assertErrorResponse(r, Status.BAD_REQUEST);
         }
@@ -304,14 +302,11 @@ public final class UserServiceBrowseTest
             assertErrorResponse(r, Status.BAD_REQUEST.getStatusCode(),
                     "invalid_scope");
         } else if (isAccessible(filtered, getAdminToken())) {
-            List<User> results = r.readEntity(getListType());
-            Assert.assertEquals(expectedOffset.toString(),
-                    r.getHeaderString("Offset"));
-            Assert.assertEquals(expectedLimit.toString(),
-                    r.getHeaderString("Limit"));
-            Assert.assertEquals(expectedTotal.toString(),
-                    r.getHeaderString("Total"));
-            Assert.assertEquals(expectedResultSize, results.size());
+            assertListResponse(r,
+                    expectedResultSize,
+                    expectedOffset,
+                    expectedLimit,
+                    expectedTotal);
         } else {
             assertErrorResponse(r, Status.BAD_REQUEST);
         }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserServiceCRUDTest.java
@@ -18,17 +18,19 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
+import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
 import net.krotscheck.kangaroo.authz.common.database.entity.Role;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
-import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
@@ -43,6 +45,14 @@ import java.util.Collection;
  */
 public final class UserServiceCRUDTest
         extends AbstractServiceCRUDTest<User> {
+
+    /**
+     * Convenience generic type for response decoding.
+     */
+    private static final GenericType<ListResponseEntity<User>> LIST_TYPE =
+            new GenericType<ListResponseEntity<User>>() {
+
+            };
 
     /**
      * Create a new instance of this parameterized test.
@@ -104,6 +114,16 @@ public final class UserServiceCRUDTest
                         false,
                         false
                 });
+    }
+
+    /**
+     * Return the appropriate list type for this test suite.
+     *
+     * @return The list type, used for test decoding.
+     */
+    @Override
+    protected GenericType<ListResponseEntity<User>> getListType() {
+        return LIST_TYPE;
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserServiceSearchTest.java
@@ -18,13 +18,14 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
+import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.Role;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
-import net.krotscheck.kangaroo.authz.admin.Scope;
+import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
@@ -53,8 +54,8 @@ public final class UserServiceSearchTest
     /**
      * Convenience generic type for response decoding.
      */
-    private static final GenericType<List<User>> LIST_TYPE =
-            new GenericType<List<User>>() {
+    private static final GenericType<ListResponseEntity<User>> LIST_TYPE =
+            new GenericType<ListResponseEntity<User>>() {
 
             };
 
@@ -118,7 +119,7 @@ public final class UserServiceSearchTest
      * @return The list type, used for test decoding.
      */
     @Override
-    protected GenericType<List<User>> getListType() {
+    protected GenericType<ListResponseEntity<User>> getListType() {
         return LIST_TYPE;
     }
 
@@ -231,14 +232,11 @@ public final class UserServiceSearchTest
         } else {
             Assert.assertTrue(expectedTotal > 0);
 
-            List<User> results = r.readEntity(getListType());
-            Assert.assertEquals(expectedOffset.toString(),
-                    r.getHeaderString("Offset"));
-            Assert.assertEquals(expectedLimit.toString(),
-                    r.getHeaderString("Limit"));
-            Assert.assertEquals(expectedTotal.toString(),
-                    r.getHeaderString("Total"));
-            Assert.assertEquals(expectedResultSize, results.size());
+            assertListResponse(r,
+                    expectedResultSize,
+                    expectedOffset,
+                    expectedLimit,
+                    expectedTotal);
         }
     }
 
@@ -320,14 +318,11 @@ public final class UserServiceSearchTest
         } else {
             Assert.assertTrue(expectedTotal > 0);
 
-            List<User> results = r.readEntity(getListType());
-            Assert.assertEquals(expectedOffset.toString(),
-                    r.getHeaderString("Offset"));
-            Assert.assertEquals(expectedLimit.toString(),
-                    r.getHeaderString("Limit"));
-            Assert.assertEquals(expectedTotal.toString(),
-                    r.getHeaderString("Total"));
-            Assert.assertEquals(expectedResultSize, results.size());
+            assertListResponse(r,
+                    expectedResultSize,
+                    expectedOffset,
+                    expectedLimit,
+                    expectedTotal);
         }
     }
 


### PR DESCRIPTION
Returning arrays is actually insecure and permits data injection.
This wraps the result, annotates some metadata, and provides type-sensitive
tooling which will hopefully assist in de/serialization.