### PR TITLE
HttpClient Feature

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/httpClient/HttpClientFactory.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/httpClient/HttpClientFactory.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.httpClient;
+
+import org.glassfish.jersey.client.JerseyClientBuilder;
+import org.glassfish.jersey.internal.inject.AbstractBinder;
+import org.glassfish.jersey.internal.inject.DisposableSupplier;
+import org.glassfish.jersey.process.internal.RequestScoped;
+
+import javax.inject.Inject;
+import javax.ws.rs.client.Client;
+
+/**
+ * This Jersey2 feature permits the creation and injection of a common HTTP
+ * Client instance that may be used to make outgoing api requests. These
+ * clients are generated on a per-request basis - only the factory is
+ * considered a singleton - in order to ensure that every HTTP request is
+ * closed.
+ *
+ * @author Michael Krotscheck
+ */
+public final class HttpClientFactory implements DisposableSupplier<Client> {
+
+    /**
+     * The Jersey client builder.
+     */
+    private final JerseyClientBuilder builder;
+
+    /**
+     * Create a jersey client builder.
+     *
+     * @param builder The client builder.
+     */
+    @Inject
+    public HttpClientFactory(final JerseyClientBuilder builder) {
+        this.builder = builder;
+    }
+
+    /**
+     * Create a new client instance.
+     *
+     * @return The created instance.
+     */
+    @Override
+    public Client get() {
+        return builder.build();
+    }
+
+    /**
+     * Ensure that all outstanding requests created by the client are closed.
+     *
+     * @param instance The client instance to dispose of.
+     */
+    @Override
+    public void dispose(final Client instance) {
+        instance.close();
+    }
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bindFactory(HttpClientFactory.class)
+                    .to(Client.class)
+                    .in(RequestScoped.class);
+        }
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/httpClient/HttpClientFeature.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/httpClient/HttpClientFeature.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.httpClient;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+/**
+ * This Jersey2 feature permits the creation and injection of a common HTTP
+ * Client instance that may be used to make outgoing api requests.
+ *
+ * @author Michael Krotscheck
+ */
+public final class HttpClientFeature implements Feature {
+
+    /**
+     * Register all necessary components for the HTTP client feature.
+     *
+     * @param context The application feature context.
+     * @return True.
+     */
+    @Override
+    public boolean configure(final FeatureContext context) {
+
+        // The client builder...
+        context.register(new JerseyClientBuilderFactory.Binder());
+
+        // And the per-request generated client.
+        context.register(new HttpClientFactory.Binder());
+
+        return true;
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/httpClient/JerseyClientBuilderFactory.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/httpClient/JerseyClientBuilderFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.httpClient;
+
+import net.krotscheck.kangaroo.common.jackson.JacksonFeature;
+import net.krotscheck.kangaroo.common.security.SecurityFeature;
+import org.glassfish.jersey.client.JerseyClientBuilder;
+import org.glassfish.jersey.internal.inject.AbstractBinder;
+
+import javax.inject.Singleton;
+import java.util.function.Supplier;
+
+/**
+ * This factory provides a singleton JerseyClient builder that is
+ * preconfigured with all necessary entities, parsers, and keystores.
+ *
+ * @author Michael Krotscheck
+ */
+public final class JerseyClientBuilderFactory
+        implements Supplier<JerseyClientBuilder> {
+
+    /**
+     * Create the application's Jersey Client builder.
+     *
+     * @return Our configured client builder.
+     */
+    @Override
+    public JerseyClientBuilder get() {
+        JerseyClientBuilder newBuilder = new JerseyClientBuilder();
+        newBuilder.register(JacksonFeature.class);
+        newBuilder.register(SecurityFeature.class);
+
+        return newBuilder;
+    }
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bindFactory(JerseyClientBuilderFactory.class)
+                    .to(JerseyClientBuilder.class)
+                    .in(Singleton.class);
+        }
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/httpClient/package-info.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/httpClient/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * A common HTTP Client that issues requests.
+ *
+ * @author Michael Krotscheck
+ */
+package net.krotscheck.kangaroo.common.httpClient;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/httpClient/HttpClientFactoryTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/httpClient/HttpClientFactoryTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.httpClient;
+
+import org.junit.Test;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for the HTTP Client test.
+ *
+ * @author Michael Krotscheck
+ */
+public class HttpClientFactoryTest {
+
+    /**
+     * Assert that the client builder can be created.
+     */
+    @Test
+    public void assertCanCreateClient() {
+        JerseyClientBuilderFactory builder = new JerseyClientBuilderFactory();
+        HttpClientFactory factory = new HttpClientFactory(builder.get());
+        assertNotNull(factory.get());
+    }
+
+    /**
+     * Assert that the client builder can be created.
+     */
+    @Test
+    public void assertCanDisposeClient() {
+        Client testClient = mock(Client.class);
+        JerseyClientBuilderFactory builder = new JerseyClientBuilderFactory();
+        HttpClientFactory factory = new HttpClientFactory(builder.get());
+        factory.dispose(testClient);
+        verify(testClient, times(1)).close();
+    }
+
+    /**
+     * Assert that the client builder can be created.
+     */
+    @Test
+    public void assertCanUseClient() {
+        JerseyClientBuilderFactory builder = new JerseyClientBuilderFactory();
+        HttpClientFactory factory = new HttpClientFactory(builder.get());
+        Client client = factory.get();
+
+        Response r = client.target("https://www.example.com/")
+                .request()
+                .get();
+
+        assertEquals(200, r.getStatus());
+
+        factory.dispose(client);
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/httpClient/HttpClientFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/httpClient/HttpClientFeatureTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.httpClient;
+
+import net.krotscheck.kangaroo.test.jersey.ContainerTest;
+import org.apache.http.HttpStatus;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * Test that the client feature works.
+ *
+ * @author Michael Krotscheck
+ */
+public class HttpClientFeatureTest extends ContainerTest {
+
+    /**
+     * Create an application.
+     *
+     * @return The application to test.
+     */
+    @Override
+    protected ResourceConfig createApplication() {
+        ResourceConfig a = new ResourceConfig();
+        a.register(HttpClientFeature.class);
+        a.register(MockService.class);
+        return a;
+    }
+
+    /**
+     * Quick check to make sure that the code inside the service executes
+     * correctly.
+     */
+    @Test
+    public void testFeature() {
+        Response response = target("/").request().get();
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatus());
+    }
+
+    /**
+     * A simple endpoint that returns the list of authenticators registered.
+     *
+     * @author Michael Krotscheck
+     */
+    @Path("/")
+    public static final class MockService {
+
+        /**
+         * The injected component.
+         */
+        private Client client;
+
+        /**
+         * Create a new instance of the status service.
+         *
+         * @param client Injected HTTP Client.
+         */
+        @Inject
+        public MockService(final Client client) {
+            this.client = client;
+        }
+
+        /**
+         * Test the service.
+         *
+         * @return HTTP Response object, OK if the test passes.
+         */
+        @GET
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response test() {
+            return client.target("https://www.example.com/")
+                    .request()
+                    .get();
+        }
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/httpClient/JerseyClientBuilderFactoryTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/httpClient/JerseyClientBuilderFactoryTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.httpClient;
+
+import org.glassfish.jersey.internal.inject.InjectionManager;
+import org.glassfish.jersey.internal.inject.Injections;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertSame;
+
+/**
+ * Unit tests for the client builder factory.
+ *
+ * @author Michael Krotscheck
+ */
+public class JerseyClientBuilderFactoryTest {
+
+    /**
+     * Assert that the client builder can be created.
+     */
+    @Test
+    public void assertCanCreateFactory() {
+        JerseyClientBuilderFactory factory = new JerseyClientBuilderFactory();
+        assertNotNull(factory.get());
+    }
+
+    /**
+     * Assert that injection works.
+     */
+    @Test
+    public void testInjection() {
+        InjectionManager injector = Injections.createInjectionManager();
+        injector.register(new JerseyClientBuilderFactory.Binder());
+        injector.completeRegistration();
+
+        JerseyClientBuilderFactory factory1 =
+                injector.getInstance(JerseyClientBuilderFactory.class);
+        JerseyClientBuilderFactory factory2 =
+                injector.getInstance(JerseyClientBuilderFactory.class);
+
+        assertSame(factory1, factory2);
+        injector.shutdown();
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/httpClient/package-info.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/httpClient/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Unit tests for the HTTP Client injector.
+ */
+package net.krotscheck.kangaroo.common.httpClient;

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/AdminV1API.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/AdminV1API.java
@@ -37,6 +37,7 @@ import net.krotscheck.kangaroo.authz.common.cors.AuthzCORSFeature;
 import net.krotscheck.kangaroo.authz.common.database.DatabaseFeature;
 import net.krotscheck.kangaroo.common.config.ConfigurationFeature;
 import net.krotscheck.kangaroo.common.exception.ExceptionFeature;
+import net.krotscheck.kangaroo.common.httpClient.HttpClientFeature;
 import net.krotscheck.kangaroo.common.jackson.JacksonFeature;
 import net.krotscheck.kangaroo.common.logging.LoggingFeature;
 import net.krotscheck.kangaroo.common.security.SecurityFeature;
@@ -73,6 +74,7 @@ public final class AdminV1API extends ResourceConfig {
         register(TimedTasksFeature.class);       // Timed tasks service.
         register(AuthenticatorFeature.class);    // OAuth2 Authenticators
         register(AuthzCORSFeature.class);        // CORS feature.
+        register(HttpClientFeature.class);       // Make Http requests.
 
         // Internal components
         register(new ServletConfigFactory.Binder());

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/OAuthAPI.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/OAuthAPI.java
@@ -34,6 +34,7 @@ import net.krotscheck.kangaroo.authz.oauth2.session.SessionFeature;
 import net.krotscheck.kangaroo.authz.oauth2.tasks.TokenCleanupTask;
 import net.krotscheck.kangaroo.common.config.ConfigurationFeature;
 import net.krotscheck.kangaroo.common.exception.ExceptionFeature;
+import net.krotscheck.kangaroo.common.httpClient.HttpClientFeature;
 import net.krotscheck.kangaroo.common.jackson.JacksonFeature;
 import net.krotscheck.kangaroo.common.logging.LoggingFeature;
 import net.krotscheck.kangaroo.common.security.SecurityFeature;
@@ -68,6 +69,7 @@ public class OAuthAPI extends ResourceConfig {
         register(TimedTasksFeature.class);       // Timed tasks service.
         register(AuthenticatorFeature.class);    // OAuth2 Authenticators
         register(AuthzCORSFeature.class);        // CORS feature.
+        register(HttpClientFeature.class);       // Make Http requests.
 
         // Authorization context
         register(OAuthServerAuthnFeature.class);


### PR DESCRIPTION
This feature allows the per-request injection of a jersey/jax-rs Http client
instance. It can be used to communicate with third party services, such as
IdP's.