### PR TITLE
Switched from /dev/random to /dev/urandom

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/id/IdUtil.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/id/IdUtil.java
@@ -22,9 +22,7 @@ import com.google.common.base.Strings;
 import org.apache.commons.lang3.StringUtils;
 
 import java.math.BigInteger;
-import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.util.Random;
 
 /**
  * A small utility that generates positive database identifiers.
@@ -34,29 +32,20 @@ import java.util.Random;
 public final class IdUtil {
 
     /**
-     * Static ID util, for convenience access.
-     */
-    private static final IdUtil INSTANCE = new IdUtil();
-
-    /**
-     * The # of bits in the ID. OSSTP recommends 128 bits.
+     * The # of bytes in the ID. OSSTP recommends 128 bits, which means 16
+     * bytes.
      */
     private static final int BIT_COUNT = 128;
 
     /**
      * Random number generator.
      */
-    private Random randomNumberGenerator;
+    private static final SecureRandom RND = new SecureRandom();
 
     /**
      * Utility class, private constructor.
      */
-    protected IdUtil() {
-        try {
-            randomNumberGenerator = SecureRandom.getInstanceStrong();
-        } catch (NoSuchAlgorithmException nsae) {
-            throw new RuntimeException(nsae);
-        }
+    private IdUtil() {
     }
 
     /**
@@ -91,15 +80,6 @@ public final class IdUtil {
      * @return An ID generated from the SecureRandom stream of bytes.
      */
     public static BigInteger next() {
-        return INSTANCE.nextInternal();
-    }
-
-    /**
-     * Generate an ID.
-     *
-     * @return An ID generated from the SecureRandom stream of bytes.
-     */
-    protected BigInteger nextInternal() {
-        return new BigInteger(BIT_COUNT - 1, randomNumberGenerator);
+        return new BigInteger(BIT_COUNT - 1, RND);
     }
 }

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/id/SecureRandomIdGenerator.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/id/SecureRandomIdGenerator.java
@@ -63,11 +63,6 @@ public final class SecureRandomIdGenerator
     private Type type = new CustomType(new BigIntegerType());
 
     /**
-     * Id Util.
-     */
-    private IdUtil id = new IdUtil();
-
-    /**
      * Set a new SQL statement (used for testing).
      *
      * @param sql New statement.
@@ -92,7 +87,7 @@ public final class SecureRandomIdGenerator
 
         BigInteger nextId;
         do {
-            nextId = id.next();
+            nextId = IdUtil.next();
         } while (hasDuplicate(session, nextId));
 
         return nextId;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/id/IdUtilTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/id/IdUtilTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.math.BigInteger;
-import java.security.Security;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -44,29 +43,11 @@ public class IdUtilTest {
     @Test
     public void testPrivateConstructor() throws Exception {
         Constructor c = IdUtil.class.getDeclaredConstructor();
-        Assert.assertTrue(Modifier.isProtected(c.getModifiers()));
+        Assert.assertTrue(Modifier.isPrivate(c.getModifiers()));
 
         // Create a new instance for coverage.
         c.setAccessible(true);
         c.newInstance();
-    }
-
-    /**
-     * Assert that a security exception is rethrown.
-     *
-     * @throws Exception Should not be thrown.
-     */
-    @Test(expected = RuntimeException.class)
-    public void testSecureRandomThrows() throws Exception {
-        String key = "securerandom.strongAlgorithms";
-        String propValue = Security.getProperty(key);
-        Security.setProperty(key, "");
-
-        try {
-            new IdUtil();
-        } finally {
-            Security.setProperty(key, propValue);
-        }
     }
 
     /**


### PR DESCRIPTION
The former is only necessary during VM boot, which we're not
concerned with. It also removes a class of problems encountered
when not enough entropy is available on the system.