### PR TITLE
Implicit flow now manages refresh tokens via the browser session.

### DIFF
--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jersey/ContainerTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jersey/ContainerTest.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.client.Invocation.Builder;
 import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -182,6 +183,23 @@ public abstract class ContainerTest extends KangarooJerseyTest {
      */
     protected final Response followRedirect(final Response original,
                                             final String authHeader) {
+        Cookie c = original.getCookies().get("kangaroo");
+        return this.followRedirect(original, authHeader, c);
+    }
+
+    /**
+     * This is a convenience method which, presuming a response constitutes a
+     * redirect, will follow that redirect and return the subsequent response.
+     *
+     * @param original   The original response, which should constitute a
+     *                   redirect.
+     * @param authHeader An optional authorization header.
+     * @param cookie     An optional cookie to send.
+     * @return The response.
+     */
+    protected final Response followRedirect(final Response original,
+                                            final String authHeader,
+                                            final Cookie cookie) {
         assertTrue(VALID_REDIRECT_CODES
                 .contains(Status.fromStatusCode(original.getStatus())));
 
@@ -194,6 +212,9 @@ public abstract class ContainerTest extends KangarooJerseyTest {
         }
 
         Builder b = target.request();
+        if (cookie != null) {
+            b.cookie(cookie.getName(), cookie.getValue());
+        }
         if (authHeader != null) {
             b.header(HttpHeaders.AUTHORIZATION, authHeader);
         }

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/HttpSession.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/HttpSession.java
@@ -20,11 +20,8 @@ package net.krotscheck.kangaroo.authz.common.database.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import net.krotscheck.kangaroo.common.hibernate.entity.AbstractEntity;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.Basic;
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -47,14 +44,8 @@ public final class HttpSession extends AbstractEntity {
     /**
      * OAuth tokens attached to this session.
      */
-    @OneToMany(
-            fetch = FetchType.LAZY,
-            mappedBy = "httpSession",
-            cascade = {CascadeType.REMOVE, CascadeType.MERGE},
-            orphanRemoval = true
-    )
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "httpSession")
     @JsonIgnore
-    @OnDelete(action = OnDeleteAction.CASCADE)
     private List<OAuthToken> refreshTokens = new ArrayList<>();
 
     /**

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/OAuthToken.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/OAuthToken.java
@@ -106,12 +106,8 @@ public final class OAuthToken extends AbstractAuthzEntity implements Principal {
      * The HTTP session that contains this token, usually only used for
      * refresh tokens.
      */
-    @ManyToOne(
-            fetch = FetchType.LAZY,
-            cascade = {CascadeType.REMOVE, CascadeType.MERGE}
-    )
-    @JoinColumn(name = "httpSession", nullable = true, updatable = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "httpSession")
     @JsonIgnore
     private HttpSession httpSession;
 

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/authorize/AuthCodeHandler.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/authorize/AuthCodeHandler.java
@@ -35,6 +35,7 @@ import org.glassfish.jersey.process.internal.RequestScoped;
 import org.hibernate.Session;
 
 import javax.inject.Inject;
+import javax.servlet.http.HttpSession;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
@@ -85,20 +86,24 @@ public final class AuthCodeHandler implements IAuthorizeHandler {
         return injector.getInstance(IAuthenticator.class, a.getType().name());
     }
 
-
     /**
      * Handle an authorization request using the Auth Code flow.
      *
-     * @param uriInfo  The original request, in case additional data is needed.
-     * @param auth     The authenticator to use to process this request.
-     * @param redirect The redirect (already validated) to which the response
-     *                 should be returned.
-     * @param scopes   The (validated) list of scopes requested by the user.
-     * @param state    The client's requested state ID.
+     * @param uriInfo        The original request, in case additional data
+     *                       is needed.
+     * @param browserSession The browser session, maintained via cookies.
+     * @param auth           The authenticator to use to process this
+     *                       request.
+     * @param redirect       The redirect (already validated) to which
+     *                       the response  should be returned.
+     * @param scopes         The (validated) list of scopes requested by
+     *                       the user.
+     * @param state          The client's requested state ID.
      * @return The response from the handler.
      */
     @Override
     public Response handle(final UriInfo uriInfo,
+                           final HttpSession browserSession,
                            final Authenticator auth,
                            final URI redirect,
                            final SortedMap<String, ApplicationScope> scopes,
@@ -135,12 +140,14 @@ public final class AuthCodeHandler implements IAuthorizeHandler {
      * the previously stored state, this method should return to the client
      * either a valid token, or an appropriate error response.
      *
-     * @param s       The request state previously saved by the client.
-     * @param uriInfo The URI response from the third party IdP.
+     * @param s              The request state previously saved by the client.
+     * @param browserSession The browser session, maintained via cookies.
+     * @param uriInfo        The URI response from the third party IdP.
      * @return A response entity indicating success or failure.
      */
     @Override
     public Response callback(final AuthenticatorState s,
+                             final HttpSession browserSession,
                              final UriInfo uriInfo) {
 
         IAuthenticator a = getAuthenticator(s);

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/authorize/IAuthorizeHandler.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/authorize/IAuthorizeHandler.java
@@ -23,6 +23,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.ApplicationScope;
 import net.krotscheck.kangaroo.authz.common.database.entity.Authenticator;
 import net.krotscheck.kangaroo.authz.common.database.entity.AuthenticatorState;
 
+import javax.servlet.http.HttpSession;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
@@ -39,15 +40,20 @@ public interface IAuthorizeHandler {
     /**
      * Handle a specific authorization grant request.
      *
-     * @param uriInfo  The original request, in case additional data is needed.
-     * @param auth     The authenticator to use to process this request.
-     * @param redirect The redirect (already validated) to which the response
-     *                 should be returned.
-     * @param scopes   The (validated) list of scopes requested by the user.
-     * @param state    The client's requested state ID.
+     * @param uriInfo        The original request, in case additional data
+     *                       is needed.
+     * @param browserSession The browser session, maintained via cookies.
+     * @param auth           The authenticator to use to process this
+     *                       request.
+     * @param redirect       The redirect (already validated) to which
+     *                       the response  should be returned.
+     * @param scopes         The (validated) list of scopes requested by
+     *                       the user.
+     * @param state          The client's requested state ID.
      * @return A response entity with the appropriate response.
      */
     Response handle(UriInfo uriInfo,
+                    HttpSession browserSession,
                     Authenticator auth,
                     URI redirect,
                     SortedMap<String, ApplicationScope> scopes,
@@ -58,11 +64,14 @@ public interface IAuthorizeHandler {
      * the previously stored state, this method should return to the client
      * either a valid token, or an appropriate error response.
      *
-     * @param s       The request state previously saved by the client.
-     * @param uriInfo The URI response from the third party IdP.
+     * @param s              The request state previously saved by the client.
+     * @param browserSession The browser session, maintained via cookies.
+     * @param uriInfo        The URI response from the third party IdP.
      * @return A response entity indicating success or failure.
      */
-    Response callback(AuthenticatorState s, UriInfo uriInfo);
+    Response callback(AuthenticatorState s,
+                      HttpSession browserSession,
+                      UriInfo uriInfo);
 
     /**
      * Provided a stored intermediate authenticator state, attempt to resolve

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/authorize/ImplicitHandler.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/authorize/ImplicitHandler.java
@@ -22,11 +22,14 @@ import net.krotscheck.kangaroo.authz.common.authenticator.IAuthenticator;
 import net.krotscheck.kangaroo.authz.common.database.entity.ApplicationScope;
 import net.krotscheck.kangaroo.authz.common.database.entity.Authenticator;
 import net.krotscheck.kangaroo.authz.common.database.entity.AuthenticatorState;
+import net.krotscheck.kangaroo.authz.common.database.entity.Client;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
+import net.krotscheck.kangaroo.authz.common.database.entity.HttpSession;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthTokenType;
 import net.krotscheck.kangaroo.authz.common.database.entity.UserIdentity;
 import net.krotscheck.kangaroo.authz.common.util.ValidationUtil;
+import net.krotscheck.kangaroo.authz.oauth2.authn.factory.CredentialsFactory.Credentials;
 import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -41,6 +44,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
+import java.math.BigInteger;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -65,17 +69,25 @@ public final class ImplicitHandler implements IAuthorizeHandler {
     private final Session session;
 
     /**
+     * Request credentials.
+     */
+    private final Credentials credentials;
+
+    /**
      * Create a new handler.
      *
-     * @param injector The system injection manager..
-     * @param session  The hibernate session.
+     * @param injector    The system injection manager..
+     * @param session     The hibernate session.
+     * @param credentials The request credentials.
      */
     @Inject
     @SuppressWarnings({"CPD-START"})
     public ImplicitHandler(final InjectionManager injector,
-                           final Session session) {
+                           final Session session,
+                           final Credentials credentials) {
         this.injector = injector;
         this.session = session;
+        this.credentials = credentials;
     }
 
     /**
@@ -98,20 +110,68 @@ public final class ImplicitHandler implements IAuthorizeHandler {
      * domain-specific refresh token read from the session), in which case
      * the user is immediately issued a token.
      *
-     * @param uriInfo  The original request, in case additional data is needed.
-     * @param auth     The authenticator to use to process this request.
-     * @param redirect The redirect (already validated) to which the response
-     *                 should be returned.
-     * @param scopes   The (validated) list of scopes requested by the user.
-     * @param state    The client's requested state ID.
+     * @param uriInfo        The original request, in case additional data
+     *                       is needed.
+     * @param browserSession The browser session, maintained via cookies.
+     * @param auth           The authenticator to use to process this
+     *                       request.
+     * @param redirect       The redirect (already validated) to which
+     *                       the response  should be returned.
+     * @param scopes         The (validated) list of scopes requested by
+     *                       the user.
+     * @param state          The client's requested state ID.
      * @return The response, indicating success or failure.
      */
     @Override
     public Response handle(final UriInfo uriInfo,
+                           final javax.servlet.http.HttpSession browserSession,
                            final Authenticator auth,
                            final URI redirect,
                            final SortedMap<String, ApplicationScope> scopes,
                            final String state) {
+
+        // Pull any refresh tokens that may already exist for this client.
+        List<OAuthToken> refreshTokens = getContextToken(browserSession);
+
+        // If there's only one refresh token, let's try to issue a refresh.
+        if (refreshTokens.size() == 1) {
+            OAuthToken refreshToken = refreshTokens.get(0);
+            return handleRefresh(refreshToken, browserSession, redirect,
+                    scopes, state);
+        }
+
+        // If we have too many refresh tokens, something weird is going on.
+        // Err on the side of caution, delete them all, and fire a brand new
+        // flow.
+        if (refreshTokens.size() > 1) {
+            refreshTokens.forEach(session::delete);
+        }
+
+        // If there's zero refresh tokens, issue a new one.
+        return handleIssue(uriInfo, auth, redirect, scopes, state);
+    }
+
+    /**
+     * This private handler presumes that we are trying to issue a brand new
+     * token, and responds accordingly.
+     *
+     * @param uriInfo  The original request, in case additional data
+     *                 is needed.
+     * @param auth     The authenticator to use to process this
+     *                 request.
+     * @param redirect The redirect (already validated) to which
+     *                 the response  should be returned.
+     * @param scopes   The (validated) list of scopes requested by
+     *                 the user.
+     * @param state    The client's requested state ID.
+     * @return A response indicating the success.
+     */
+    private Response handleIssue(final UriInfo uriInfo,
+                                 final Authenticator auth,
+                                 final URI redirect,
+                                 final SortedMap<String, ApplicationScope>
+                                         scopes,
+                                 final String state) {
 
         // Retrieve the authenticator instance.
         IAuthenticator authImpl = injector.getInstance(
@@ -139,51 +199,131 @@ public final class ImplicitHandler implements IAuthorizeHandler {
     }
 
     /**
+     * This private handler will issue a brand new token, based on an
+     * existing refresh token.
+     *
+     * @param oldRefreshToken The refresh token.
+     * @param browserSession  The browser session id.
+     * @param redirect        The redirect (already validated) to which
+     *                        the response  should be returned.
+     * @param requestedScopes The (validated) list of scopes requested by
+     *                        the user.
+     * @param state           The client's requested state ID.
+     * @return The appropriate response
+     */
+    private Response handleRefresh(final OAuthToken oldRefreshToken,
+                                   final javax.servlet.http.HttpSession
+                                           browserSession,
+                                   final URI redirect,
+                                   final SortedMap<String, ApplicationScope>
+                                           requestedScopes,
+                                   final String state) {
+        String simulatedScopeRequest =
+                String.join(" ", requestedScopes.keySet());
+
+        // Make sure the requested scopes are valid for the refresh token.
+        SortedMap<String, ApplicationScope> issuableScopes =
+                ValidationUtil.revalidateScope(simulatedScopeRequest,
+                        oldRefreshToken.getScopes(),
+                        oldRefreshToken.getIdentity().getUser().getRole());
+
+        // Go ahead and create the tokens.
+        OAuthToken newBearerToken = buildBearerToken(
+                oldRefreshToken.getClient(),
+                oldRefreshToken.getIdentity(),
+                issuableScopes, redirect);
+        OAuthToken newRefreshToken = buildRefreshToken(newBearerToken);
+        HttpSession dbSession = getDbSession(browserSession);
+
+        // Persist all of our changes
+        dbSession.getRefreshTokens().remove(oldRefreshToken);
+        oldRefreshToken.setHttpSession(null);
+        dbSession.getRefreshTokens().add(newRefreshToken);
+        newRefreshToken.setHttpSession(dbSession);
+
+        session.save(newBearerToken);
+        session.save(newRefreshToken);
+        if (oldRefreshToken.getAuthToken() != null) {
+            session.delete(oldRefreshToken.getAuthToken());
+        }
+        session.delete(oldRefreshToken);
+        session.getTransaction().commit();
+
+        return buildRedirectResponse(redirect, state, newBearerToken);
+    }
+
+    /**
      * Handle a callback response from the IdP (Authenticator). Provided with
      * the previously stored state, this method should return to the client
      * either a valid token, or an appropriate error response.
      *
-     * @param s       The request state previously saved by the client.
-     * @param uriInfo The URI response from the third party IdP.
+     * @param s              The request state previously saved by the client.
+     * @param browserSession The browser session, maintained via cookies.
+     * @param uriInfo        The URI response from the third party IdP.
      * @return A response entity indicating success or failure.
      */
     @Override
     public Response callback(final AuthenticatorState s,
+                             final javax.servlet.http.HttpSession
+                                     browserSession,
                              final UriInfo uriInfo) {
+
         IAuthenticator a = getAuthenticator(s);
-        UserIdentity i = a.authenticate(s.getAuthenticator(),
+        UserIdentity identity = a.authenticate(s.getAuthenticator(),
                 uriInfo.getPathParameters());
+        Client client = s.getAuthenticator().getClient();
+        SortedMap<String, ApplicationScope> issuedScopes = ValidationUtil
+                .validateScope(s.getClientScopes(),
+                        identity.getUser().getRole());
 
         // Build the token.
-        OAuthToken t = new OAuthToken();
-        t.setClient(s.getAuthenticator().getClient());
-        t.setIdentity(i);
-        t.setScopes(ValidationUtil
-                .validateScope(s.getClientScopes(), i.getUser().getRole()));
-        t.setTokenType(OAuthTokenType.Bearer);
-        t.setExpiresIn(s.getAuthenticator().getClient()
-                .getAccessTokenExpireIn());
+        OAuthToken accessToken = buildBearerToken(
+                client, identity, issuedScopes, s.getClientRedirect());
+        OAuthToken refreshToken = buildRefreshToken(accessToken);
+        HttpSession dbSession = getDbSession(browserSession);
 
-        // Persist and get an ID.
-        session.save(t);
+        // Persist all of our changes
+        refreshToken.setHttpSession(dbSession);
+
         session.delete(s);
+        session.save(accessToken);
+        session.save(refreshToken);
+        session.getTransaction().commit();
+
+        return buildRedirectResponse(
+                s.getClientRedirect(),
+                s.getClientState(),
+                accessToken);
+    }
+
+    /**
+     * Provided with input parameters, build the redirect response for a
+     * token back to the client.
+     *
+     * @param clientRedirect The client redirect.
+     * @param clientState    The client state.
+     * @param accessToken    An access token.
+     * @return The response with all the necessary parameters.
+     */
+    private Response buildRedirectResponse(final URI clientRedirect,
+                                           final String clientState,
+                                           final OAuthToken accessToken) {
 
         // Build our redirect URL.
-        UriBuilder responseBuilder = UriBuilder.fromUri(s.getClientRedirect());
+        UriBuilder responseBuilder = UriBuilder.fromUri(clientRedirect);
 
         List<BasicNameValuePair> params = new ArrayList<>();
         params.add(new BasicNameValuePair("access_token",
-                IdUtil.toString(t.getId())));
+                IdUtil.toString(accessToken.getId())));
         params.add(new BasicNameValuePair("token_type",
-                t.getTokenType().toString()));
+                accessToken.getTokenType().toString()));
         params.add(new BasicNameValuePair("expires_in",
-                String.valueOf(t.getExpiresIn())));
-        if (!StringUtils.isEmpty(s.getClientState())) {
-            params.add(new BasicNameValuePair("state",
-                    s.getClientState()));
+                String.valueOf(accessToken.getExpiresIn())));
+        if (!StringUtils.isEmpty(clientState)) {
+            params.add(new BasicNameValuePair("state", clientState));
         }
-        if (t.getScopes().size() > 0) {
-            String scopeString = t.getScopes().values()
+        if (accessToken.getScopes().size() > 0) {
+            String scopeString = accessToken.getScopes().values()
                     .stream().map(ApplicationScope::getName)
                     .collect(Collectors.joining(" "));
             params.add(new BasicNameValuePair("scope", scopeString));
@@ -193,6 +333,94 @@ public final class ImplicitHandler implements IAuthorizeHandler {
         return Response.status(Status.FOUND)
                 .location(responseBuilder.build())
                 .build();
+    }
+
+    /**
+     * Build the bearer token.
+     *
+     * @param client       The client.
+     * @param identity     The user identity.
+     * @param issuedScopes The issued scopes.
+     * @param redirect     The client redirect.
+     * @return A constructed, but not persisted, oauth bearer token.
+     */
+    private OAuthToken buildBearerToken(
+            final Client client,
+            final UserIdentity identity,
+            final SortedMap<String, ApplicationScope> issuedScopes,
+            final URI redirect) {
+
+        // Go ahead and create the tokens.
+        OAuthToken bearerToken = new OAuthToken();
+        bearerToken.setClient(client);
+        bearerToken.setTokenType(OAuthTokenType.Bearer);
+        bearerToken.setExpiresIn(client.getAccessTokenExpireIn());
+        bearerToken.setScopes(issuedScopes);
+        bearerToken.setIdentity(identity);
+        bearerToken.setRedirect(redirect);
+
+        return bearerToken;
+    }
+
+    /**
+     * Given a bearer token, build a refresh token.
+     *
+     * @param bearerToken The bearer token to 'refresh'
+     * @return A constructed, but not persisted, oauth refresh token.
+     */
+    private OAuthToken buildRefreshToken(final OAuthToken bearerToken) {
+        Client client = bearerToken.getClient();
+
+        OAuthToken newRefreshToken = new OAuthToken();
+        newRefreshToken.setClient(client);
+        newRefreshToken.setTokenType(OAuthTokenType.Refresh);
+        newRefreshToken.setExpiresIn(client.getRefreshTokenExpireIn());
+        newRefreshToken.setScopes(bearerToken.getScopes());
+        newRefreshToken.setIdentity(bearerToken.getIdentity());
+        newRefreshToken.setAuthToken(bearerToken);
+        newRefreshToken.setRedirect(bearerToken.getRedirect());
+
+        return newRefreshToken;
+    }
+
+    /**
+     * Provided a browser session, return the database entity that matches it.
+     *
+     * @param browserSession The HTTP browser session (from the servlet
+     *                       container)
+     * @return The DB entity.
+     */
+    private HttpSession getDbSession(
+            final javax.servlet.http.HttpSession browserSession) {
+
+        // Get the HTTP session
+        BigInteger sessionId = IdUtil.fromString(browserSession.getId());
+        return session.get(HttpSession.class, sessionId);
+    }
+
+    /**
+     * Retrieve any refresh tokens associated to the current client and
+     * request context.
+     *
+     * @param browserSession The browser session.
+     * @return A list of tokens, which may be empty.
+     */
+    private List<OAuthToken> getContextToken(
+            final javax.servlet.http.HttpSession browserSession) {
+
+        // Get the DB session entity.
+        HttpSession httpSession = getDbSession(browserSession);
+
+        // Get the client ID.
+        BigInteger clientId = credentials.getLogin();
+        Client c = session.get(Client.class, clientId);
+
+        // We have a session and we have a client...
+        return httpSession.getRefreshTokens().stream()
+                .filter(t -> t.getClient().equals(c))
+                .filter(t -> t.getTokenType().equals(OAuthTokenType.Refresh))
+                .filter(t -> !t.isExpired())
+                .collect(Collectors.toList());
     }
 
     /**

--- a/kangaroo-server-authz/src/main/resources/liquibase/db.changelog-authz-1.0.0.yaml
+++ b/kangaroo-server-authz/src/main/resources/liquibase/db.changelog-authz-1.0.0.yaml
@@ -829,7 +829,7 @@ databaseChangeLog:
                   nullable: true
             - column:
                 name: httpSession
-                type: BINARY(64)
+                type: BINARY(16)
                 constraints:
                   nullable: true
             - column:

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/Section420ImplicitGrantTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/Section420ImplicitGrantTest.java
@@ -19,6 +19,9 @@ package net.krotscheck.kangaroo.authz.oauth2.rfc6749;
 
 import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorType;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
+import net.krotscheck.kangaroo.authz.common.database.entity.HttpSession;
+import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
+import net.krotscheck.kangaroo.authz.common.database.entity.OAuthTokenType;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
 import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder.ErrorResponse;
@@ -26,6 +29,7 @@ import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
 import net.krotscheck.kangaroo.test.HttpUtil;
 import net.krotscheck.kangaroo.test.rule.TestDataResource;
 import org.hibernate.Session;
+import org.hibernate.criterion.Restrictions;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -33,15 +37,21 @@ import org.junit.rules.TestRule;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import java.math.BigInteger;
 import java.net.URI;
+import java.util.Date;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * These tests run through the Implicit Grant Flow.
@@ -55,26 +65,32 @@ public final class Section420ImplicitGrantTest
      * The environment context for the regular client.
      */
     private static ApplicationContext context;
+
     /**
      * The environment context for the regular client and two redirects.
      */
     private static ApplicationContext twoRedirectContext;
+
     /**
      * An application with no role.
      */
     private static ApplicationContext noRoleContext;
+
     /**
      * An application with a role, but no scopes on that role.
      */
     private static ApplicationContext roleNoScopeContext;
+
     /**
      * The test context for a bare-bones application.
      */
     private static ApplicationContext bareContext;
+
     /**
      * An application without an authenticator.
      */
     private static ApplicationContext noauthContext;
+
     /**
      * Test data loading for this test.
      */
@@ -133,20 +149,120 @@ public final class Section420ImplicitGrantTest
             };
 
     /**
+     * Test helper, asserts that the session is properly set.
+     *
+     * @param r The response to scan.
+     */
+    private HttpSession assertNewSession(final Response r) {
+        Map<String, NewCookie> cookies = r.getCookies();
+        assertTrue(cookies.containsKey("kangaroo"));
+        NewCookie kangarooCookie = cookies.get("kangaroo");
+
+        BigInteger sessionId = IdUtil.fromString(kangarooCookie.getValue());
+
+        // Read the DB session
+        Session hSession = getSession();
+        hSession.beginTransaction();
+        HttpSession dbSession = hSession.get(HttpSession.class, sessionId);
+        hSession.getTransaction().commit();
+        assertNotNull(dbSession);
+
+        assertTrue(kangarooCookie.isHttpOnly());
+        assertTrue(kangarooCookie.isSecure());
+        // Can't be specific here, since there's a bit of latency in the test.
+        assertTrue(kangarooCookie.getExpiry().compareTo(new Date()) > 0);
+        assertEquals("localhost", kangarooCookie.getDomain());
+
+        return dbSession;
+    }
+
+    /**
+     * Assert that a session has been rotated between two requests.
+     *
+     * @param first  First response.
+     * @param second Second response.
+     */
+    private void assertRotatedSession(final Response first,
+                                      final Response second) {
+        NewCookie firstCookie = first.getCookies().get("kangaroo");
+        NewCookie secondCookie = second.getCookies().get("kangaroo");
+
+        assertEquals(firstCookie.getMaxAge(), secondCookie.getMaxAge());
+        // Can't test this reliably, as we might hit a time bridge.
+        // assertEquals(firstCookie.getExpiry(), secondCookie.getExpiry());
+        assertEquals(firstCookie.getDomain(), secondCookie.getDomain());
+        assertEquals(firstCookie.getName(), secondCookie.getName());
+        assertEquals(firstCookie.getPath(), secondCookie.getPath());
+
+        assertNotEquals(firstCookie.getValue(), secondCookie.getValue());
+
+        // Make sure the first cookie does not exist in the database, and the
+        // second does.
+        BigInteger firstCookieId = IdUtil.fromString(firstCookie.getValue());
+        BigInteger secondCookieId = IdUtil.fromString(secondCookie.getValue());
+        Session hSession = getSession();
+        hSession.clear();
+        hSession.beginTransaction();
+        HttpSession firstDbSession = hSession.get(HttpSession.class,
+                firstCookieId);
+        HttpSession secondDbSession = hSession.get(HttpSession.class,
+                secondCookieId);
+        hSession.getTransaction().commit();
+
+        assertNull(firstDbSession);
+        assertNotNull(secondDbSession);
+    }
+
+    /**
+     * Assert that a session has not been rotated between two requests.
+     *
+     * @param first  First response.
+     */
+    private void assertNoNewSession(final Response first) {
+        assertNull(first.getCookies().get("kangaroo"));
+    }
+
+    /**
+     * Assert that the session has a refresh token associated with it,
+     * assigned to the provided OAuth2 token.
+     *
+     * @param params The query parameters to scan.
+     */
+    private void assertValidSessionRefreshToken(
+            final MultivaluedMap<String, String> params) {
+        String token = params.getFirst("access_token");
+        BigInteger tokenId = IdUtil.fromString(token);
+        OAuthToken bearerToken = getSession().get(OAuthToken.class, tokenId);
+        assertNotNull(bearerToken);
+        assertTrue(bearerToken.getTokenType().equals(OAuthTokenType.Bearer));
+
+        // Get the refresh token.
+        OAuthToken refreshToken =
+                (OAuthToken) getSession()
+                        .createCriteria(OAuthToken.class)
+                        .add(Restrictions.eq("authToken", bearerToken))
+                        .uniqueResult();
+        assertNotNull(refreshToken);
+        assertTrue(refreshToken.getTokenType().equals(OAuthTokenType.Refresh));
+    }
+
+    /**
      * Assert that a simple request works. This request requires the setup of a
      * default authenticator, a single redirect_uri, and a default scope.
      */
     @Test
     public void testAuthorizeSimpleRequest() {
-        Response r = target("/authorize")
+        Response first = target("/authorize")
                 .queryParam("response_type", "token")
                 .queryParam("client_id",
                         IdUtil.toString(context.getClient().getId()))
                 .request()
                 .get();
+        assertNewSession(first);
 
         // Follow the redirect
-        Response second = followRedirect(r);
+        Response second = followRedirect(first);
+        assertRotatedSession(first, second);
 
         // Validate the redirect location
         URI location = second.getLocation();
@@ -158,6 +274,7 @@ public final class Section420ImplicitGrantTest
         MultivaluedMap<String, String> params =
                 HttpUtil.parseQueryParams(location.getFragment());
         assertValidBearerToken(params, true);
+        assertValidSessionRefreshToken(params);
         assertFalse(params.containsKey("scope"));
     }
 
@@ -166,18 +283,19 @@ public final class Section420ImplicitGrantTest
      */
     @Test
     public void testAuthorizeResponseTypeInvalid() {
-        Response r = target("/authorize")
+        Response first = target("/authorize")
                 .queryParam("response_type", "invalid")
                 .queryParam("client_id",
                         IdUtil.toString(context.getClient().getId()))
                 .request()
                 .get();
+        assertNewSession(first);
 
         // Assert various response-specific parameters.
-        Assert.assertEquals(Status.FOUND.getStatusCode(), r.getStatus());
+        Assert.assertEquals(Status.FOUND.getStatusCode(), first.getStatus());
 
         // Validate the redirect location
-        URI location = r.getLocation();
+        URI location = first.getLocation();
         Assert.assertEquals("http", location.getScheme());
         Assert.assertEquals("valid.example.com", location.getHost());
         Assert.assertEquals("/redirect", location.getPath());
@@ -195,19 +313,20 @@ public final class Section420ImplicitGrantTest
      */
     @Test
     public void testAuthorizeClientIdInvalid() {
-        Response r = target("/authorize")
+        Response first = target("/authorize")
                 .queryParam("response_type", "token")
                 .queryParam("client_id", "invalid_client_id")
                 .request()
                 .get();
+        assertNoNewSession(first);
 
         // Assert various response-specific parameters.
-        assertEquals(Status.BAD_REQUEST.getStatusCode(), r.getStatus());
-        assertNull(r.getLocation());
-        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+        assertEquals(Status.BAD_REQUEST.getStatusCode(), first.getStatus());
+        assertNull(first.getLocation());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, first.getMediaType());
 
         // Validate the response parameters received.
-        ErrorResponse error = r.readEntity(ErrorResponse.class);
+        ErrorResponse error = first.readEntity(ErrorResponse.class);
         assertEquals("invalid_client", error.getError());
         assertNotNull(error.getErrorDescription());
     }
@@ -217,16 +336,18 @@ public final class Section420ImplicitGrantTest
      */
     @Test
     public void testAuthorizeScopeSimple() {
-        Response r = target("/authorize")
+        Response first = target("/authorize")
                 .queryParam("response_type", "token")
                 .queryParam("client_id",
                         IdUtil.toString(context.getClient().getId()))
                 .queryParam("scope", "debug")
                 .request()
                 .get();
+        assertNewSession(first);
 
         // Follow the redirect
-        Response second = followRedirect(r);
+        Response second = followRedirect(first);
+        assertNewSession(second);
 
         // Validate the redirect location
         URI location = second.getLocation();
@@ -238,6 +359,7 @@ public final class Section420ImplicitGrantTest
         MultivaluedMap<String, String> params =
                 HttpUtil.parseQueryParams(location.getFragment());
         assertValidBearerToken(params, true);
+        assertValidSessionRefreshToken(params);
         assertEquals("debug", params.getFirst("scope"));
         assertFalse(params.containsKey("state"));
     }
@@ -247,20 +369,20 @@ public final class Section420ImplicitGrantTest
      */
     @Test
     public void testAuthorizeNone() {
-        Response r = target("/authorize")
+        Response first = target("/authorize")
                 .queryParam("response_type", "token")
                 .queryParam("client_id",
-
                         IdUtil.toString(noauthContext.getClient().getId()))
                 .queryParam("scope", "debug")
                 .request()
                 .get();
+        assertNewSession(first);
 
         // Assert various response-specific parameters.
-        assertEquals(Status.FOUND.getStatusCode(), r.getStatus());
+        assertEquals(Status.FOUND.getStatusCode(), first.getStatus());
 
         // Validate the redirect location
-        URI location = r.getLocation();
+        URI location = first.getLocation();
         assertEquals("http", location.getScheme());
         assertEquals("valid.example.com", location.getHost());
         assertEquals("/redirect", location.getPath());
@@ -278,16 +400,18 @@ public final class Section420ImplicitGrantTest
      */
     @Test
     public void testAuthorizeScopeInvalid() {
-        Response r = target("/authorize")
+        Response first = target("/authorize")
                 .queryParam("response_type", "token")
                 .queryParam("client_id",
                         IdUtil.toString(context.getClient().getId()))
                 .queryParam("scope", "invalid")
                 .request()
                 .get();
+        assertNewSession(first);
 
         // Follow the redirect
-        Response second = followRedirect(r);
+        Response second = followRedirect(first);
+        assertRotatedSession(first, second);
 
         // Validate the redirect location
         URI location = second.getLocation();
@@ -299,6 +423,7 @@ public final class Section420ImplicitGrantTest
         MultivaluedMap<String, String> params =
                 HttpUtil.parseQueryParams(location.getFragment());
         assertValidBearerToken(params, true);
+        assertValidSessionRefreshToken(params);
         assertFalse(params.containsKey("scope"));
         assertFalse(params.containsKey("state"));
     }
@@ -310,7 +435,7 @@ public final class Section420ImplicitGrantTest
     public void testAuthorizeStateSimple() {
         String state =
                 IdUtil.toString(IdUtil.next());
-        Response r = target("/authorize")
+        Response first = target("/authorize")
                 .queryParam("response_type", "token")
                 .queryParam("client_id",
                         IdUtil.toString(context.getClient().getId()))
@@ -318,9 +443,11 @@ public final class Section420ImplicitGrantTest
                 .queryParam("state", state)
                 .request()
                 .get();
+        assertNewSession(first);
 
         // Follow the redirect
-        Response second = followRedirect(r);
+        Response second = followRedirect(first);
+        assertRotatedSession(first, second);
 
         // Validate the redirect location
         URI location = second.getLocation();
@@ -332,6 +459,7 @@ public final class Section420ImplicitGrantTest
         MultivaluedMap<String, String> params =
                 HttpUtil.parseQueryParams(location.getFragment());
         assertValidBearerToken(params, true);
+        assertValidSessionRefreshToken(params);
         assertEquals("debug", params.getFirst("scope"));
         assertEquals(state, params.getFirst("state"));
     }
@@ -341,7 +469,7 @@ public final class Section420ImplicitGrantTest
      */
     @Test
     public void testAuthorizeRedirectSimple() {
-        Response r = target("/authorize")
+        Response first = target("/authorize")
                 .queryParam("response_type", "token")
                 .queryParam("scope", "debug")
                 .queryParam("client_id",
@@ -349,9 +477,11 @@ public final class Section420ImplicitGrantTest
                 .queryParam("redirect_uri", "http://valid.example.com/redirect")
                 .request()
                 .get();
+        assertNewSession(first);
 
         // Follow the redirect
-        Response second = followRedirect(r);
+        Response second = followRedirect(first);
+        assertRotatedSession(first, second);
 
         // Validate the redirect location
         URI location = second.getLocation();
@@ -363,6 +493,7 @@ public final class Section420ImplicitGrantTest
         MultivaluedMap<String, String> params =
                 HttpUtil.parseQueryParams(location.getFragment());
         assertValidBearerToken(params, true);
+        assertValidSessionRefreshToken(params);
         assertEquals("debug", params.getFirst("scope"));
         assertFalse(params.containsKey("state"));
     }
@@ -373,7 +504,7 @@ public final class Section420ImplicitGrantTest
     @Test
     public void testAuthorizeRedirectMulti() {
         // Register a new redirect on the current builder.
-        Response r = target("/authorize")
+        Response first = target("/authorize")
                 .queryParam("response_type", "token")
                 .queryParam("client_id",
 
@@ -382,9 +513,11 @@ public final class Section420ImplicitGrantTest
                         "http://other.example.com/redirect")
                 .request()
                 .get();
+        assertNewSession(first);
 
         // Follow the redirect
-        Response second = followRedirect(r);
+        Response second = followRedirect(first);
+        assertRotatedSession(first, second);
 
         // Validate the redirect location
         URI location = second.getLocation();
@@ -396,6 +529,7 @@ public final class Section420ImplicitGrantTest
         MultivaluedMap<String, String> params =
                 HttpUtil.parseQueryParams(location.getFragment());
         assertValidBearerToken(params, true);
+        assertValidSessionRefreshToken(params);
         assertFalse(params.containsKey("scope"));
         assertFalse(params.containsKey("state"));
     }
@@ -406,21 +540,22 @@ public final class Section420ImplicitGrantTest
      */
     @Test
     public void testAuthorizeRedirectNoneRegistered() {
-        Response r = target("/authorize")
+        Response first = target("/authorize")
                 .queryParam("response_type", "token")
                 .queryParam("client_id",
 
                         IdUtil.toString(bareContext.getClient().getId()))
                 .request()
                 .get();
+        assertNewSession(first);
 
         // Assert various response-specific parameters.
-        assertEquals(Status.BAD_REQUEST.getStatusCode(), r.getStatus());
-        assertNull(r.getLocation());
-        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+        assertEquals(Status.BAD_REQUEST.getStatusCode(), first.getStatus());
+        assertNull(first.getLocation());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, first.getMediaType());
 
         // Validate the response parameters received.
-        ErrorResponse error = r.readEntity(ErrorResponse.class);
+        ErrorResponse error = first.readEntity(ErrorResponse.class);
         assertEquals("invalid_request", error.getError());
         assertNotNull(error.getErrorDescription());
     }
@@ -431,7 +566,7 @@ public final class Section420ImplicitGrantTest
      */
     @Test
     public void testAuthorizeRedirectNoneRegisteredWithRequest() {
-        Response r = target("/authorize")
+        Response first = target("/authorize")
                 .queryParam("response_type", "token")
                 .queryParam("client_id",
 
@@ -440,14 +575,15 @@ public final class Section420ImplicitGrantTest
                         "http://redirect.example.com/redirect")
                 .request()
                 .get();
+        assertNewSession(first);
 
         // Assert various response-specific parameters.
-        assertEquals(Status.BAD_REQUEST.getStatusCode(), r.getStatus());
-        assertNull(r.getLocation());
-        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+        assertEquals(Status.BAD_REQUEST.getStatusCode(), first.getStatus());
+        assertNull(first.getLocation());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, first.getMediaType());
 
         // Validate the response parameters received.
-        ErrorResponse error = r.readEntity(ErrorResponse.class);
+        ErrorResponse error = first.readEntity(ErrorResponse.class);
         assertEquals("invalid_request", error.getError());
         assertNotNull(error.getErrorDescription());
     }
@@ -459,21 +595,21 @@ public final class Section420ImplicitGrantTest
      */
     @Test
     public void testAuthorizeRedirectMultiNoneProvided() {
-        Response r = target("/authorize")
+        Response first = target("/authorize")
                 .queryParam("response_type", "token")
                 .queryParam("client_id",
-
                         IdUtil.toString(twoRedirectContext.getClient().getId()))
                 .request()
                 .get();
+        assertNewSession(first);
 
         // Assert various response-specific parameters.
-        assertEquals(Status.BAD_REQUEST.getStatusCode(), r.getStatus());
-        assertNull(r.getLocation());
-        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+        assertEquals(Status.BAD_REQUEST.getStatusCode(), first.getStatus());
+        assertNull(first.getLocation());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, first.getMediaType());
 
         // Validate the response parameters received.
-        ErrorResponse error = r.readEntity(ErrorResponse.class);
+        ErrorResponse error = first.readEntity(ErrorResponse.class);
         assertEquals("invalid_request", error.getError());
         assertNotNull(error.getErrorDescription());
     }
@@ -491,6 +627,7 @@ public final class Section420ImplicitGrantTest
                         IdUtil.toString(context.getClient().getId()))
                 .request()
                 .get();
+        assertNewSession(first);
 
         // We expect this response to head to /authorize/redirect
         assertEquals(Status.FOUND.getStatusCode(), first.getStatus());
@@ -501,12 +638,14 @@ public final class Section420ImplicitGrantTest
 
         // Follow the redirect
         Response second = followRedirect(first);
+        assertRotatedSession(first, second);
         URI secondLocation = second.getLocation();
 
         // Extract the query parameters in the fragment
         MultivaluedMap<String, String> params =
                 HttpUtil.parseQueryParams(secondLocation.getFragment());
         assertValidBearerToken(params, true);
+        assertValidSessionRefreshToken(params);
         assertFalse(params.containsKey("scope"));
         assertFalse(params.containsKey("state"));
     }
@@ -516,7 +655,7 @@ public final class Section420ImplicitGrantTest
      */
     @Test
     public void testAuthorizeRedirectInvalid() {
-        Response r = target("/authorize")
+        Response first = target("/authorize")
                 .queryParam("response_type", "token")
                 .queryParam("client_id",
 
@@ -525,14 +664,15 @@ public final class Section420ImplicitGrantTest
                         "http://invalid.example.com/redirect")
                 .request()
                 .get();
+        assertNewSession(first);
 
         // Assert various response-specific parameters.
-        assertEquals(Status.BAD_REQUEST.getStatusCode(), r.getStatus());
-        assertNull(r.getLocation());
-        assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
+        assertEquals(Status.BAD_REQUEST.getStatusCode(), first.getStatus());
+        assertNull(first.getLocation());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, first.getMediaType());
 
         // Validate the response parameters received.
-        ErrorResponse error = r.readEntity(ErrorResponse.class);
+        ErrorResponse error = first.readEntity(ErrorResponse.class);
         assertEquals("invalid_request", error.getError());
         assertNotNull(error.getErrorDescription());
     }
@@ -551,6 +691,7 @@ public final class Section420ImplicitGrantTest
                         IdUtil.toString(noRoleContext.getClient().getId()))
                 .request()
                 .get();
+        assertNewSession(first);
 
         // We expect this response to head to /authorize/redirect
         assertEquals(Status.FOUND.getStatusCode(), first.getStatus());
@@ -561,6 +702,7 @@ public final class Section420ImplicitGrantTest
 
         // Follow the redirect
         Response second = followRedirect(first);
+        assertNoNewSession(second);
         URI secondLocation = second.getLocation();
 
         // Extract the query parameters in the fragment
@@ -595,6 +737,7 @@ public final class Section420ImplicitGrantTest
                         IdUtil.toString(testContext.getClient().getId()))
                 .request()
                 .get();
+        assertNewSession(first);
 
         // We expect this response to head to /authorize/redirect
         assertEquals(Status.FOUND.getStatusCode(), first.getStatus());
@@ -605,6 +748,7 @@ public final class Section420ImplicitGrantTest
 
         // Follow the redirect
         Response second = followRedirect(first);
+        assertNoNewSession(second);
         URI secondLocation = second.getLocation();
 
         // Extract the query parameters in the fragment
@@ -628,6 +772,7 @@ public final class Section420ImplicitGrantTest
                         IdUtil.toString(roleNoScopeContext.getClient().getId()))
                 .request()
                 .get();
+        assertNewSession(first);
 
         // We expect this response to head to /authorize/redirect
         assertEquals(Status.FOUND.getStatusCode(), first.getStatus());
@@ -638,13 +783,434 @@ public final class Section420ImplicitGrantTest
 
         // Follow the redirect
         Response second = followRedirect(first);
+        assertRotatedSession(first, second);
         URI secondLocation = second.getLocation();
 
         // Extract the query parameters in the fragment
         MultivaluedMap<String, String> params =
                 HttpUtil.parseQueryParams(secondLocation.getFragment());
         assertValidBearerToken(params, true);
+        assertValidSessionRefreshToken(params);
         assertFalse(params.containsKey("scope"));
         assertFalse(params.containsKey("state"));
+    }
+
+    /**
+     * Assert that a simple refresh request works. This presumes a refresh
+     * token that is attached to an existing http session.
+     */
+    @Test
+    public void testRefreshSimpleRequest() {
+        ApplicationContext refreshContext = context.getBuilder()
+                .user()
+                .identity()
+                .bearerToken()
+                .refreshToken()
+                .httpSession(false)
+                .build();
+
+        Response first = target("/authorize")
+                .queryParam("response_type", "token")
+                .queryParam("client_id",
+                        IdUtil.toString(refreshContext.getClient().getId()))
+                .request()
+                .cookie("kangaroo", refreshContext.getHttpSessionId())
+                .get();
+        assertNewSession(first);
+        assertNull(getSession().get(HttpSession.class,
+                refreshContext.getHttpSession().getId()));
+
+        // Validate the redirect location
+        URI location = first.getLocation();
+        assertEquals("http", location.getScheme());
+        assertEquals("valid.example.com", location.getHost());
+        assertEquals("/redirect", location.getPath());
+
+        // Extract the query parameters in the fragment
+        MultivaluedMap<String, String> params =
+                HttpUtil.parseQueryParams(location.getFragment());
+        assertValidBearerToken(params, true);
+        assertValidSessionRefreshToken(params);
+        assertFalse(params.containsKey("scope"));
+    }
+
+    /**
+     * Assert that a refresh request, using a refresh token whose access
+     * token has already been cleaned up, can issue a new token.
+     */
+    @Test
+    public void testRefreshSimpleRequestWithoutBearer() {
+        ApplicationContext refreshContext = context.getBuilder()
+                .user()
+                .identity()
+                .refreshToken()
+                .httpSession(false)
+                .build();
+
+        Response first = target("/authorize")
+                .queryParam("response_type", "token")
+                .queryParam("client_id",
+                        IdUtil.toString(refreshContext.getClient().getId()))
+                .request()
+                .cookie("kangaroo", refreshContext.getHttpSessionId())
+                .get();
+        assertNewSession(first);
+        assertNull(getSession().get(HttpSession.class,
+                refreshContext.getHttpSession().getId()));
+
+        // Validate the redirect location
+        URI location = first.getLocation();
+        assertEquals("http", location.getScheme());
+        assertEquals("valid.example.com", location.getHost());
+        assertEquals("/redirect", location.getPath());
+
+        // Extract the query parameters in the fragment
+        MultivaluedMap<String, String> params =
+                HttpUtil.parseQueryParams(location.getFragment());
+        assertValidBearerToken(params, true);
+        assertValidSessionRefreshToken(params);
+        assertFalse(params.containsKey("scope"));
+    }
+
+    /**
+     * Assert that a request with an invalid response type errors.
+     */
+    @Test
+    public void testRefreshResponseTypeInvalid() {
+        ApplicationContext refreshContext = context.getBuilder()
+                .user()
+                .identity()
+                .bearerToken()
+                .refreshToken()
+                .httpSession(false)
+                .build();
+
+        Response first = target("/authorize")
+                .queryParam("response_type", "invalid")
+                .queryParam("client_id",
+                        IdUtil.toString(refreshContext.getClient().getId()))
+                .request()
+                .cookie("kangaroo", refreshContext.getHttpSessionId())
+                .get();
+        assertNotNull(getSession().get(HttpSession.class,
+                refreshContext.getHttpSession().getId()));
+
+        // Assert various response-specific parameters.
+        Assert.assertEquals(Status.FOUND.getStatusCode(), first.getStatus());
+
+        // Validate the redirect location
+        URI location = first.getLocation();
+        Assert.assertEquals("http", location.getScheme());
+        Assert.assertEquals("valid.example.com", location.getHost());
+        Assert.assertEquals("/redirect", location.getPath());
+
+        // Validate the query parameters received.
+        MultivaluedMap<String, String> params =
+                HttpUtil.parseQueryParams(location.getFragment());
+        assertTrue(params.containsKey("error"));
+        assertEquals("unsupported_response_type", params.getFirst("error"));
+        assertTrue(params.containsKey("error_description"));
+    }
+
+    /**
+     * Assert that a request with an invalid client id errors.
+     */
+    @Test
+    public void testRefreshClientIdInvalid() {
+        ApplicationContext refreshContext = context.getBuilder()
+                .user()
+                .identity()
+                .bearerToken()
+                .refreshToken()
+                .httpSession(false)
+                .build();
+
+        Response first = target("/authorize")
+                .queryParam("response_type", "token")
+                .queryParam("client_id", "invalid_client_id")
+                .request()
+                .cookie("kangaroo", refreshContext.getHttpSessionId())
+                .get();
+
+        // Assert various response-specific parameters.
+        assertEquals(Status.BAD_REQUEST.getStatusCode(), first.getStatus());
+        assertNull(first.getLocation());
+        assertEquals(MediaType.APPLICATION_JSON_TYPE, first.getMediaType());
+
+        // Validate the response parameters received.
+        ErrorResponse error = first.readEntity(ErrorResponse.class);
+        assertEquals("invalid_client", error.getError());
+        assertNotNull(error.getErrorDescription());
+    }
+
+    /**
+     * Assert that a request with an explicit scope works.
+     */
+    @Test
+    public void testRefreshScopeSimple() {
+        ApplicationContext refreshContext = context.getBuilder()
+                .user()
+                .identity()
+                .bearerToken("debug")
+                .refreshToken()
+                .httpSession(false)
+                .build();
+
+        Response first = target("/authorize")
+                .queryParam("response_type", "token")
+                .queryParam("client_id",
+                        IdUtil.toString(refreshContext.getClient().getId()))
+                .queryParam("scope", "debug")
+                .request()
+                .cookie("kangaroo", refreshContext.getHttpSessionId())
+                .get();
+        assertNewSession(first);
+
+        // Validate the redirect location
+        URI location = first.getLocation();
+        assertEquals("http", location.getScheme());
+        assertEquals("valid.example.com", location.getHost());
+        assertEquals("/redirect", location.getPath());
+
+        // Extract the query parameters in the fragment
+        MultivaluedMap<String, String> params =
+                HttpUtil.parseQueryParams(location.getFragment());
+        assertValidBearerToken(params, true);
+        assertValidSessionRefreshToken(params);
+        assertEquals("debug", params.getFirst("scope"));
+        assertFalse(params.containsKey("state"));
+    }
+
+    /**
+     * Assert that a request with an invalid scope does not grant said scope.
+     */
+    @Test
+    public void testRefreshScopeInvalid() {
+        ApplicationContext refreshContext = context.getBuilder()
+                .user()
+                .identity()
+                .bearerToken("debug")
+                .refreshToken()
+                .httpSession(false)
+                .build();
+
+        Response first = target("/authorize")
+                .queryParam("response_type", "token")
+                .queryParam("client_id",
+                        IdUtil.toString(refreshContext.getClient().getId()))
+                .queryParam("scope", "invalid")
+                .request()
+                .cookie("kangaroo", refreshContext.getHttpSessionId())
+                .get();
+
+        // Validate the redirect location
+        URI location = first.getLocation();
+        assertEquals("http", location.getScheme());
+        assertEquals("valid.example.com", location.getHost());
+        assertEquals("/redirect", location.getPath());
+
+        // Extract the query parameters in the fragment
+        MultivaluedMap<String, String> params =
+                HttpUtil.parseQueryParams(location.getFragment());
+        assertValidBearerToken(params, true);
+        assertValidSessionRefreshToken(params);
+        assertFalse(params.containsKey("scope"));
+        assertFalse(params.containsKey("state"));
+    }
+
+    /**
+     * Assert that a request with a state works.
+     */
+    @Test
+    public void testRefreshStateSimple() {
+        ApplicationContext refreshContext = context.getBuilder()
+                .user()
+                .identity()
+                .bearerToken("debug")
+                .refreshToken()
+                .httpSession(false)
+                .build();
+
+        String state = IdUtil.toString(IdUtil.next());
+        Response first = target("/authorize")
+                .queryParam("response_type", "token")
+                .queryParam("client_id",
+                        IdUtil.toString(refreshContext.getClient().getId()))
+                .queryParam("scope", "debug")
+                .queryParam("state", state)
+                .request()
+                .cookie("kangaroo", refreshContext.getHttpSessionId())
+                .get();
+        assertNewSession(first);
+
+        // Validate the redirect location
+        URI location = first.getLocation();
+        assertEquals("http", location.getScheme());
+        assertEquals("valid.example.com", location.getHost());
+        assertEquals("/redirect", location.getPath());
+
+        // Extract the query parameters in the fragment
+        MultivaluedMap<String, String> params =
+                HttpUtil.parseQueryParams(location.getFragment());
+        assertValidBearerToken(params, true);
+        assertValidSessionRefreshToken(params);
+        assertEquals("debug", params.getFirst("scope"));
+        assertEquals(state, params.getFirst("state"));
+    }
+
+    /**
+     * Assert that a request with a redirect works.
+     */
+    @Test
+    public void testRefreshRedirectSimple() {
+        ApplicationContext refreshContext = context.getBuilder()
+                .user()
+                .identity()
+                .token(OAuthTokenType.Bearer, false, "debug",
+                        "http://valid.example.com/redirect", null)
+                .refreshToken()
+                .httpSession(false)
+                .build();
+
+        Response first = target("/authorize")
+                .queryParam("response_type", "token")
+                .queryParam("scope", "debug")
+                .queryParam("client_id",
+                        IdUtil.toString(refreshContext.getClient().getId()))
+                .queryParam("redirect_uri", "http://valid.example.com/redirect")
+                .request()
+                .cookie("kangaroo", refreshContext.getHttpSessionId())
+                .get();
+        assertNewSession(first);
+
+        // Validate the redirect location
+        URI location = first.getLocation();
+        assertEquals("http", location.getScheme());
+        assertEquals("valid.example.com", location.getHost());
+        assertEquals("/redirect", location.getPath());
+
+        // Extract the query parameters in the fragment
+        MultivaluedMap<String, String> params =
+                HttpUtil.parseQueryParams(location.getFragment());
+        assertValidBearerToken(params, true);
+        assertValidSessionRefreshToken(params);
+        assertEquals("debug", params.getFirst("scope"));
+        assertFalse(params.containsKey("state"));
+    }
+
+    /**
+     * Assert that a refresh request, with a session that is holding a
+     * refresh token for a different client, kicks off a normal auth flow.
+     */
+    @Test
+    public void testRefreshClientIsolation() {
+        ApplicationContext refreshContext = context.getBuilder()
+                .user()
+                .identity()
+                .bearerToken()
+                .refreshToken()
+                .httpSession(false)
+                .build();
+
+        Response first = target("/authorize")
+                .queryParam("response_type", "token")
+                .queryParam("client_id",
+                        IdUtil.toString(roleNoScopeContext.getClient().getId()))
+                .request()
+                .cookie("kangaroo", refreshContext.getHttpSessionId())
+                .get();
+        assertNewSession(first);
+
+        // Follow the redirect
+        Response second = followRedirect(first);
+        assertRotatedSession(first, second);
+
+        // Validate the redirect location
+        URI location = second.getLocation();
+        assertEquals("http", location.getScheme());
+        assertEquals("valid.example.com", location.getHost());
+        assertEquals("/redirect", location.getPath());
+
+        // Extract the query parameters in the fragment
+        MultivaluedMap<String, String> params =
+                HttpUtil.parseQueryParams(location.getFragment());
+        assertValidBearerToken(params, true);
+        assertValidSessionRefreshToken(params);
+        assertFalse(params.containsKey("scope"));
+    }
+
+    /**
+     * Assert that a refresh request, with a session that is holding an
+     * expired token, kicks off a normal auth flow.
+     */
+    @Test
+    public void testRefreshWithExpiredToken() {
+        ApplicationContext refreshContext = context.getBuilder()
+                .user()
+                .identity()
+                .bearerToken("debug")
+                .build();
+        OAuthToken original = refreshContext.getToken();
+        refreshContext = refreshContext.getBuilder()
+                .token(OAuthTokenType.Refresh, true, null, null, original)
+                .httpSession(false)
+                .build();
+
+        Response first = target("/authorize")
+                .queryParam("response_type", "token")
+                .queryParam("client_id",
+                        IdUtil.toString(refreshContext.getClient().getId()))
+                .queryParam("scope", "debug")
+                .request()
+                .cookie("kangaroo", refreshContext.getHttpSessionId())
+                .get();
+
+        // Validate the redirect location
+        URI location = first.getLocation();
+        assertEquals("http", location.getScheme());
+        assertEquals("localhost", location.getHost());
+        assertEquals("/authorize/callback", location.getPath());
+    }
+
+    /**
+     * Assert that a refresh request, with a session which for some reason
+     * has two valid refresh tokens attached, deletes all tokens and kicks
+     * off a new auth flow.
+     */
+    @Test
+    public void testRefreshWithTooManyTokens() {
+        ApplicationBuilder refreshBuilder = context.getBuilder()
+                .user()
+                .identity()
+                .bearerToken("debug")
+                .refreshToken()
+                .httpSession(false)
+                .refreshToken();
+
+        // Make modifications to the latter refreshToken.
+        refreshBuilder.getContext().getToken().setHttpSession(
+                refreshBuilder.getContext().getHttpSession());
+        ApplicationContext refreshContext = refreshBuilder.build();
+
+        Response first = target("/authorize")
+                .queryParam("response_type", "token")
+                .queryParam("client_id",
+                        IdUtil.toString(refreshContext.getClient().getId()))
+                .queryParam("scope", "debug")
+                .request()
+                .cookie("kangaroo", refreshContext.getHttpSessionId())
+                .get();
+
+        // Validate the redirect location
+        URI location = first.getLocation();
+        assertEquals("http", location.getScheme());
+        assertEquals("localhost", location.getHost());
+        assertEquals("/authorize/callback", location.getPath());
+
+        // Make sure the refresh tokens are gone.
+        Session s = getSession();
+        s.beginTransaction();
+        assertNull(s.get(OAuthToken.class, refreshContext.getToken().getId()));
+        s.getTransaction().commit();
     }
 }


### PR DESCRIPTION
In order to provide a seamless authn flow for long-lasting implicit
flow sessions (while still permitting short-lived tokens), the
/authorize endpoint now maintains a session cookie used as a
key into a list of refresh tokens. If a user asks for a new token
using the implicit flow, and a valid refresh token is attached to
the browser session (and they both are valid) for the requested client,
the resulting redirect will return immediately to the provided redirect
endpoint with a new token.

If a refresh token is _not_ found, the 302 will still point to the
endpoint of the IdP.