### PR TITLE
Hibernate-based grizzly http session management

### DIFF
--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/HibernateResource.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/HibernateResource.java
@@ -19,9 +19,13 @@
 package net.krotscheck.kangaroo.test.rule;
 
 import net.krotscheck.kangaroo.common.hibernate.factory.HibernateServiceRegistryFactory;
+import net.krotscheck.kangaroo.common.hibernate.listener.CreatedUpdatedListener;
 import net.krotscheck.kangaroo.test.rule.hibernate.TestDirectoryProvider;
 import org.hibernate.SessionFactory;
 import org.hibernate.boot.MetadataSources;
+import org.hibernate.event.service.spi.EventListenerRegistry;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.internal.SessionFactoryImpl;
 import org.hibernate.service.ServiceRegistry;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
@@ -142,5 +146,15 @@ public class HibernateResource implements TestRule {
         sessionFactory = new MetadataSources(registry)
                 .buildMetadata()
                 .buildSessionFactory();
+
+        logger.debug("Injecting event listeners");
+        EventListenerRegistry eventRegistry =
+                ((SessionFactoryImpl) sessionFactory)
+                        .getServiceRegistry()
+                        .getService(EventListenerRegistry.class);
+        eventRegistry.appendListeners(EventType.PRE_INSERT,
+                new CreatedUpdatedListener());
+        eventRegistry.appendListeners(EventType.PRE_UPDATE,
+                new CreatedUpdatedListener());
     }
 }

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/OAuthAPI.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/OAuthAPI.java
@@ -30,6 +30,7 @@ import net.krotscheck.kangaroo.authz.oauth2.resource.token.AuthorizationCodeGran
 import net.krotscheck.kangaroo.authz.oauth2.resource.token.ClientCredentialsGrantHandler;
 import net.krotscheck.kangaroo.authz.oauth2.resource.token.OwnerCredentialsGrantHandler;
 import net.krotscheck.kangaroo.authz.oauth2.resource.token.RefreshTokenGrantHandler;
+import net.krotscheck.kangaroo.authz.oauth2.session.SessionFeature;
 import net.krotscheck.kangaroo.authz.oauth2.tasks.TokenCleanupTask;
 import net.krotscheck.kangaroo.common.config.ConfigurationFeature;
 import net.krotscheck.kangaroo.common.exception.ExceptionFeature;
@@ -70,6 +71,7 @@ public class OAuthAPI extends ResourceConfig {
 
         // Authorization context
         register(OAuthServerAuthnFeature.class);
+        register(SessionFeature.class);
 
         // Authorization handlers
         register(new AuthCodeHandler.Binder());

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/session/HttpSessionFactory.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/session/HttpSessionFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.oauth2.session;
+
+import org.glassfish.jersey.internal.inject.AbstractBinder;
+import org.glassfish.jersey.process.internal.RequestScoped;
+
+import javax.inject.Provider;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import javax.ws.rs.core.Context;
+import java.util.function.Supplier;
+
+/**
+ * A quick factory that extracts the HTTPSession on request.
+ *
+ * @author Michael Krotscheck
+ */
+public final class HttpSessionFactory implements Supplier<HttpSession> {
+
+    /**
+     * The request provider.
+     */
+    private final Provider<HttpServletRequest> requestProvider;
+
+    /**
+     * Create a new instance of this factory.
+     *
+     * @param requestProvider The request provider.
+     */
+    public HttpSessionFactory(
+            @Context final Provider<HttpServletRequest> requestProvider) {
+        this.requestProvider = requestProvider;
+    }
+
+    /**
+     * Extract, and provide, the HTTP Session from the servlet request.
+     *
+     * @return The HTTP Session.
+     */
+    @Override
+    public HttpSession get() {
+        return requestProvider.get().getSession();
+    }
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bindFactory(HttpSessionFactory.class)
+                    .to(HttpSession.class)
+                    .in(RequestScoped.class);
+        }
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/session/SessionFeature.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/session/SessionFeature.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.oauth2.session;
+
+import net.krotscheck.kangaroo.authz.oauth2.session.grizzly.GrizzlySessionLifecycleListener;
+import net.krotscheck.kangaroo.authz.oauth2.session.grizzly.GrizzlySessionManager;
+import net.krotscheck.kangaroo.authz.oauth2.session.tasks.HttpSessionCleanupTask;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+/**
+ * This feature overrides the container's session management with our own, so
+ * that cookies may be manipulated and maintained by a DI-provided entity.
+ * With that in place, it then provides the necessary processors and
+ * injectors to provide access to session and client sensitive refresh tokens.
+ *
+ * @author Michael Krotscheck
+ */
+public final class SessionFeature implements Feature {
+
+    /**
+     * Register all associated features.
+     *
+     * @param context The context in which to register features.
+     * @return true.
+     */
+    @Override
+    public boolean configure(final FeatureContext context) {
+
+        // Convenience injector for the HTTP session.
+        context.register(new HttpSessionFactory.Binder());
+
+        // Cleanup all old sessions.
+        context.register(new HttpSessionCleanupTask.Binder());
+
+        // Grizzly session management
+        context.register(GrizzlySessionLifecycleListener.class);
+        context.register(new GrizzlySessionManager.Binder());
+
+        return true;
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/session/grizzly/GrizzlySession.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/session/grizzly/GrizzlySession.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.oauth2.session.grizzly;
+
+import org.glassfish.grizzly.http.server.Session;
+
+/**
+ * This extends the default session implementation, as the one provided by
+ * grizzly (and required by it) doesn't actually do all the things we need it
+ * to.
+ *
+ * @author Michael Krotscheck
+ */
+public final class GrizzlySession extends Session {
+
+    /**
+     * When this session was created.
+     */
+    private long creationTime = System.currentTimeMillis();
+
+    /**
+     * A session identifier.
+     */
+    private String id = null;
+
+    /**
+     * Is this Session valid.
+     */
+    private boolean isValid = true;
+
+    /**
+     * Is this session new.
+     */
+    private boolean isNew = true;
+
+    /**
+     * Creation time stamp.
+     */
+    private long timestamp = System.currentTimeMillis();
+
+    /**
+     * @return the session identifier for this session.
+     */
+    @Override
+    public String getIdInternal() {
+        return id;
+    }
+
+    /**
+     * Sets the session identifier for this session.
+     *
+     * @param id The internal ID.
+     */
+    @Override
+    public void setIdInternal(final String id) {
+        this.id = id;
+    }
+
+    /**
+     * Is the current Session valid?
+     *
+     * @return true if valid.
+     */
+    public boolean isValid() {
+        return isValid;
+    }
+
+    /**
+     * Set this object as validated.
+     *
+     * @param isValid Set whether this session is valid.
+     */
+    public void setValid(final boolean isValid) {
+        this.isValid = isValid;
+
+        if (!isValid) {
+            timestamp = -1;
+        }
+    }
+
+    /**
+     * Returns <code>true</code> if the client does not yet know about the
+     * session or if the client chooses not to join the session.  For
+     * example, if the server used only cookie-based sessions, and
+     * the client had disabled the use of cookies, then a session would
+     * be new on each request.
+     *
+     * @return <code>true</code> if the
+     * server has created a session,
+     * but the client has not yet joined
+     */
+    public boolean isNew() {
+        return isNew;
+    }
+
+    /**
+     * Returns the time when this session was created, measured
+     * in milliseconds since midnight January 1, 1970 GMT.
+     *
+     * @return a <code>long</code> specifying when this session was created,
+     * expressed in milliseconds since 1/1/1970 GMT
+     */
+    public long getCreationTime() {
+        return creationTime;
+    }
+
+    /**
+     * Set the creation time of this session.
+     *
+     * @param creationTime The creation time, in milliseconds.
+     */
+    public void setCreationTime(final long creationTime) {
+        this.creationTime = creationTime;
+    }
+
+    /**
+     * @return the timestamp when this session was accessed the last time
+     */
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    /**
+     * Set the timestamp when this session was accessed the last time.
+     *
+     * @param timestamp A long representing when the session was last accessed.
+     */
+    public void setTimestamp(final long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * Updates the "last accessed" timestamp with the current time.
+     *
+     * @return the time stamp
+     */
+    public long access() {
+        final long localTimeStamp = System.currentTimeMillis();
+        timestamp = localTimeStamp;
+        isNew = false;
+
+        return localTimeStamp;
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/session/grizzly/GrizzlySessionLifecycleListener.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/session/grizzly/GrizzlySessionLifecycleListener.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.oauth2.session.grizzly;
+
+import net.krotscheck.kangaroo.authz.AuthzServerConfig;
+import net.krotscheck.kangaroo.common.config.SystemConfiguration;
+import org.glassfish.grizzly.servlet.WebappContext;
+import org.glassfish.jersey.server.spi.Container;
+import org.glassfish.jersey.server.spi.ContainerLifecycleListener;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.servlet.ServletContext;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Container lifecycle listener for the session feature, which grabs an
+ * instance of the server and replaces session management with our own
+ * implementation. This implementation is provided with full knowledge of the
+ * Jersey2 injection context, including things like database connections, etc.
+ *
+ * @author Michael Krotscheck
+ */
+@Provider
+@Singleton
+public final class GrizzlySessionLifecycleListener
+        implements ContainerLifecycleListener {
+
+    /**
+     * The grizzly webapplication context.
+     */
+    private final WebappContext context;
+
+    /**
+     * The injected & Constructed session manager.
+     */
+    private final GrizzlySessionManager sessionManager;
+
+    /**
+     * Max age, in seconds, of the session.
+     */
+    private final Integer sessionMaxAge;
+
+    /**
+     * The name of the session (aka cookie).
+     */
+    private final String sessionName;
+
+    /**
+     * Create a new instance of this lifecycle listener.
+     *
+     * @param context        The servlet context, expected to be Grizzly
+     *                       WebappContext.
+     * @param sessionManager The OAuth2 Session manager.
+     * @param c              Global system configuration.
+     */
+    @Inject
+    public GrizzlySessionLifecycleListener(
+            @Context final ServletContext context,
+            final GrizzlySessionManager sessionManager,
+            final SystemConfiguration c) {
+        this.context = (WebappContext) context;
+        this.sessionManager = sessionManager;
+
+        // Get the session name and expiry.
+        sessionMaxAge = c.getInt(
+                AuthzServerConfig.SESSION_MAX_AGE.getKey(),
+                AuthzServerConfig.SESSION_MAX_AGE.getValue());
+        sessionName = c.getString(
+                AuthzServerConfig.SESSION_NAME.getKey(),
+                AuthzServerConfig.SESSION_NAME.getValue());
+    }
+
+    /**
+     * On container startup, replace our session manager.
+     *
+     * @param container The servlet container, not used.
+     */
+    @Override
+    public void onStartup(final Container container) {
+        context.setSessionManager(sessionManager);
+        context.getSessionCookieConfig().setName(sessionName);
+        context.getSessionCookieConfig().setHttpOnly(true);
+        context.getSessionCookieConfig().setSecure(true);
+        context.getSessionCookieConfig().setMaxAge(sessionMaxAge);
+    }
+
+    /**
+     * On reload, do nothing.
+     *
+     * @param container The servlet container, not used.
+     */
+    @Override
+    public void onReload(final Container container) {
+    }
+
+    /**
+     * On shutdown, do nothing.
+     *
+     * @param container The servlet container, not used.
+     */
+    @Override
+    public void onShutdown(final Container container) {
+
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/session/grizzly/GrizzlySessionManager.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/session/grizzly/GrizzlySessionManager.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.oauth2.session.grizzly;
+
+import net.krotscheck.kangaroo.authz.AuthzServerConfig;
+import net.krotscheck.kangaroo.authz.common.database.entity.HttpSession;
+import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
+import net.krotscheck.kangaroo.common.config.SystemConfiguration;
+import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
+import org.glassfish.grizzly.http.Cookie;
+import org.glassfish.grizzly.http.server.Request;
+import org.glassfish.grizzly.http.server.Session;
+import org.glassfish.grizzly.http.server.SessionManager;
+import org.glassfish.jersey.internal.inject.AbstractBinder;
+import org.hibernate.SessionFactory;
+import org.hibernate.query.Query;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import java.math.BigInteger;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+import java.util.TimeZone;
+
+/**
+ * The grizzly session manager overrides the SessionManager from the grizzly
+ * servlet container with itself, in order to provide a manager that is bound
+ * to the Jersey2 injection context. The purpose of this is to be able to
+ * access the same injectable resources - such as a database connection, when
+ * resolving session persistence.
+ *
+ * @author Michael Krotscheck
+ */
+public final class GrizzlySessionManager implements SessionManager {
+
+    /**
+     * The date HQL.
+     */
+    private static final String DATE_HQL = "update HttpSession set"
+            + " createdDate=?,"
+            + " modifiedDate=? where id=?";
+
+    /**
+     * Max age, in seconds, of the session.
+     */
+    private final Integer sessionMaxAge;
+
+    /**
+     * The context sensitive session factory provider.
+     */
+    private final Provider<SessionFactory> sessionFactoryProvider;
+
+    /**
+     * The name of the session (aka cookie).
+     */
+    private String sessionCookieName;
+
+    /**
+     * Create a new instance of this session manager.
+     *
+     * @param c          The system configuration.
+     * @param sfProvider The session factory provider.
+     */
+    @Inject
+    public GrizzlySessionManager(final SystemConfiguration c,
+                                 final Provider<SessionFactory> sfProvider) {
+        this.sessionFactoryProvider = sfProvider;
+
+        // Get the session name and expiry.
+        sessionMaxAge = c.getInt(
+                AuthzServerConfig.SESSION_MAX_AGE.getKey(),
+                AuthzServerConfig.SESSION_MAX_AGE.getValue());
+        sessionCookieName = c.getString(
+                AuthzServerConfig.SESSION_NAME.getKey(),
+                AuthzServerConfig.SESSION_NAME.getValue());
+    }
+
+    /**
+     * Return the session associated with this Request.
+     *
+     * @param request            {@link Request}
+     * @param requestedSessionId the session id associated with the
+     *                           {@link Request}
+     * @return {@link Session}
+     */
+    @Override
+    public Session getSession(final Request request,
+                              final String requestedSessionId) {
+        BigInteger sessionId = IdUtil.fromString(requestedSessionId);
+
+        if (sessionId != null) {
+            SessionFactory sessionFactory = sessionFactoryProvider.get();
+            org.hibernate.Session hibernateSession =
+                    sessionFactory.openSession();
+
+            hibernateSession.beginTransaction();
+            HttpSession entity =
+                    hibernateSession.get(HttpSession.class, sessionId);
+            hibernateSession.getTransaction().commit();
+
+            if (entity != null) {
+                // quick persist to update modified date.
+                Calendar now =
+                        Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+                entity.setModifiedDate(now);
+
+                hibernateSession.beginTransaction();
+                hibernateSession.update(entity);
+                hibernateSession.getTransaction().commit();
+            }
+            hibernateSession.close();
+
+            return asSession(entity);
+        }
+
+        return null;
+    }
+
+    /**
+     * Create a new {@link Session} associated with the {@link Request}.
+     *
+     * @param request {@link Request}
+     * @return a new {@link Session} associated with the {@link Request}
+     */
+    @Override
+    public Session createSession(final Request request) {
+        SessionFactory sessionFactory = sessionFactoryProvider.get();
+        org.hibernate.Session hibernateSession = sessionFactory.openSession();
+
+        hibernateSession.beginTransaction();
+        HttpSession entity = new HttpSession();
+        entity.setSessionTimeout(sessionMaxAge);
+        hibernateSession.save(entity);
+        hibernateSession.getTransaction().commit();
+        hibernateSession.close();
+
+        return asSession(entity);
+    }
+
+    /**
+     * Change the session ID of a provided session in-place.
+     *
+     * @param request The request context.
+     * @param session The session whose ID to change.
+     * @return The old session ID.
+     */
+    @Override
+    public String changeSessionId(final Request request,
+                                  final Session session) {
+        String oldId = session.getIdInternal();
+        GrizzlySession grizzlySession = (GrizzlySession) session;
+        SessionFactory sessionFactory = sessionFactoryProvider.get();
+        org.hibernate.Session hibernateSession = sessionFactory.openSession();
+
+        try {
+            BigInteger old = IdUtil.fromString(session.getIdInternal());
+
+            hibernateSession.beginTransaction();
+            HttpSession oldEntity =
+                    hibernateSession.get(HttpSession.class, old);
+            hibernateSession.getTransaction().commit();
+
+            if (oldEntity != null) {
+                hibernateSession.beginTransaction();
+                List<OAuthToken> refreshTokens =
+                        new ArrayList<>(oldEntity.getRefreshTokens());
+                HttpSession newSession = new HttpSession();
+                newSession.setCreatedDate(oldEntity.getCreatedDate());
+                newSession.setModifiedDate(oldEntity.getModifiedDate());
+                newSession.setSessionTimeout(session.getSessionTimeout());
+                newSession.setRefreshTokens(refreshTokens);
+
+                hibernateSession.delete(oldEntity);
+                hibernateSession.save(newSession);
+
+                // Modify the dates, because the entity persister will use
+                // the default listeners...
+                Query setDates = hibernateSession.createQuery(DATE_HQL);
+                setDates.setParameter(0, oldEntity.getCreatedDate());
+                setDates.setParameter(1, oldEntity.getModifiedDate());
+                setDates.setParameter(2, newSession.getId());
+                setDates.executeUpdate();
+
+                hibernateSession.getTransaction().commit();
+
+                grizzlySession
+                        .setIdInternal(IdUtil.toString(newSession.getId()));
+            }
+        } catch (Exception e) {
+            hibernateSession.getTransaction().rollback();
+        }
+
+        hibernateSession.close();
+
+        return oldId;
+    }
+
+
+    /**
+     * Return the current session cookie name.
+     *
+     * @return The current cookie name.
+     */
+    @Override
+    public String getSessionCookieName() {
+        return sessionCookieName;
+    }
+
+    /**
+     * Set the current session cookie name.
+     *
+     * @param name The name of the cookie.
+     */
+    @Override
+    public void setSessionCookieName(final String name) {
+        this.sessionCookieName = name;
+    }
+
+    /**
+     * Configure session cookie before adding it to the
+     * {@link Request#getResponse()}.
+     *
+     * @param request The request.
+     * @param cookie  The cookie to configure.
+     */
+    @Override
+    public void configureSessionCookie(final Request request,
+                                       final Cookie cookie) {
+        String requestUrlString = request.getRequestURL().toString();
+        URI requestUrl = URI.create(requestUrlString);
+
+        // Most of these properties are overridden by the session container
+        // after this has been set, but we write them here just in case
+        // there's a refactor in the future that breaks it.
+        cookie.setDomain(requestUrl.getHost());
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setName(sessionCookieName);
+        cookie.setMaxAge(sessionMaxAge);
+    }
+
+    /**
+     * Convert a database entity session to a regular detached grizzly session.
+     *
+     * @param entity The entity to convert.
+     * @return The HTTP session.
+     */
+    protected Session asSession(final HttpSession entity) {
+        if (entity == null) {
+            return null;
+        }
+
+        GrizzlySession s = new GrizzlySession();
+        s.setIdInternal(IdUtil.toString(entity.getId()));
+        s.setCreationTime(entity.getCreatedDate().getTimeInMillis());
+        s.setTimestamp(entity.getModifiedDate().getTimeInMillis());
+        s.setSessionTimeout(entity.getSessionTimeout());
+        return s;
+    }
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bind(GrizzlySessionManager.class)
+                    .to(GrizzlySessionManager.class)
+                    .in(Singleton.class);
+        }
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/session/grizzly/package-info.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/session/grizzly/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Session management specifically for the Grizzly servlet container.
+ */
+package net.krotscheck.kangaroo.authz.oauth2.session.grizzly;

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/session/package-info.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/session/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * HTTP Session management.
+ */
+package net.krotscheck.kangaroo.authz.oauth2.session;

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/session/tasks/HttpSessionCleanupTask.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/session/tasks/HttpSessionCleanupTask.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.oauth2.session.tasks;
+
+import net.krotscheck.kangaroo.common.hibernate.migration.DatabaseMigrationState;
+import net.krotscheck.kangaroo.common.timedtasks.RepeatingTask;
+import org.glassfish.jersey.internal.inject.AbstractBinder;
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.type.LongType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Calendar;
+import java.util.TimeZone;
+import java.util.TimerTask;
+
+/**
+ * This timed task cleans up expired HTTP sessions.
+ *
+ * @author Michael Krotscheck
+ */
+public final class HttpSessionCleanupTask
+        extends TimerTask
+        implements RepeatingTask {
+
+    /**
+     * Logger instance.
+     */
+    private static Logger logger = LoggerFactory
+            .getLogger(HttpSessionCleanupTask.class);
+
+    /**
+     * The session factory.
+     */
+    private final SessionFactory sessionFactory;
+
+    /**
+     * The migration state of the database, this ensures that the task only
+     * runs if the DB has been bootstrapped.
+     */
+    @SuppressWarnings("PMD.UnusedPrivateField")
+    private final DatabaseMigrationState migrationState;
+
+    /**
+     * Create a new instance of this task, with injected parameters.
+     *
+     * @param sessionFactory The hibernate session factory, from which we
+     *                       grab database sessions.
+     * @param dbState        The database migration state, used to indicate
+     *                       whether the DB is stable enough to run this query.
+     */
+    @Inject
+    public HttpSessionCleanupTask(final SessionFactory sessionFactory,
+                                  final DatabaseMigrationState dbState) {
+        this.sessionFactory = sessionFactory;
+        this.migrationState = dbState;
+    }
+
+    /**
+     * The task to execute.
+     *
+     * @return The task to execute.
+     */
+    @Override
+    public TimerTask getTask() {
+        return this;
+    }
+
+    /**
+     * Time in milliseconds between successive task executions.
+     *
+     * @return Time in milliseconds between successive task executions.
+     */
+    @Override
+    public long getPeriod() {
+        return 10 * 60 * 1000; // Every 10 minutes.
+    }
+
+    /**
+     * The action to be performed by this timer task.
+     */
+    @Override
+    public void run() {
+        Session session = sessionFactory.openSession();
+        Transaction t = session.beginTransaction();
+
+        long deletedCount = 0;
+        try {
+            Calendar now = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+
+            // Add a buffer, because tick sync.
+            now.add(Calendar.MINUTE, -1);
+            Long timestamp = now.getTimeInMillis();
+
+            String hql = "DELETE FROM HttpSession"
+                    + " WHERE (modifiedDate + (sessionTimeout * 1000))"
+                    + " < :timestamp";
+
+            deletedCount = session.createQuery(hql)
+                    .setParameter("timestamp", timestamp, LongType.INSTANCE)
+                    .executeUpdate();
+            t.commit();
+        } catch (HibernateException e) {
+            logger.error(e.getMessage(), e);
+            t.rollback();
+        } finally {
+            session.close();
+        }
+
+        if (deletedCount > 0) {
+            logger.debug(String.format("%s expired http sessions deleted.",
+                    deletedCount));
+        }
+    }
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bind(HttpSessionCleanupTask.class)
+                    .to(RepeatingTask.class)
+                    .in(Singleton.class);
+        }
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/session/tasks/package-info.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/session/tasks/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Database maintenance for HTTP session handling.
+ */
+package net.krotscheck.kangaroo.authz.oauth2.session.tasks;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/session/HttpSessionFactoryTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/session/HttpSessionFactoryTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.oauth2.session;
+
+import org.junit.Test;
+
+import javax.inject.Provider;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for the session factory.
+ *
+ * @author Michael Krotscheck
+ */
+public final class HttpSessionFactoryTest {
+
+    /**
+     * Assert that it returns the session instance provided by the HTTP
+     * Servlet request.
+     */
+    @Test
+    public void get() {
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        HttpSession mockSession = mock(HttpSession.class);
+        doReturn(mockSession).when(mockRequest).getSession();
+        Provider<HttpServletRequest> requestProvider = () -> mockRequest;
+
+        HttpSessionFactory factory = new HttpSessionFactory(requestProvider);
+        HttpSession responseSession = factory.get();
+        assertSame(responseSession, mockSession);
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/session/SessionFeatureTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/session/SessionFeatureTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.oauth2.session;
+
+import net.krotscheck.kangaroo.authz.common.database.DatabaseFeature;
+import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
+import net.krotscheck.kangaroo.authz.oauth2.session.tasks.HttpSessionCleanupTask;
+import net.krotscheck.kangaroo.common.config.ConfigurationFeature;
+import net.krotscheck.kangaroo.common.hibernate.HibernateFeature;
+import net.krotscheck.kangaroo.common.timedtasks.RepeatingTask;
+import net.krotscheck.kangaroo.test.jersey.ContainerTest;
+import org.apache.http.HttpStatus;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.Assert;
+import org.junit.Test;
+import org.jvnet.hk2.annotations.Optional;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.servlet.http.HttpSession;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+/**
+ * Test that the session feature works.
+ *
+ * @author Michael Krotscheck
+ */
+public final class SessionFeatureTest extends ContainerTest {
+
+    /**
+     * Create an application.
+     *
+     * @return The application to test.
+     */
+    @Override
+    protected ResourceConfig createApplication() {
+        ResourceConfig a = new ResourceConfig();
+        a.register(HibernateFeature.class);
+        a.register(DatabaseFeature.class);
+        a.register(ConfigurationFeature.class);
+        a.register(SessionFeature.class);
+        a.register(MockService.class);
+        return a;
+    }
+
+    /**
+     * Quick check to see if we can inject and access the authenticators. The
+     * test code itself is in the mock service below.
+     */
+    @Test
+    public void testStatus() {
+        Response response = target("/").request().get();
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatus());
+    }
+
+    /**
+     * A simple endpoint that returns the list of authenticators registered.
+     *
+     * @author Michael Krotscheck
+     */
+    @Path("/")
+    public static final class MockService {
+
+        /**
+         * The HTTP session.
+         */
+        private Provider<HttpSession> httpSessionProvider;
+
+        /**
+         * The task provider.
+         */
+        private Provider<RepeatingTask> taskProvider;
+
+        /**
+         * The oauth2 token.
+         */
+        private OAuthToken token;
+
+        /**
+         * Create a new instance of the status service.
+         *
+         * @param httpSessionProvider The HTTP session provider.
+         * @param taskProvider        Provider for injected tasks.
+         * @param token               The OAUth token (should actually be null)
+         */
+        @Inject
+        public MockService(final Provider<HttpSession> httpSessionProvider,
+                           final Provider<RepeatingTask> taskProvider,
+                           @Optional final OAuthToken token) {
+            this.taskProvider = taskProvider;
+            this.httpSessionProvider = httpSessionProvider;
+            this.token = token;
+        }
+
+        /**
+         * Try to access various injectees.
+         *
+         * @return HTTP Response object with the current service status.
+         */
+        @GET
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response status() {
+            HttpSession session = httpSessionProvider.get();
+            if (session == null || token != null) {
+                return Response.status(Status.BAD_REQUEST).build();
+            }
+
+            RepeatingTask task = taskProvider.get();
+            if (task == null || !(task instanceof HttpSessionCleanupTask)) {
+                return Response.status(Status.BAD_REQUEST).build();
+            }
+
+            return Response
+                    .status(HttpStatus.SC_OK)
+                    .build();
+        }
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/session/grizzly/GrizzlySessionLifecycleListenerTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/session/grizzly/GrizzlySessionLifecycleListenerTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.oauth2.session.grizzly;
+
+import net.krotscheck.kangaroo.authz.AuthzServerConfig;
+import net.krotscheck.kangaroo.common.config.SystemConfiguration;
+import net.krotscheck.kangaroo.test.jersey.DatabaseTest;
+import org.glassfish.grizzly.servlet.WebappContext;
+import org.glassfish.hk2.api.ActiveDescriptor;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.api.ServiceLocatorFactory;
+import org.glassfish.hk2.utilities.BuilderHelper;
+import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
+import org.glassfish.jersey.server.spi.Container;
+import org.glassfish.jersey.server.spi.ContainerLifecycleListener;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.inject.Singleton;
+import javax.servlet.SessionCookieConfig;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+/**
+ * Unit tests for the lifecycle listener test. Its job is to replace the
+ * grizzly session manager with one that's attached to the injection context.
+ *
+ * @author Michael Krotscheck
+ */
+public class GrizzlySessionLifecycleListenerTest extends DatabaseTest {
+
+    /**
+     * The listener under test.
+     */
+    private GrizzlySessionLifecycleListener listener;
+
+    /**
+     * The container to inject.
+     */
+    private Container mockContainer;
+
+    /**
+     * The mock servlet context..
+     */
+    private WebappContext context;
+
+    /**
+     * The mock session manager.
+     */
+    private GrizzlySessionManager sessionManager;
+
+    /**
+     * The mock configuration.
+     */
+    private SystemConfiguration configuration;
+
+    /**
+     * Bootstrap the test.
+     */
+    @Before
+    public void setupTest() {
+        mockContainer = mock(Container.class);
+        context = mock(WebappContext.class);
+        SessionCookieConfig config =
+                new org.glassfish.grizzly.servlet.SessionCookieConfig(context);
+        doReturn(config).when(context).getSessionCookieConfig();
+
+        configuration = new SystemConfiguration(Collections.emptyList());
+        sessionManager = new GrizzlySessionManager(configuration,
+                this::getSessionFactory);
+
+        listener = new GrizzlySessionLifecycleListener(
+                context, sessionManager, configuration);
+    }
+
+    /**
+     * Assert that the session manager is replaced on startup.
+     */
+    @Test
+    public void onStartup() {
+        listener.onStartup(mockContainer);
+        verifyNoMoreInteractions(mockContainer);
+        verify(context, times(1))
+                .setSessionManager(sessionManager);
+    }
+
+    /**
+     * Assert that the cookie configuration is overridden on startup.
+     */
+    @Test
+    public void onStartupConfigureCookie() {
+        listener.onStartup(mockContainer);
+        verifyNoMoreInteractions(mockContainer);
+
+        SessionCookieConfig config = context.getSessionCookieConfig();
+
+        assertTrue(config.isHttpOnly());
+        assertTrue(config.isSecure());
+        assertEquals(config.getMaxAge(),
+                (long) AuthzServerConfig.SESSION_MAX_AGE.getValue());
+        assertEquals(config.getName(),
+                AuthzServerConfig.SESSION_NAME.getValue());
+    }
+
+    /**
+     * Assert that nothing happens on reload.
+     */
+    @Test
+    public void onReload() {
+        listener.onReload(mockContainer);
+        verifyNoMoreInteractions(mockContainer);
+    }
+
+    /**
+     * Assert that nothing happens on shutdown.
+     */
+    @Test
+    public void onShutdown() {
+        listener.onShutdown(mockContainer);
+        verifyNoMoreInteractions(mockContainer);
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/session/grizzly/GrizzlySessionManagerTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/session/grizzly/GrizzlySessionManagerTest.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.oauth2.session.grizzly;
+
+import net.krotscheck.kangaroo.authz.AuthzServerConfig;
+import net.krotscheck.kangaroo.authz.common.database.entity.HttpSession;
+import net.krotscheck.kangaroo.common.config.SystemConfiguration;
+import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
+import net.krotscheck.kangaroo.test.jersey.DatabaseTest;
+import org.glassfish.grizzly.http.Cookie;
+import org.glassfish.grizzly.http.server.Request;
+import org.glassfish.grizzly.http.server.Session;
+import org.hibernate.HibernateException;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.query.Query;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for our Grizzly session manager.
+ *
+ * @author Michael Krotscheck
+ */
+public final class GrizzlySessionManagerTest extends DatabaseTest {
+
+    /**
+     * Manager under test.
+     */
+    private GrizzlySessionManager manager;
+
+    /**
+     * Setup the test.
+     */
+    @Before
+    public void setup() {
+        SystemConfiguration config =
+                new SystemConfiguration(Collections.emptyList());
+        manager = new GrizzlySessionManager(config, this::getSessionFactory);
+    }
+
+    /**
+     * Test creating a session.
+     */
+    @Test
+    public void testCreateSession() {
+        Session newSession = manager.createSession(null);
+
+        // Assert that this session exists in the database.
+        org.hibernate.Session hSession = getSession();
+        HttpSession dbSession = hSession.get(HttpSession.class,
+                IdUtil.fromString(newSession.getIdInternal()));
+
+        ensureSessionsMatch(dbSession, newSession);
+    }
+
+    /**
+     * Test a simple "Get session" action.
+     */
+    @Test
+    public void testGetSession() {
+        org.hibernate.Session hSession = getSession();
+        HttpSession s = new HttpSession();
+        s.setSessionTimeout(1000);
+
+        Calendar zero = Calendar.getInstance();
+        zero.setTimeInMillis(0);
+
+        // Create the session and zero the dates.
+        hSession.beginTransaction();
+        hSession.save(s);
+        Query q = hSession.createQuery("update HttpSession set " +
+                "createdDate=?, modifiedDate=?");
+        q.setParameter(0, zero);
+        q.setParameter(1, zero);
+        q.executeUpdate();
+        hSession.evict(s);
+        hSession.getTransaction().commit();
+
+        Session result = manager.getSession(null,
+                IdUtil.toString(s.getId()));
+
+        // Clear the whole session...
+        hSession.clear();
+
+        hSession.beginTransaction();
+        s = hSession.get(HttpSession.class, s.getId());
+        hSession.getTransaction().commit();
+
+        // Make sure that modified is greater than created
+        assertTrue(s.getModifiedDate().getTimeInMillis() > 0);
+
+        ensureSessionsMatch(s, result);
+    }
+
+    /**
+     * If no id is passed, do nothing.
+     */
+    @Test
+    public void testGetSessionNoId() {
+        assertNull(manager.getSession(null, null));
+    }
+
+    /**
+     * If the requested ID doesn't exist, do nothing.
+     */
+    @Test
+    public void testNonexistentSession() {
+        String testId = IdUtil.toString(IdUtil.next());
+        assertNull(manager.getSession(null, testId));
+    }
+
+    /**
+     * Assert that we can change a session ID.
+     */
+    @Test
+    public void testChangeSessionId() {
+        org.hibernate.Session hSession = getSession();
+        HttpSession s = new HttpSession();
+        s.setSessionTimeout(1000);
+
+        hSession.beginTransaction();
+        hSession.save(s);
+        hSession.getTransaction().commit();
+        hSession.evict(s);
+
+        Session browserSession = manager.asSession(s);
+
+        String oldId = manager.changeSessionId(null, browserSession);
+
+        assertEquals(s.getId(), IdUtil.fromString(oldId));
+
+        hSession.beginTransaction();
+        HttpSession testSession = hSession.get(HttpSession.class, s.getId());
+        hSession.getTransaction().commit();
+        assertNull(testSession);
+
+        assertNotEquals(oldId, browserSession.getIdInternal());
+
+        hSession.beginTransaction();
+        HttpSession newSession = hSession.get(HttpSession.class,
+                IdUtil.fromString(browserSession.getIdInternal()));
+        hSession.getTransaction().commit();
+        assertNotNull(newSession);
+
+        assertEquals(s.getSessionTimeout(), newSession.getSessionTimeout());
+        assertEquals(s.getCreatedDate(), newSession.getCreatedDate());
+        assertEquals(s.getModifiedDate(), newSession.getModifiedDate());
+    }
+
+    /**
+     * Assert that changing an ID, if no original exists, does nothing.
+     */
+    @Test
+    public void testChangeSessionIdNoOriginal() {
+        HttpSession s = new HttpSession();
+        s.setId(IdUtil.next());
+        s.setCreatedDate(Calendar.getInstance());
+        s.setModifiedDate(Calendar.getInstance());
+        s.setSessionTimeout(1000);
+
+        Session browserSession = manager.asSession(s);
+
+        String oldId = manager.changeSessionId(null, browserSession);
+
+        assertEquals(s.getId(), IdUtil.fromString(oldId));
+    }
+
+    /**
+     * Assert that throwing in the change ID block is cleanly caught.
+     */
+    @Test
+    public void testChangeSessionIdThrown() {
+        SystemConfiguration config =
+                new SystemConfiguration(Collections.emptyList());
+        SessionFactory mockFactory = mock(SessionFactory.class);
+        org.hibernate.Session mockHSession = mock(org.hibernate.Session.class);
+        Transaction mockTransaction = mock(Transaction.class);
+
+        doReturn(mockHSession).when(mockFactory).openSession();
+        doReturn(mockTransaction).when(mockHSession).getTransaction();
+        doThrow(HibernateException.class).when(mockHSession).beginTransaction();
+
+        manager = new GrizzlySessionManager(config, () -> mockFactory);
+
+        HttpSession s = new HttpSession();
+        s.setId(IdUtil.next());
+        s.setCreatedDate(Calendar.getInstance());
+        s.setModifiedDate(Calendar.getInstance());
+        s.setSessionTimeout(1000);
+
+        Session browserSession = manager.asSession(s);
+
+        String oldId = manager.changeSessionId(null, browserSession);
+
+        verify(mockHSession, times(1)).close();
+        verify(mockTransaction, times(1)).rollback();
+
+        assertEquals(s.getId(), IdUtil.fromString(oldId));
+    }
+
+    /**
+     * Assert that we can get/set the session cookie name.
+     */
+    @Test
+    public void testGetSetSessionCookieName() {
+        String oldName = manager.getSessionCookieName();
+        manager.setSessionCookieName("new_cookie_name");
+
+        assertEquals("new_cookie_name", manager.getSessionCookieName());
+        assertEquals("kangaroo", oldName);
+    }
+
+    /**
+     * Assert that we can convert from entity to session.
+     */
+    @Test
+    public void testAsSession() {
+        assertNull(manager.asSession(null));
+
+        HttpSession s = new HttpSession();
+        s.setId(IdUtil.next());
+        s.setCreatedDate(Calendar.getInstance());
+        s.setModifiedDate(Calendar.getInstance());
+        s.setSessionTimeout(1000);
+
+        Session result = manager.asSession(s);
+        ensureSessionsMatch(s, result);
+    }
+
+    /**
+     * Assert that cookie parameters are set when called for.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testConfigureSessionCookie() throws Exception {
+        Request r = mock(Request.class);
+        doReturn(new StringBuilder("http://example.com/foo"))
+                .when(r)
+                .getRequestURL();
+
+        Cookie c = new Cookie("JSESSIONID", null);
+
+        manager.configureSessionCookie(r, c);
+
+        assertEquals("example.com", c.getDomain());
+        assertTrue(c.isHttpOnly());
+        assertTrue(c.isSecure());
+        assertEquals(AuthzServerConfig.SESSION_NAME.getValue(),
+                c.getName());
+        assertEquals(AuthzServerConfig.SESSION_MAX_AGE.getValue(),
+                Integer.valueOf(c.getMaxAge()));
+    }
+
+    /**
+     * Comparison helper method.
+     *
+     * @param dbSession      The DB session to match.
+     * @param browserSession The browser session to match.
+     */
+    private void ensureSessionsMatch(final HttpSession dbSession,
+                                     final Session browserSession) {
+        assertEquals(IdUtil.toString(dbSession.getId()),
+                browserSession.getIdInternal());
+        assertEquals(dbSession.getCreatedDate().getTimeInMillis(),
+                browserSession.getCreationTime());
+        assertEquals(dbSession.getModifiedDate().getTimeInMillis(),
+                browserSession.getTimestamp());
+        assertEquals(dbSession.getSessionTimeout(),
+                browserSession.getSessionTimeout());
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/session/grizzly/GrizzlySessionTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/session/grizzly/GrizzlySessionTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.oauth2.session.grizzly;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the grizzly session pojo.
+ *
+ * @author Michael Krotscheck
+ */
+public final class GrizzlySessionTest {
+
+    /**
+     * Assert that we can modify the ID directly.
+     */
+    @Test
+    public void getSetIdInternal() {
+        GrizzlySession s = new GrizzlySession();
+
+        assertNull(s.getIdInternal());
+        s.setIdInternal("this_is_a_string");
+        assertEquals("this_is_a_string", s.getIdInternal());
+    }
+
+    /**
+     * Assert that we can modify the valid value.
+     */
+    @Test
+    public void isValid() {
+        GrizzlySession s = new GrizzlySession();
+
+        assertTrue(s.getTimestamp() > -1);
+        assertTrue(s.isValid());
+        s.setValid(false);
+        assertEquals(-1, s.getTimestamp());
+        assertFalse(s.isValid());
+
+        s.setTimestamp(10000);
+        s.setValid(true);
+        assertTrue(s.isValid());
+        assertEquals(10000, s.getTimestamp());
+    }
+
+    /**
+     * Assert that isNew returns the correct method.
+     */
+    @Test
+    public void isNew() {
+        GrizzlySession s = new GrizzlySession();
+        assertTrue(s.isNew());
+    }
+
+    /**
+     * Assert that we can modify the creation time.
+     */
+    @Test
+    public void getSetCreationTime() {
+        GrizzlySession s = new GrizzlySession();
+
+        assertTrue(s.getCreationTime() > 0);
+        s.setCreationTime(10000);
+        assertEquals(10000, s.getCreationTime());
+    }
+
+    /**
+     * Assert that we can modify the timestamp.
+     */
+    @Test
+    public void getTimestamp() {
+        GrizzlySession s = new GrizzlySession();
+
+        assertTrue(s.getTimestamp() > 0);
+        s.setTimestamp(10000);
+        assertEquals(10000, s.getTimestamp());
+    }
+
+    /**
+     * Assert that access behaves the same as the parent instance.
+     */
+    @Test
+    public void access() {
+        GrizzlySession s = new GrizzlySession();
+        assertTrue(s.isNew());
+        assertEquals(System.currentTimeMillis(), s.access());
+        assertFalse(s.isNew());
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/session/grizzly/package-info.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/session/grizzly/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Unit tests specifically for the grizzly connection.
+ *
+ * @author Michael Krotscheck
+ */
+package net.krotscheck.kangaroo.authz.oauth2.session.grizzly;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/session/package-info.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/session/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Unit tests for the session feature.
+ *
+ * @author Michael Krotscheck
+ */
+package net.krotscheck.kangaroo.authz.oauth2.session;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/session/tasks/HttpSessionCleanupTaskTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/session/tasks/HttpSessionCleanupTaskTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.oauth2.session.tasks;
+
+import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorType;
+import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
+import net.krotscheck.kangaroo.authz.test.ApplicationBuilder;
+import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.test.jersey.DatabaseTest;
+import net.krotscheck.kangaroo.test.rule.TestDataResource;
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.query.Query;
+import org.hibernate.type.Type;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+
+import java.sql.SQLException;
+import java.util.TimerTask;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit test the HTTP Session cleanup task.
+ *
+ * @author Michael Krotscheck
+ */
+public class HttpSessionCleanupTaskTest extends DatabaseTest {
+
+    /**
+     * The application context used for this test suite.
+     */
+    private static ApplicationContext context;
+
+    /**
+     * Preload data into the system.
+     */
+    @ClassRule
+    public static final TestDataResource TEST_DATA_RESOURCE =
+            new TestDataResource(HIBERNATE_RESOURCE) {
+                @Override
+                protected void loadTestData(final Session session) {
+                    context = ApplicationBuilder.newApplication(session)
+                            .client(ClientType.Implicit)
+                            .authenticator(AuthenticatorType.Test)
+                            .user()
+                            .identity()
+                            .build();
+                }
+
+            };
+
+    /**
+     * Assert that the task can be executed with expected results.
+     */
+    @Test
+    public void testGetTask() {
+        HttpSessionCleanupTask task =
+                new HttpSessionCleanupTask(getSessionFactory(), null);
+        TimerTask rTask = task.getTask();
+        Assert.assertSame(task, rTask);
+    }
+
+    /**
+     * Assert that the task can be executed with expected results.
+     */
+    @Test
+    public void testSimpleRun() {
+        // A series of 10 test tokens, 5 of which are expired and 5 of which
+        // are not.
+        ApplicationBuilder b = context.getBuilder();
+        for (int i = 0; i < 10; i++) {
+            b.httpSession(i % 2 == 1);
+        }
+        b.build();
+
+        HttpSessionCleanupTask task =
+                new HttpSessionCleanupTask(getSessionFactory(), null);
+        TimerTask rTask = task.getTask();
+        Query q = getSession()
+                .createQuery("SELECT count(id) from HttpSession");
+
+        long startCount = (long) q.uniqueResult();
+        Assert.assertEquals((long) 10, startCount);
+        rTask.run();
+        long count = (long) q.uniqueResult();
+        Assert.assertEquals((long) 5, count);
+
+        // Run one more time, make sure it doesn't change anything.
+        rTask.run();
+        long secondCount = (long) q.uniqueResult();
+        Assert.assertEquals((long) 5, secondCount);
+    }
+
+    /**
+     * Assert that if the cleanup throws an exception, the resources are
+     * still released.
+     */
+    @Test
+    public void testRunWithError() {
+        SessionFactory mockFactory = Mockito.mock(SessionFactory.class);
+        Session mockSession = Mockito.mock(Session.class);
+        Query mockQuery = Mockito.mock(Query.class);
+        Transaction mockTransaction = Mockito.mock(Transaction.class);
+
+        doReturn(mockQuery)
+                .when(mockQuery)
+                .setParameter(Matchers.anyString(),
+                        Matchers.any(),
+                        Matchers.any(Type.class));
+        doThrow(HibernateException.class)
+                .when(mockQuery)
+                .executeUpdate();
+        doReturn(mockQuery)
+                .when(mockSession)
+                .createQuery(Matchers.anyString());
+        doReturn(mockSession)
+                .when(mockFactory)
+                .openSession();
+        doReturn(mockTransaction)
+                .when(mockSession)
+                .beginTransaction();
+
+        HttpSessionCleanupTask task =
+                new HttpSessionCleanupTask(mockFactory, null);
+        TimerTask rTask = task.getTask();
+        rTask.run();
+
+        verify(mockTransaction, Mockito.times(1)).rollback();
+        verify(mockSession, Mockito.times(1)).close();
+    }
+
+    /**
+     * Assert that if an unexpected error occurs, we still close the session.
+     */
+    @Test(expected = SQLException.class)
+    public void testRunWithUnexpectedError() {
+        SessionFactory mockFactory = Mockito.mock(SessionFactory.class);
+        Session mockSession = Mockito.mock(Session.class);
+        Query mockQuery = Mockito.mock(Query.class);
+        Transaction mockTransaction = Mockito.mock(Transaction.class);
+
+        doReturn(mockQuery)
+                .when(mockQuery)
+                .setParameter(Matchers.anyString(),
+                        Matchers.any(),
+                        Matchers.any(Type.class));
+        doThrow(SQLException.class)
+                .when(mockQuery)
+                .executeUpdate();
+        doReturn(mockQuery)
+                .when(mockSession)
+                .createQuery(Matchers.anyString());
+        doReturn(mockSession)
+                .when(mockFactory)
+                .openSession();
+        doReturn(mockTransaction)
+                .when(mockSession)
+                .beginTransaction();
+
+        HttpSessionCleanupTask task =
+                new HttpSessionCleanupTask(mockFactory, null);
+        TimerTask rTask = task.getTask();
+        rTask.run();
+
+        verify(mockTransaction, Mockito.times(1)).rollback();
+        verify(mockSession, Mockito.times(1)).close();
+    }
+
+    /**
+     * Make sure that if transaction rollback fails, an the session is still
+     * closed.
+     */
+    @Test
+    public void assertSessionClosedOnRollbackFailure() {
+        SessionFactory mockFactory = Mockito.mock(SessionFactory.class);
+        Session mockSession = Mockito.mock(Session.class);
+        Query mockQuery = Mockito.mock(Query.class);
+        Transaction mockTransaction = Mockito.mock(Transaction.class);
+
+        doReturn(mockQuery)
+                .when(mockQuery)
+                .setParameter(Matchers.anyString(),
+                        Matchers.any(),
+                        Matchers.any(Type.class));
+        doReturn(0)
+                .when(mockQuery)
+                .executeUpdate();
+        doReturn(mockQuery)
+                .when(mockSession)
+                .createQuery(Matchers.anyString());
+        doReturn(mockSession)
+                .when(mockFactory)
+                .openSession();
+        doReturn(mockTransaction)
+                .when(mockSession)
+                .beginTransaction();
+
+        HttpSessionCleanupTask task =
+                new HttpSessionCleanupTask(mockFactory, null);
+        TimerTask rTask = task.getTask();
+        rTask.run();
+
+        verify(mockTransaction, Mockito.times(1)).commit();
+        verify(mockSession, Mockito.times(1)).close();
+    }
+
+    /**
+     * Make sure that if session closure fails, we rethrow.
+     */
+    @Test(expected = HibernateException.class)
+    public void assertSessionClosedErrorRethrown() {
+        SessionFactory mockFactory = Mockito.mock(SessionFactory.class);
+        Session mockSession = Mockito.mock(Session.class);
+        Query mockQuery = Mockito.mock(Query.class);
+        Transaction mockTransaction = Mockito.mock(Transaction.class);
+
+        doReturn(mockQuery)
+                .when(mockQuery)
+                .setParameter(Matchers.anyString(),
+                        Matchers.any(),
+                        Matchers.any(Type.class));
+        doReturn(0)
+                .when(mockQuery)
+                .executeUpdate();
+        doReturn(mockQuery)
+                .when(mockSession)
+                .createQuery(Matchers.anyString());
+        doReturn(mockSession)
+                .when(mockFactory)
+                .openSession();
+        doReturn(mockTransaction)
+                .when(mockSession)
+                .beginTransaction();
+        doThrow(HibernateException.class)
+                .when(mockSession)
+                .close();
+
+        HttpSessionCleanupTask task =
+                new HttpSessionCleanupTask(mockFactory, null);
+        TimerTask rTask = task.getTask();
+        rTask.run();
+    }
+
+    /**
+     * Assert that the tick is every 10 minutes.
+     */
+    @Test
+    public void getPeriod() {
+        HttpSessionCleanupTask task =
+                new HttpSessionCleanupTask(getSessionFactory(), null);
+        Assert.assertEquals(10 * 60 * 1000, task.getPeriod());
+    }
+
+    /**
+     * Assert that the delay is zero.
+     */
+    @Test
+    public void getDelay() {
+        HttpSessionCleanupTask task =
+                new HttpSessionCleanupTask(getSessionFactory(), null);
+        // By default, the period should equal the delay. No
+        // immediately-running tasks.
+        Assert.assertEquals(task.getPeriod(), task.getDelay());
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/session/tasks/package-info.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/session/tasks/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Unit tests for periodic session maintenance.
+ *
+ * @author Michael Krotscheck
+ */
+package net.krotscheck.kangaroo.authz.oauth2.session.tasks;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/test/ApplicationBuilder.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/test/ApplicationBuilder.java
@@ -27,6 +27,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.Client;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientRedirect;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientReferrer;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
+import net.krotscheck.kangaroo.authz.common.database.entity.HttpSession;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthTokenType;
 import net.krotscheck.kangaroo.authz.common.database.entity.Role;
@@ -51,7 +52,6 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.TimeZone;
 import java.util.TreeMap;
-
 import java.util.stream.Collectors;
 
 /**
@@ -717,6 +717,21 @@ public final class ApplicationBuilder {
     }
 
     /**
+     * Create a new http session.
+     *
+     * @param expired Whether this session is expired.
+     * @return This builder.
+     */
+    public ApplicationBuilder httpSession(final Boolean expired) {
+
+        context.httpSession = new HttpSession();
+        context.httpSession.setSessionTimeout(expired ? -100 : 100);
+        persist(context.httpSession);
+
+        return this;
+    }
+
+    /**
      * Track the entity for later flushing to the database.
      *
      * @param e The entity to persist.
@@ -765,6 +780,63 @@ public final class ApplicationBuilder {
     public static final class ApplicationContext {
 
         /**
+         * The session used to persist this data.
+         */
+        private final Session session;
+        /**
+         * The HTTP session.
+         */
+        private HttpSession httpSession;
+        /**
+         * The current application context.
+         */
+        private Application application;
+        /**
+         * The most recent created scope.
+         */
+        private ApplicationScope scope;
+        /**
+         * The current application scopes.
+         */
+        private SortedMap<String, ApplicationScope> scopes = new TreeMap<>();
+        /**
+         * An authenticator state.
+         */
+        private AuthenticatorState authenticatorState;
+        /**
+         * The current role context.
+         */
+        private Role role;
+        /**
+         * The current client context.
+         */
+        private Client client;
+        /**
+         * The current authenticator context.
+         */
+        private Authenticator authenticator;
+        /**
+         * The user context.
+         */
+        private User user;
+        /**
+         * The user identity context.
+         */
+        private UserIdentity userIdentity;
+        /**
+         * The oauth token context.
+         */
+        private OAuthToken token;
+        /**
+         * The last redirect created.
+         */
+        private ClientRedirect redirect;
+        /**
+         * The last referrer created.
+         */
+        private ClientReferrer referrer;
+
+        /**
          * Create a new context instance.
          *
          * @param session The session used to persist these entities.
@@ -783,69 +855,13 @@ public final class ApplicationBuilder {
         }
 
         /**
-         * The session used to persist this data.
+         * Get the current http session.
+         *
+         * @return The current session.
          */
-        private final Session session;
-
-        /**
-         * The current application context.
-         */
-        private Application application;
-
-        /**
-         * The most recent created scope.
-         */
-        private ApplicationScope scope;
-
-        /**
-         * The current application scopes.
-         */
-        private SortedMap<String, ApplicationScope> scopes = new TreeMap<>();
-
-        /**
-         * An authenticator state.
-         */
-        private AuthenticatorState authenticatorState;
-
-        /**
-         * The current role context.
-         */
-        private Role role;
-
-        /**
-         * The current client context.
-         */
-        private Client client;
-
-        /**
-         * The current authenticator context.
-         */
-        private Authenticator authenticator;
-
-        /**
-         * The user context.
-         */
-        private User user;
-
-        /**
-         * The user identity context.
-         */
-        private UserIdentity userIdentity;
-
-        /**
-         * The oauth token context.
-         */
-        private OAuthToken token;
-
-        /**
-         * The last redirect created.
-         */
-        private ClientRedirect redirect;
-
-        /**
-         * The last referrer created.
-         */
-        private ClientReferrer referrer;
+        public HttpSession getHttpSession() {
+            return httpSession;
+        }
 
         /**
          * Get the current application.

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,7 @@
     <hibernate-validator.version>5.4.1.Final</hibernate-validator.version>
     <hibernate-search.version>5.8.0.Final</hibernate-search.version>
     <jersey.version>2.26</jersey.version>
+    <grizzly.version>2.4.2</grizzly.version>
     <slf4j.version>1.7.25</slf4j.version>
     <powermock.version>2.0.0-beta.5</powermock.version>
     <jacoco.version>0.7.9</jacoco.version>
@@ -649,6 +650,18 @@
         <groupId>org.slf4j</groupId>
         <artifactId>log4j-over-slf4j</artifactId>
         <version>${slf4j.version}</version>
+      </dependency>
+
+      <!-- Grizzly -->
+      <dependency>
+        <groupId>org.glassfish.grizzly</groupId>
+        <artifactId>grizzly-http-servlet</artifactId>
+        <version>${grizzly.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.grizzly</groupId>
+        <artifactId>grizzly-http-servlet-extras</artifactId>
+        <version>${grizzly.version}</version>
       </dependency>
 
       <!-- Jersey (JAX-RS) -->


### PR DESCRIPTION
This commit replaces - at runtime - the default grizzly session
manager with one that is linked to the injection context. With that in place,
it uses Hibernate/DB as a persistence layer for the HTTP sessions. Additional
changes necessary were:
- Locking the version of grizzly to one that supports the correct servlet api.
- Convenience injectors for the request's HttpSession
- An HttpCleanupTask that cleans out old sessions every 10 minutes.
- The neccessary testing harnesses and components.