### PR TITLE
Switched from byte[] back to BigInteger

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/id/IdUtil.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/id/IdUtil.java
@@ -19,8 +19,8 @@
 package net.krotscheck.kangaroo.common.hibernate.id;
 
 import com.google.common.base.Strings;
-import com.google.common.io.BaseEncoding;
 
+import java.math.BigInteger;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Random;
@@ -36,11 +36,6 @@ public final class IdUtil {
      * Static ID util, for convenience access.
      */
     private static final IdUtil INSTANCE = new IdUtil();
-
-    /**
-     * Our Base16 encoder/decoder.
-     */
-    private static final BaseEncoding BASE_16 = BaseEncoding.base16();
 
     /**
      * The # of bytes in the ID. OSSTP recommends 128 bits, which means 16
@@ -70,15 +65,11 @@ public final class IdUtil {
      * @param idString The string.
      * @return The BigInteger representation of that ID.
      */
-    public static byte[] fromString(final String idString) {
+    public static BigInteger fromString(final String idString) {
         if (Strings.isNullOrEmpty(idString)) {
             return null;
         }
-        byte[] decoded = BASE_16.decode(idString);
-        if (decoded == null || decoded.length != BYTE_COUNT) {
-            throw new IllegalArgumentException("id is not the correct length");
-        }
-        return decoded;
+        return new BigInteger(idString, 16);
     }
 
     /**
@@ -87,14 +78,11 @@ public final class IdUtil {
      * @param id The ID to convert.
      * @return The string representation of this id.
      */
-    public static String toString(final byte[] id) {
+    public static String toString(final BigInteger id) {
         if (id == null) {
             return null;
         }
-        if (id.length != BYTE_COUNT) {
-            throw new IllegalArgumentException("id is not the correct length");
-        }
-        return BASE_16.encode(id);
+        return id.toString(16);
     }
 
     /**
@@ -102,7 +90,7 @@ public final class IdUtil {
      *
      * @return An ID generated from the SecureRandom stream of bytes.
      */
-    public static byte[] next() {
+    public static BigInteger next() {
         return INSTANCE.nextInternal();
     }
 
@@ -111,9 +99,9 @@ public final class IdUtil {
      *
      * @return An ID generated from the SecureRandom stream of bytes.
      */
-    protected byte[] nextInternal() {
+    protected BigInteger nextInternal() {
         byte[] randomBytes = new byte[BYTE_COUNT];
         randomNumberGenerator.nextBytes(randomBytes);
-        return randomBytes;
+        return new BigInteger(randomBytes);
     }
 }

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/id/SecureRandomIdGenerator.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/id/SecureRandomIdGenerator.java
@@ -18,6 +18,7 @@
 
 package net.krotscheck.kangaroo.common.hibernate.id;
 
+import net.krotscheck.kangaroo.common.hibernate.type.BigIntegerType;
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
 import org.hibernate.boot.model.naming.ObjectNameNormalizer;
@@ -29,10 +30,11 @@ import org.hibernate.id.IdentifierGenerationException;
 import org.hibernate.id.IdentifierGenerator;
 import org.hibernate.id.PersistentIdentifierGenerator;
 import org.hibernate.service.ServiceRegistry;
-import org.hibernate.type.BinaryType;
+import org.hibernate.type.CustomType;
 import org.hibernate.type.Type;
 
 import java.io.Serializable;
+import java.math.BigInteger;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -58,7 +60,7 @@ public final class SecureRandomIdGenerator
     /**
      * The type instance, used for adjusting our prepared statements.
      */
-    private Type type = BinaryType.INSTANCE;
+    private Type type = new CustomType(new BigIntegerType());
 
     /**
      * Id Util.
@@ -88,7 +90,7 @@ public final class SecureRandomIdGenerator
                                  final Object object)
             throws HibernateException {
 
-        byte[] nextId;
+        BigInteger nextId;
         do {
             nextId = id.next();
         } while (hasDuplicate(session, nextId));
@@ -139,7 +141,7 @@ public final class SecureRandomIdGenerator
      */
     protected boolean hasDuplicate(
             final SharedSessionContractImplementor session,
-            final byte[] id) {
+            final BigInteger id) {
 
         PreparedStatement st = session
                 .getJdbcCoordinator()

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/type/BigIntegerType.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/type/BigIntegerType.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate.type;
+
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.usertype.UserType;
+
+import java.io.Serializable;
+import java.math.BigInteger;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * Custom hibernate type that permits storing URI's into varchar columns.
+ *
+ * @author Michael Krotscheck
+ */
+public final class BigIntegerType implements UserType {
+
+    /**
+     * Return the SQL type codes for the columns mapped by this type. The
+     * codes are defined on <tt>java.sql.Types</tt>.
+     *
+     * @return int[] the typecodes
+     * @see Types
+     */
+    @Override
+    public int[] sqlTypes() {
+        return new int[]{Types.BINARY};
+    }
+
+    /**
+     * The class returned by <tt>nullSafeGet()</tt>.
+     *
+     * @return Class
+     */
+    @Override
+    public Class returnedClass() {
+        return BigInteger.class;
+    }
+
+    /**
+     * Compare two instances of the class mapped by this type for persistence
+     * "equality". Equality of the persistent state.
+     *
+     * @param x Left
+     * @param y Right
+     * @return boolean True if they are equal.
+     */
+    @Override
+    public boolean equals(final Object x,
+                          final Object y) throws HibernateException {
+        if (x == null) {
+            return y == null;
+        }
+        return x.equals(y);
+    }
+
+    /**
+     * Get a hashcode for the instance, consistent with persistence "equality".
+     *
+     * @param x The object to hash.
+     */
+    @Override
+    public int hashCode(final Object x) throws HibernateException {
+        return x.hashCode();
+    }
+
+    /**
+     * Retrieve an instance of the mapped class from a JDBC resultset.
+     * Implementors should handle possibility of null values.
+     *
+     * @param rs      A JDBC result set
+     * @param names   The column names
+     * @param session The session implementation.
+     * @param owner   the containing entity  @return Object
+     * @throws HibernateException Thrown if hibernate throws up.
+     * @throws SQLException       Thrown if the type is not mapped properly.
+     */
+    @Override
+    public Object nullSafeGet(final ResultSet rs,
+                              final String[] names,
+                              final SharedSessionContractImplementor session,
+                              final Object owner)
+            throws HibernateException, SQLException {
+        // Read the value as a string, so we can check for null.
+        byte[] idAsBytes = rs.getBytes(names[0]);
+        if (idAsBytes == null) {
+            return null;
+        }
+        return new BigInteger(idAsBytes);
+    }
+
+    /**
+     * Write an instance of the mapped class to a prepared statement.
+     * Implementors should handle possibility of null values. A multi-column
+     * type should be written to parameters starting from <tt>index</tt>.
+     *
+     * @param st      A JDBC prepared statement.
+     * @param value   The object to write.
+     * @param index   Statement parameter index.
+     * @param session The session implementation.
+     * @throws HibernateException Thrown if hibernate throws up.
+     * @throws SQLException       Thrown if the type is not mapped properly.
+     */
+    @Override
+    public void nullSafeSet(final PreparedStatement st,
+                            final Object value,
+                            final int index,
+                            final SharedSessionContractImplementor session)
+            throws HibernateException, SQLException {
+        if (value != null) {
+            BigInteger bigInteger = (BigInteger) value;
+            st.setBytes(index, bigInteger.toByteArray());
+        } else {
+            st.setNull(index, Types.BINARY);
+        }
+    }
+
+    /**
+     * Return a deep copy of the persistent state, stopping at entities and at
+     * collections. It is not necessary to copy immutable objects, or null
+     * values, in which case it is safe to simply return the argument.
+     *
+     * @param value the object to be cloned, which may be null
+     * @return Object a copy
+     */
+    @Override
+    public Object deepCopy(final Object value) throws HibernateException {
+        return value;
+    }
+
+    /**
+     * Are objects of this type mutable?
+     *
+     * @return boolean
+     */
+    @Override
+    public boolean isMutable() {
+        return false;
+    }
+
+    /**
+     * Transform the object into its cacheable representation. At the very
+     * least this method should perform a deep copy if the type is mutable.
+     * That may not be enough for some implementations, however; for example,
+     * associations must be cached as identifier values. (optional operation)
+     *
+     * @param value The object to be cached
+     * @return A cachable representation of the object
+     * @throws HibernateException Thrown if hibernate throws up.
+     */
+    @Override
+    public Serializable disassemble(final Object value)
+            throws HibernateException {
+        BigInteger bigInteger = (BigInteger) value;
+        return bigInteger.toByteArray();
+    }
+
+    /**
+     * Reconstruct an object from the cacheable representation. At the very
+     * least this method should perform a deep copy if the type is mutable.
+     * (optional operation)
+     *
+     * @param cached The object to be cached.
+     * @param owner  The owner of the cached object.
+     * @return A reconstructed object from the cachable representation.
+     * @throws HibernateException Thrown if hibernate throws up.
+     */
+    @Override
+    public Object assemble(final Serializable cached,
+                           final Object owner) throws HibernateException {
+        byte[] radixBigint = (byte[]) cached;
+        return new BigInteger(radixBigint);
+    }
+
+    /**
+     * During merge, replace the existing (target) value in the entity we are
+     * merging to with a new (original) value from the detached entity we are
+     * merging. For immutable objects, or null values, it is safe to simply
+     * return the first parameter. For mutable objects, it is safe to return
+     * a copy of the first parameter. For objects with component values, it
+     * might make sense to recursively replace component values.
+     *
+     * @param original the value from the detached entity being merged.
+     * @param target   the value in the managed entity.
+     * @param owner    The owning entity.
+     * @return the value to be merged
+     */
+    @Override
+    public Object replace(final Object original,
+                          final Object target,
+                          final Object owner)
+            throws HibernateException {
+        return original;
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/jackson/types/Base16BigIntegerDeserializer.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/jackson/types/Base16BigIntegerDeserializer.java
@@ -18,31 +18,40 @@
 
 package net.krotscheck.kangaroo.common.jackson.types;
 
-import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
 
 import javax.inject.Singleton;
 import javax.ws.rs.ext.Provider;
 import java.io.IOException;
+import java.math.BigInteger;
 
 /**
- * Base16 serializer for byte arrays.
+ * Base16 deserializer for bigintegers.
  *
  * @author Michael Krotscheck
  */
 @Provider
 @Singleton
-public final class Base16ByteSerializer
-        extends JsonSerializer<byte[]> {
+public final class Base16BigIntegerDeserializer
+        extends JsonDeserializer<BigInteger> {
 
+    /**
+     * Deserialize a JSON value (usually a string) into a byte array.
+     *
+     * @param p    The JSON parser.
+     * @param ctxt The serialization context.
+     * @return The value as a byte array.
+     * @throws IOException             Not thrown.
+     * @throws JsonProcessingException Not thrown.
+     */
     @Override
-    public void serialize(final byte[] value,
-                          final JsonGenerator gen,
-                          final SerializerProvider serializers)
+    public BigInteger deserialize(final JsonParser p,
+                                  final DeserializationContext ctxt)
             throws IOException, JsonProcessingException {
-        gen.writeString(IdUtil.toString(value));
+        return IdUtil.fromString(p.getValueAsString());
     }
 }

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/jackson/types/Base16BigIntegerSerializer.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/jackson/types/Base16BigIntegerSerializer.java
@@ -18,39 +18,32 @@
 
 package net.krotscheck.kangaroo.common.jackson.types;
 
-import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
 import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
 
 import javax.inject.Singleton;
 import javax.ws.rs.ext.Provider;
 import java.io.IOException;
+import java.math.BigInteger;
 
 /**
- * Base16 deserializer for byte arrays.
+ * Base16 serializer for bigintegers.
  *
  * @author Michael Krotscheck
  */
 @Provider
 @Singleton
-public final class Base16ByteDeserializer
-        extends JsonDeserializer<byte[]> {
+public final class Base16BigIntegerSerializer
+        extends JsonSerializer<BigInteger> {
 
-    /**
-     * Deserialize a JSON value (usually a string) into a byte array.
-     *
-     * @param p    The JSON parser.
-     * @param ctxt The serialization context.
-     * @return The value as a byte array.
-     * @throws IOException             Not thrown.
-     * @throws JsonProcessingException Not thrown.
-     */
     @Override
-    public byte[] deserialize(final JsonParser p,
-                              final DeserializationContext ctxt)
+    public void serialize(final BigInteger value,
+                          final JsonGenerator gen,
+                          final SerializerProvider serializers)
             throws IOException, JsonProcessingException {
-        return IdUtil.fromString(p.getValueAsString());
+        gen.writeString(IdUtil.toString(value));
     }
 }

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/jackson/types/KangarooCustomTypesModule.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/jackson/types/KangarooCustomTypesModule.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.module.SimpleSerializers;
 
 import javax.inject.Singleton;
 import javax.ws.rs.ext.Provider;
+import java.math.BigInteger;
 
 /**
  * This Jackson Module registers all the necessary De/Serializers for proper
@@ -77,10 +78,12 @@ public final class KangarooCustomTypesModule extends Module {
     @Override
     public void setupModule(final SetupContext context) {
         SimpleDeserializers des = new SimpleDeserializers();
-        des.addDeserializer(byte[].class, new Base16ByteDeserializer());
+        des.addDeserializer(BigInteger.class,
+                new Base16BigIntegerDeserializer());
 
         SimpleSerializers ser = new SimpleSerializers();
-        ser.addSerializer(byte[].class, new Base16ByteSerializer());
+        ser.addSerializer(BigInteger.class,
+                new Base16BigIntegerSerializer());
 
         context.addDeserializers(des);
         context.addSerializers(ser);

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/entity/TestByteIdEntity.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/entity/TestByteIdEntity.java
@@ -34,6 +34,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.validation.constraints.Size;
+import java.math.BigInteger;
 import java.util.Calendar;
 
 /**
@@ -54,7 +55,9 @@ public final class TestByteIdEntity {
                     + ".SecureRandomIdGenerator")
     @GeneratedValue(generator = "secure_random_bytes")
     @Column(name = "id", unique = true, nullable = false, updatable = false)
-    private byte[] id = null;
+    @Type(type = "net.krotscheck.kangaroo.common.hibernate.type"
+            + ".BigIntegerType")
+    private BigInteger id = null;
 
     /**
      * The date this record was created.
@@ -86,7 +89,7 @@ public final class TestByteIdEntity {
      *
      * @return The id for this entity.
      */
-    public byte[] getId() {
+    public BigInteger getId() {
         return id;
     }
 
@@ -95,7 +98,7 @@ public final class TestByteIdEntity {
      *
      * @param id The unique ID for this entity.
      */
-    public void setId(final byte[] id) {
+    public void setId(final BigInteger id) {
         this.id = id;
     }
 

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/id/IdUtilTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/id/IdUtilTest.java
@@ -23,10 +23,9 @@ import org.junit.Test;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
-import java.security.SecureRandom;
+import java.math.BigInteger;
 import java.security.Security;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -71,26 +70,15 @@ public class IdUtilTest {
     }
 
     /**
-     * Assert that generated ID's are 16 characters long.
-     *
-     * @throws Exception Should not be thrown.
-     */
-    @Test
-    public void testIdCorrectLength() throws Exception {
-        byte[] id = IdUtil.next();
-        assertEquals(16, id.length);
-    }
-
-    /**
      * Assert that we can convert an ID to a string and back.
      *
      * @throws Exception Should not be thrown.
      */
     @Test
     public void testIdStringConvert() throws Exception {
-        byte[] id = IdUtil.next();
+        BigInteger id = IdUtil.next();
         String idString = IdUtil.toString(id);
-        assertArrayEquals(id, IdUtil.fromString(idString));
+        assertEquals(id, IdUtil.fromString(idString));
     }
 
     /**
@@ -103,46 +91,10 @@ public class IdUtilTest {
     }
 
     /**
-     * Assert that a malformed string cannot be converted back to a byte[].
+     * Assert that a malformed string cannot be converted back to a BigInteger.
      */
     @Test(expected = IllegalArgumentException.class)
     public void testMalformedIdFromString() {
         IdUtil.fromString("notBase16String");
-    }
-
-    /**
-     * Assert that a too short string cannot be converted back to a byte[].
-     */
-    @Test(expected = IllegalArgumentException.class)
-    public void testTooShortIdFromString() {
-        IdUtil.fromString("4214");
-    }
-
-    /**
-     * Assert that a too long string cannot be converted back to a byte[].
-     */
-    @Test(expected = IllegalArgumentException.class)
-    public void testTooLongIdFromString() {
-        IdUtil.fromString("0123456789012345678901234567890123456789");
-    }
-
-    /**
-     * Assert that a byte array that's too short cannot be converted.
-     */
-    @Test(expected = IllegalArgumentException.class)
-    public void testTooShortIdToString() {
-        byte[] shortId = new byte[2];
-        new SecureRandom().nextBytes(shortId);
-        IdUtil.toString(shortId);
-    }
-
-    /**
-     * Assert that a byte array that's too long cannot be converted.
-     */
-    @Test(expected = IllegalArgumentException.class)
-    public void testTooLongIdToString() {
-        byte[] shortId = new byte[1000];
-        new SecureRandom().nextBytes(shortId);
-        IdUtil.toString(shortId);
     }
 }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/id/SecureRandomIdGeneratorTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/id/SecureRandomIdGeneratorTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -41,7 +40,6 @@ import static org.junit.Assert.assertTrue;
  * @author Michael Krotscheck
  */
 public final class SecureRandomIdGeneratorTest extends DatabaseTest {
-
 
     /**
      * Assert that using it via an annotated ID works.
@@ -58,7 +56,6 @@ public final class SecureRandomIdGeneratorTest extends DatabaseTest {
 
         assertNotNull(e);
         assertNotNull(e.getId());
-        assertEquals(16, e.getId().length);
     }
 
     /**
@@ -110,7 +107,7 @@ public final class SecureRandomIdGeneratorTest extends DatabaseTest {
 
         // Mariadb can signal an error directly.
         String sql = "signal set message_text='an error occurred';";
-        
+
         if (TestConfig.getDbDialect().equals(H2Dialect.class.getName())) {
             sql = "select id from test where 1=0";
         }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/type/BigIntegerTypeTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/type/BigIntegerTypeTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate.type;
+
+import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.math.BigInteger;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Types;
+
+import static org.mockito.Mockito.times;
+
+/**
+ * Unit test for the BigInteger-to-byte[] converter.
+ *
+ * @author Michael Krotscheck
+ */
+public final class BigIntegerTypeTest {
+
+    /**
+     * Assert that we map to the correct types.
+     */
+    @Test
+    public void sqlTypes() {
+        BigIntegerType type = new BigIntegerType();
+
+        int[] types = type.sqlTypes();
+        Assert.assertEquals(1, types.length);
+        Assert.assertEquals(Types.BINARY, types[0]);
+    }
+
+    /**
+     * Assert that the converted type is a BigInteger.
+     */
+    @Test
+    public void returnedClass() {
+        BigIntegerType type = new BigIntegerType();
+
+        Assert.assertEquals(BigInteger.class, type.returnedClass());
+    }
+
+    /**
+     * Assert that comparison works.
+     */
+    @Test
+    public void equals() {
+        BigIntegerType type = new BigIntegerType();
+
+        BigInteger one = IdUtil.next();
+        BigInteger two = new BigInteger(one.toByteArray());
+        BigInteger three = IdUtil.next();
+
+        // Basic comparison
+        Assert.assertTrue(type.equals(one, two));
+        Assert.assertFalse(type.equals(three, two));
+        Assert.assertFalse(type.equals(two, three));
+        Assert.assertTrue(type.equals(null, null));
+        Assert.assertFalse(type.equals(null, two));
+        Assert.assertFalse(type.equals(two, null));
+    }
+
+    /**
+     * Assert that hashcode is passed through to the underlying instance.
+     */
+    @Test
+    public void testHashCode() {
+        BigIntegerType type = new BigIntegerType();
+
+        BigInteger one = IdUtil.next();
+        Assert.assertEquals(one.hashCode(), type.hashCode(one));
+    }
+
+    /**
+     * Assert that we can retrieve the BigInteger.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void nullSafeGet() throws Exception {
+        BigIntegerType type = new BigIntegerType();
+        String[] names = new String[]{"test"};
+        ResultSet rs = Mockito.mock(ResultSet.class);
+        BigInteger one = IdUtil.next();
+
+        Mockito.doReturn(one.toByteArray())
+                .when(rs).getBytes(names[0]);
+        BigInteger result = (BigInteger)
+                type.nullSafeGet(rs, names, null, null);
+
+        Assert.assertEquals(one, result);
+    }
+
+    /**
+     * Assert that a null value returns null.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void nullSafeGetNull() throws Exception {
+        BigIntegerType type = new BigIntegerType();
+        String[] names = new String[]{"test"};
+        ResultSet rs = Mockito.mock(ResultSet.class);
+        Mockito.doReturn(null).when(rs).getString(names[0]);
+        BigInteger result = (BigInteger)
+                type.nullSafeGet(rs, names, null, null);
+
+        Assert.assertNull(result);
+    }
+
+    /**
+     * Assert that we can set a value.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void nullSafeSet() throws Exception {
+        BigIntegerType type = new BigIntegerType();
+        PreparedStatement st = Mockito.mock(PreparedStatement.class);
+        BigInteger one = IdUtil.next();
+        type.nullSafeSet(st, one, 0, null);
+        Mockito.verify(st, times(1))
+                .setBytes(0, one.toByteArray());
+    }
+
+    /**
+     * Assert that setting with a null value sets null.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void nullSafeSetNull() throws Exception {
+        BigIntegerType type = new BigIntegerType();
+        PreparedStatement st = Mockito.mock(PreparedStatement.class);
+        type.nullSafeSet(st, null, 0, null);
+        Mockito.verify(st, times(1)).setNull(0, Types.BINARY);
+    }
+
+    /**
+     * Assert that deepCopy returns the same (immutable) instance.
+     */
+    @Test
+    public void deepCopy() {
+        BigIntegerType type = new BigIntegerType();
+        BigInteger one = IdUtil.next();
+        Assert.assertSame(one, type.deepCopy(one));
+    }
+
+    /**
+     * Assert that ismutable is false.
+     */
+    @Test
+    public void isMutable() {
+        BigIntegerType type = new BigIntegerType();
+        Assert.assertFalse(type.isMutable());
+    }
+
+    /**
+     * Assert that a BigInteger is disassembled into a byte[].
+     */
+    @Test
+    public void disassemble() {
+        BigIntegerType type = new BigIntegerType();
+
+        BigInteger one = IdUtil.next();
+        byte[] result = (byte[]) type.disassemble(one);
+        Assert.assertArrayEquals(one.toByteArray(), result);
+    }
+
+    /**
+     * Assert that a byte[] can be converted into a BigInteger.
+     */
+    @Test
+    public void assemble() {
+        BigIntegerType type = new BigIntegerType();
+
+        BigInteger one = IdUtil.next();
+        BigInteger result = (BigInteger) type.assemble(one.toByteArray(), null);
+        Assert.assertTrue(one.equals(result));
+    }
+
+    /**
+     * This type is immutable, replace should only return the first response.
+     */
+    @Test
+    public void replace() {
+        BigIntegerType type = new BigIntegerType();
+
+        BigInteger one = IdUtil.next();
+        BigInteger two = IdUtil.next();
+        BigInteger result = (BigInteger) type.replace(one, two, null);
+
+        Assert.assertSame(one, result);
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/jackson/JacksonFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/jackson/JacksonFeatureTest.java
@@ -29,7 +29,6 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 
@@ -65,7 +64,7 @@ public final class JacksonFeatureTest extends KangarooJerseyTest {
         TestByteIdEntity response = target("/").request()
                 .post(pojoEntity, TestByteIdEntity.class);
 
-        assertArrayEquals(entity.getId(), response.getId());
+        assertEquals(entity.getId(), response.getId());
     }
 
     /**

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/jackson/types/Base16BigIntegerDeserializerTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/jackson/types/Base16BigIntegerDeserializerTest.java
@@ -25,7 +25,9 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
 import org.junit.Test;
 
-import static org.junit.Assert.assertArrayEquals;
+import java.math.BigInteger;
+
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -33,7 +35,7 @@ import static org.mockito.Mockito.mock;
  *
  * @author Michael Krotscheck
  */
-public class Base16ByteDeserializerTest {
+public class Base16BigIntegerDeserializerTest {
 
     /**
      * Assert that we can access this class as its generic type.
@@ -42,18 +44,18 @@ public class Base16ByteDeserializerTest {
      */
     @Test
     public void testGenericConstructor() throws Exception {
-        byte[] id = IdUtil.next();
+        BigInteger id = IdUtil.next();
         String idBody = String.format("\"%s\"", IdUtil.toString(id));
         JsonFactory f = new JsonFactory();
         JsonParser preloadedParser = f.createParser(idBody);
         preloadedParser.nextToken(); // Advance to the first value.
 
-        JsonDeserializer deserializer = new Base16ByteDeserializer();
-        byte[] deserializedId = (byte[])
+        JsonDeserializer deserializer = new Base16BigIntegerDeserializer();
+        BigInteger deserializedId = (BigInteger)
                 deserializer.deserialize(preloadedParser,
                         mock(DeserializationContext.class));
 
-        assertArrayEquals(id, deserializedId);
+        assertEquals(id, deserializedId);
     }
 
     /**
@@ -63,16 +65,16 @@ public class Base16ByteDeserializerTest {
      */
     @Test
     public void deserialize() throws Exception {
-        byte[] id = IdUtil.next();
+        BigInteger id = IdUtil.next();
         String idBody = String.format("\"%s\"", IdUtil.toString(id));
         JsonFactory f = new JsonFactory();
         JsonParser preloadedParser = f.createParser(idBody);
         preloadedParser.nextToken(); // Advance to the first value.
 
-        Base16ByteDeserializer deserializer = new Base16ByteDeserializer();
-        byte[] deserializedId = deserializer.deserialize(preloadedParser,
+        Base16BigIntegerDeserializer deserializer = new Base16BigIntegerDeserializer();
+        BigInteger deserializedId = deserializer.deserialize(preloadedParser,
                 mock(DeserializationContext.class));
 
-        assertArrayEquals(id, deserializedId);
+        assertEquals(id, deserializedId);
     }
 }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/jackson/types/Base16BigIntegerSerializerTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/jackson/types/Base16BigIntegerSerializerTest.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
 import org.junit.Test;
 
+import java.math.BigInteger;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -31,7 +33,7 @@ import static org.mockito.Mockito.verify;
  *
  * @author Michael Krotscheck
  */
-public class Base16ByteSerializerTest {
+public class Base16BigIntegerSerializerTest {
 
     /**
      * Assert that we can access this class as its generic type.
@@ -40,10 +42,10 @@ public class Base16ByteSerializerTest {
      */
     @Test
     public void testGenericConstructor() throws Exception {
-        byte[] id = IdUtil.next();
+        BigInteger id = IdUtil.next();
         String idString = IdUtil.toString(id);
 
-        JsonSerializer serializer = new Base16ByteSerializer();
+        JsonSerializer serializer = new Base16BigIntegerSerializer();
         JsonGenerator generator = mock(JsonGenerator.class);
 
         serializer.serialize(id, generator, null);
@@ -58,10 +60,10 @@ public class Base16ByteSerializerTest {
      */
     @Test
     public void deserialize() throws Exception {
-        byte[] id = IdUtil.next();
+        BigInteger id = IdUtil.next();
         String idString = IdUtil.toString(id);
 
-        Base16ByteSerializer serializer = new Base16ByteSerializer();
+        Base16BigIntegerSerializer serializer = new Base16BigIntegerSerializer();
         JsonGenerator generator = mock(JsonGenerator.class);
 
         serializer.serialize(id, generator, null);

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/jackson/types/KangarooCustomTypesModuleTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/jackson/types/KangarooCustomTypesModuleTest.java
@@ -19,6 +19,7 @@
 package net.krotscheck.kangaroo.common.jackson.types;
 
 import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.Module.SetupContext;
@@ -30,6 +31,8 @@ import com.fasterxml.jackson.databind.type.ArrayType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+
+import java.math.BigInteger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -82,16 +85,16 @@ public final class KangarooCustomTypesModuleTest {
         verify(c).addDeserializers(deserializers.capture());
 
         TypeFactory t = TypeFactory.defaultInstance();
-        ArrayType byteArrayType = t.constructArrayType(byte.class);
+        JavaType bigIntegerType = t.constructType(BigInteger.class);
 
         SimpleSerializers s = (SimpleSerializers) serializers.getValue();
         JsonSerializer byteSerializer =
-                s.findSerializer(null, byteArrayType, null);
-        assertTrue(byteSerializer instanceof Base16ByteSerializer);
+                s.findSerializer(null, bigIntegerType, null);
+        assertTrue(byteSerializer instanceof Base16BigIntegerSerializer);
 
         SimpleDeserializers d = (SimpleDeserializers) deserializers.getValue();
         JsonDeserializer byteDeserializer =
-                d.findBeanDeserializer(byteArrayType, null, null);
-        assertTrue(byteDeserializer instanceof Base16ByteDeserializer);
+                d.findBeanDeserializer(bigIntegerType, null, null);
+        assertTrue(byteDeserializer instanceof Base16BigIntegerDeserializer);
     }
 }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/HttpUtil.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/HttpUtil.java
@@ -44,14 +44,13 @@ import java.util.UUID;
 public final class HttpUtil {
 
     /**
-     * Logger instance.
-     */
-    private static Logger logger = LoggerFactory.getLogger(HttpUtil.class);
-
-    /**
      * The character set we're using.
      */
     private static final Charset UTF8 = Charset.forName("UTF-8");
+    /**
+     * Logger instance.
+     */
+    private static Logger logger = LoggerFactory.getLogger(HttpUtil.class);
 
     /**
      * Private constructor - utility class.

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/HttpSession.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/HttpSession.java
@@ -37,6 +37,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
@@ -62,7 +63,9 @@ public final class HttpSession
                     + ".SecureRandomIdGenerator")
     @GeneratedValue(generator = "secure_random_bytes")
     @Column(name = "id", unique = true, nullable = false, updatable = false)
-    private byte[] id = null;
+    @Type(type = "net.krotscheck.kangaroo.common.hibernate.type"
+            + ".BigIntegerType")
+    private BigInteger id = null;
 
     /**
      * The date this record was created.
@@ -105,7 +108,7 @@ public final class HttpSession
      *
      * @return The ID for this session.
      */
-    public byte[] getId() {
+    public BigInteger getId() {
         return id;
     }
 
@@ -114,7 +117,7 @@ public final class HttpSession
      *
      * @param id The ID for this session.
      */
-    public void setId(final byte[] id) {
+    public void setId(final BigInteger id) {
         this.id = id;
     }
 

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/HttpSessionTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/HttpSessionTest.java
@@ -24,6 +24,7 @@ import org.hibernate.Session;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
@@ -112,7 +113,7 @@ public final class HttpSessionTest extends DatabaseTest {
 
         Assert.assertNull(httpSession.getId());
 
-        byte[] id = IdUtil.next();
+        BigInteger id = IdUtil.next();
         httpSession.setId(id);
         Assert.assertEquals(id, httpSession.getId());
     }
@@ -124,8 +125,8 @@ public final class HttpSessionTest extends DatabaseTest {
      */
     @Test
     public void testEquality() throws Exception {
-        byte[] id = IdUtil.next();
-        byte[] id2 = IdUtil.next();
+        BigInteger id = IdUtil.next();
+        BigInteger id2 = IdUtil.next();
 
         HttpSession a = new HttpSession();
         a.setId(id);
@@ -158,8 +159,8 @@ public final class HttpSessionTest extends DatabaseTest {
      */
     @Test
     public void testHashCode() throws Exception {
-        byte[] id = IdUtil.next();
-        byte[] id2 = IdUtil.next();
+        BigInteger id = IdUtil.next();
+        BigInteger id2 = IdUtil.next();
 
         HttpSession a = new HttpSession();
         a.setId(id);
@@ -184,7 +185,7 @@ public final class HttpSessionTest extends DatabaseTest {
      */
     @Test
     public void testToString() throws Exception {
-        byte[] id = IdUtil.next();
+        BigInteger id = IdUtil.next();
         HttpSession a = new HttpSession();
         a.setId(id);
         HttpSession b = new HttpSession();
@@ -206,7 +207,7 @@ public final class HttpSessionTest extends DatabaseTest {
      */
     @Test
     public void testCloneable() throws Exception {
-        byte[] id = IdUtil.next();
+        BigInteger id = IdUtil.next();
         HttpSession a = new HttpSession();
         a.setId(id);
         HttpSession b = (HttpSession) a.clone();


### PR DESCRIPTION
Hibernate doesn't out of the box support primitive arrays for ID's,
which has a impact on things like our search indexes. Rather than wait
for hibernate to deal with this, I've switched ID management back to
BigInteger.