### PR TITLE
Add validation step to authenticator

### DIFF
--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AuthenticatorService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AuthenticatorService.java
@@ -22,6 +22,7 @@ package net.krotscheck.kangaroo.authz.admin.v1.resource;
 import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.admin.v1.auth.ScopesAllowed;
 import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorType;
+import net.krotscheck.kangaroo.authz.common.authenticator.IAuthenticator;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.Authenticator;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;
@@ -268,6 +269,13 @@ public final class AuthenticatorService extends AbstractService {
             }
         }
 
+        // Assert that the configuration values are correct for this
+        // authenticator type.
+        IAuthenticator handler = getInjector()
+                .getInstance(IAuthenticator.class,
+                        authenticator.getType().toString());
+        handler.validate(authenticator);
+
         // Save it all.
         Session s = getSession();
         s.save(authenticator);
@@ -314,6 +322,13 @@ public final class AuthenticatorService extends AbstractService {
         if (authenticator.getType() == null) {
             throw new BadRequestException();
         }
+
+        // Assert that the configuration values are correct for this
+        // authenticator type.
+        IAuthenticator handler = getInjector()
+                .getInstance(IAuthenticator.class,
+                        authenticator.getType().toString());
+        handler.validate(authenticator);
 
         // Transfer all the values we're allowed to edit.
         current.setType(authenticator.getType());

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/IAuthenticator.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/IAuthenticator.java
@@ -18,12 +18,15 @@
 
 package net.krotscheck.kangaroo.authz.common.authenticator;
 
+import net.krotscheck.kangaroo.authz.common.authenticator.exception.MisconfiguredAuthenticatorException;
 import net.krotscheck.kangaroo.authz.common.database.entity.Authenticator;
 import net.krotscheck.kangaroo.authz.common.database.entity.UserIdentity;
+import net.krotscheck.kangaroo.common.exception.KangarooException;
 
-import java.net.URI;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
+import java.net.URI;
+import java.util.Map;
 
 /**
  * This interface describes the methods used during user authentication,
@@ -45,6 +48,27 @@ public interface IAuthenticator {
      */
     Response delegate(Authenticator configuration,
                       URI callback);
+
+    /**
+     * Validate that a particular authentication configuration is valid for
+     * this IdP.
+     *
+     * @param authenticator The authenticator configuration.
+     * @throws KangarooException Thrown if the internal parameters
+     *                           are invalid.
+     */
+    default void validate(Authenticator authenticator)
+            throws KangarooException {
+
+        // If we have any configuration values, throw an exception.
+        Map<String, String> config = authenticator.getConfiguration();
+        if (config == null) {
+            return;
+        }
+        if (config.size() > 0) {
+            throw new MisconfiguredAuthenticatorException();
+        }
+    }
 
     /**
      * Authenticate and/or create a user identity for a specific client, given

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/exception/MisconfiguredAuthenticatorException.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/exception/MisconfiguredAuthenticatorException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.common.authenticator.exception;
+
+import net.krotscheck.kangaroo.common.exception.KangarooException;
+
+import javax.ws.rs.core.Response.Status;
+
+/**
+ * Error thrown when an authenticator is not properly configured. It makes
+ * use of the 501 HTTP status code, indicating that use of this authenticator
+ * is not properly "implemented" (e.g. configured).
+ *
+ * @author Michael Krotscheck
+ */
+public class MisconfiguredAuthenticatorException extends KangarooException {
+
+    /**
+     * The error code for this exception.
+     */
+    public static final ErrorCode CODE = new ErrorCode(
+            Status.BAD_REQUEST,
+            "misconfigured",
+            "This service is not properly configured."
+    );
+
+    /**
+     * Create a new exception with the specified error code.
+     */
+    public MisconfiguredAuthenticatorException() {
+        super(CODE);
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/exception/package-info.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/exception/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Exceptions common to our various authenticators.
+ */
+package net.krotscheck.kangaroo.authz.common.authenticator.exception;

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/password/PasswordAuthenticator.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/password/PasswordAuthenticator.java
@@ -25,7 +25,6 @@ import net.krotscheck.kangaroo.authz.common.database.entity.UserIdentity;
 import net.krotscheck.kangaroo.authz.common.util.PasswordUtil;
 import net.krotscheck.kangaroo.authz.oauth2.exception.RFC6749.InvalidRequestException;
 import net.krotscheck.kangaroo.util.ParamUtil;
-
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.process.internal.RequestScoped;
 import org.hibernate.Criteria;

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/test/TestAuthenticator.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/test/TestAuthenticator.java
@@ -20,11 +20,12 @@ package net.krotscheck.kangaroo.authz.common.authenticator.test;
 
 import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorType;
 import net.krotscheck.kangaroo.authz.common.authenticator.IAuthenticator;
+import net.krotscheck.kangaroo.authz.common.authenticator.exception.MisconfiguredAuthenticatorException;
 import net.krotscheck.kangaroo.authz.common.database.entity.Authenticator;
 import net.krotscheck.kangaroo.authz.common.database.entity.Role;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
 import net.krotscheck.kangaroo.authz.common.database.entity.UserIdentity;
-
+import net.krotscheck.kangaroo.common.exception.KangarooException;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.process.internal.RequestScoped;
 import org.hibernate.Criteria;
@@ -130,6 +131,21 @@ public final class TestAuthenticator
         }
 
         return identity;
+    }
+
+    /**
+     * Validate the test authenticator.
+     *
+     * @param authenticator The authenticator configuration.
+     * @throws KangarooException Thrown if the "invalid" property is sent.
+     */
+    @Override
+    public void validate(final Authenticator authenticator)
+            throws KangarooException {
+        // The test authenticator will fail if a "invalid" property is set.
+        if (authenticator.getConfiguration().containsKey("invalid")) {
+            throw new MisconfiguredAuthenticatorException();
+        }
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/exception/MisconfiguredAuthenticatorExceptionTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/exception/MisconfiguredAuthenticatorExceptionTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.common.authenticator.exception;
+
+import net.krotscheck.kangaroo.common.exception.KangarooException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Assert that the exception contains the expected values.
+ *
+ * @author Michael Krotscheck
+ */
+public final class MisconfiguredAuthenticatorExceptionTest {
+
+    /**
+     * Validate that the exception contains the expected values.
+     */
+    @Test
+    public void validateCodeInException() {
+        KangarooException e = new MisconfiguredAuthenticatorException();
+        assertEquals("misconfigured", e.getCode().getError());
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/exception/package-info.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/exception/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Tests for our exceptions.
+ */
+package net.krotscheck.kangaroo.authz.common.authenticator.exception;


### PR DESCRIPTION
The IAuthenticator configuration is now checked against the actual
authenticator, so that during CRUD operations we can validate that
the expected configuration is available.