### PR TITLE
Changing the session id updates stored timestamps.

### DIFF
--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/session/grizzly/GrizzlySessionManagerTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/session/grizzly/GrizzlySessionManagerTest.java
@@ -174,8 +174,8 @@ public final class GrizzlySessionManagerTest extends DatabaseTest {
         assertNotNull(newSession);
 
         assertEquals(s.getSessionTimeout(), newSession.getSessionTimeout());
-        assertEquals(s.getCreatedDate(), newSession.getCreatedDate());
-        assertEquals(s.getModifiedDate(), newSession.getModifiedDate());
+        assertNotEquals(s.getCreatedDate(), newSession.getCreatedDate());
+        assertNotEquals(s.getModifiedDate(), newSession.getModifiedDate());
     }
 
     /**
@@ -275,6 +275,7 @@ public final class GrizzlySessionManagerTest extends DatabaseTest {
         manager.configureSessionCookie(r, c);
 
         assertEquals("example.com", c.getDomain());
+        assertEquals(1, c.getVersion());
         assertTrue(c.isHttpOnly());
         assertTrue(c.isSecure());
         assertEquals(AuthzServerConfig.SESSION_NAME.getValue(),


### PR DESCRIPTION
Grizzly's underlying session maintenance - when provided only with a
maxage - will use Systen,currentTimeMillis() to set the MaxAge and ExpireDate
times in the cookie. This creates a mismatch with the database implementation,
which maintained the current and modified dates from the previous session,
and thus would cause the session to age out before the cookie that was provided
to the browser.

This patch removes the query that updates the created and modified dates in
the newly created http session record, bringing the cookie age on the server
in line with the cookie age on the client. It also changes the version of the
cookie to "1", to ensure that grizzly will send the MaxAge date, rather than the
Expires on.