### PR TITLE
Use AMI as build slave

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,12 +11,8 @@ pipeline {
         label 'worker'
     }
 
-    environment {
-        DB_ROOT = credentials('mysql')
-    }
-
     options {
-        timeout(time: 30, unit: 'MINUTES')
+        timeout(time: 45, unit: 'MINUTES')
         buildDiscarder(logRotator(numToKeepStr: '5'))
     }
 
@@ -55,7 +51,6 @@ pipeline {
                             sh """
                                 mvn install \
                                     -Pmariadb \
-                                    -Dhibernate.root.password=${DB_ROOT_PSW} \
                                     -Dtarget-directory=target-mariadb \
                                     -Dhibernate.connection.url=${jdbc_mariadb}
                             """

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/DatabaseResource.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/DatabaseResource.java
@@ -63,8 +63,7 @@ public final class DatabaseResource implements TestRule {
     public ITestDatabase createDatabase() {
         switch (TestConfig.getDatabase()) {
             case MARIADB:
-                database =
-                        new MariaDBTestDatabase(TestConfig.getRootPassword());
+                database = new MariaDBTestDatabase("");
                 break;
             case H2:
             default:


### PR DESCRIPTION
Tweaks to the project to permit using throwaway AMI's as build slaves.