### PR TITLE
Corrected Jacoco coverage.

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/id/Base16BigIntegerConverterProvider.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/id/Base16BigIntegerConverterProvider.java
@@ -62,11 +62,14 @@ public final class Base16BigIntegerConverterProvider
         }
 
         // We only respond to path params and query params...
-        long count = Arrays.stream(annotations)
-                .filter(a -> a instanceof PathParam
-                        || a instanceof QueryParam)
-                .count();
-        if (count == 0) {
+        Boolean isPathParam = Arrays.stream(annotations)
+                .filter(a -> a instanceof PathParam)
+                .count() > 0;
+        Boolean isQueryParam = Arrays.stream(annotations)
+                .filter(a -> a instanceof QueryParam)
+                .count() > 0;
+
+        if (!isPathParam && !isQueryParam) {
             return null;
         }
 

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/id/Base16BigIntegerConverterProviderTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/id/Base16BigIntegerConverterProviderTest.java
@@ -20,6 +20,7 @@ package net.krotscheck.kangaroo.common.hibernate.id;
 
 import org.junit.Test;
 
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.ext.ParamConverter;
@@ -144,8 +145,21 @@ public final class Base16BigIntegerConverterProviderTest {
     /**
      * The string-to-biginteger converter.
      */
-    @Test
+    @Test(expected = NotFoundException.class)
     public void testConvertString() {
+        Annotation[] annotations = new Annotation[]{pathAnnotation};
+
+        ParamConverter converter = converterProvider
+                .getConverter(BigInteger.class, null, annotations);
+
+        converter.fromString("not_a_valid_string");
+    }
+
+    /**
+     * Test convert with an error.
+     */
+    @Test
+    public void testConvertFromStringError() {
         Annotation[] annotations = new Annotation[]{pathAnnotation};
 
         ParamConverter converter = converterProvider
@@ -154,6 +168,5 @@ public final class Base16BigIntegerConverterProviderTest {
         BigInteger id = IdUtil.next();
         BigInteger converted = (BigInteger)
                 converter.fromString(IdUtil.toString(id));
-        assertEquals(id, converted);
     }
 }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/keystore/FSKeystoreProviderTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/keystore/FSKeystoreProviderTest.java
@@ -20,11 +20,7 @@ package net.krotscheck.kangaroo.server.keystore;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareOnlyThisForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -33,12 +29,14 @@ import java.security.Principal;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+
 /**
  * Unit test for the filesystem keystore loader.
  *
  * @author Michael Krotscheck
  */
-@RunWith(PowerMockRunner.class)
 public class FSKeystoreProviderTest {
 
     /**
@@ -158,11 +156,11 @@ public class FSKeystoreProviderTest {
      * @throws Exception Thrown because RSA is not available.
      */
     @Test(expected = RuntimeException.class)
-    @PrepareOnlyThisForTest({FSKeystoreProvider.class, KeyStore.class})
     public void testRecastExceptionWriteTo() throws Exception {
-        FSKeystoreProvider provider = PowerMockito
+        FSKeystoreProvider provider = Mockito
                 .spy(new FSKeystoreProvider(KS_PATH, KS_PASS, KS_TYPE));
         KeyStore mockStore = Mockito.mock(KeyStore.class);
+        doThrow(Exception.class).when(mockStore).store(any(), any());
 
         Mockito.when(provider.getKeyStore()).thenReturn(mockStore);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/kangaroo-common/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/kangaroo-common/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <hibernate-search.version>5.8.0.Final</hibernate-search.version>
     <jersey.version>2.26</jersey.version>
     <slf4j.version>1.7.25</slf4j.version>
-    <powermock.version>1.6.6</powermock.version>
+    <powermock.version>2.0.0-beta.5</powermock.version>
     <jacoco.version>0.7.9</jacoco.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -284,6 +284,7 @@
             <argLine>-Xmx1024m</argLine>
 
             <systemPropertyVariables>
+              <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
               <java.security.egd>file:/dev/./urandom</java.security.egd>
               <sun.net.http.allowRestrictedHeaders>true</sun.net.http.allowRestrictedHeaders>
               <hibernate.connection.url>${hibernate.connection.url}</hibernate.connection.url>
@@ -537,7 +538,7 @@
     <!-- JUnit -->
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4-rule-agent</artifactId>
+      <artifactId>powermock-module-junit4-rule</artifactId>
       <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
@@ -549,7 +550,7 @@
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
+      <artifactId>powermock-api-mockito2</artifactId>
       <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
@@ -568,8 +569,14 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
+      <artifactId>mockito-core</artifactId>
+      <version>2.10.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>2.10.0</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
In a previous patch the jacoco configuration started to silently fail, due to a
missed commandline instruction. This patch adds it back in, and adds missing tests.
It also includes an update to mockito2, which can now mock final classes. This
makes Powermock obsolete, and we'll be removing it in subsequent patches.