### PR TITLE
Expand the authorization contract.

### DIFF
--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/IAuthenticator.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/IAuthenticator.java
@@ -60,6 +60,11 @@ public interface IAuthenticator {
     default void validate(Authenticator authenticator)
             throws KangarooException {
 
+        // If there's no authenticator...
+        if (authenticator == null) {
+            return;
+        }
+
         // If we have any configuration values, throw an exception.
         Map<String, String> config = authenticator.getConfiguration();
         if (config == null) {
@@ -74,11 +79,14 @@ public interface IAuthenticator {
      * Authenticate and/or create a user identity for a specific client, given
      * the URI from an authentication delegate.
      *
-     * @param configuration The authenticator configuration.
+     * @param authenticator The authenticator configuration.
      * @param parameters    Parameters for the authenticator, retrieved from
      *                      an appropriate source.
-     * @return A user identity.
+     * @param callback      The redirect that was provided to the original
+     *                      authorize call.
+     * @return A user identity, or a runtime error that will be sent back.
      */
-    UserIdentity authenticate(Authenticator configuration,
-                              MultivaluedMap<String, String> parameters);
+    UserIdentity authenticate(Authenticator authenticator,
+                              MultivaluedMap<String, String> parameters,
+                              URI callback);
 }

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/password/PasswordAuthenticator.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/password/PasswordAuthenticator.java
@@ -84,12 +84,15 @@ public final class PasswordAuthenticator
      * @param authenticator The authenticator configuration.
      * @param parameters    Parameters for the authenticator, retrieved from
      *                      an appropriate source.
+     * @param callback      The redirect that was provided to the original
+     *                      authorize call.
      * @return A user identity.
      */
     @Override
     public UserIdentity authenticate(final Authenticator authenticator,
                                      final MultivaluedMap<String, String>
-                                             parameters) {
+                                             parameters,
+                                     final URI callback) {
         // Validate the input
         if (authenticator == null || parameters == null) {
             throw new InvalidRequestException();

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/test/TestAuthenticator.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/test/TestAuthenticator.java
@@ -93,11 +93,14 @@ public final class TestAuthenticator
      * @param authenticator The authenticator configuration.
      * @param parameters    Parameters for the authenticator, retrieved from
      *                      an appropriate source.
+     * @param callback      The redirect that was provided to the original
+     *                      authorize call.
      */
     @Override
     public UserIdentity authenticate(final Authenticator authenticator,
                                      final MultivaluedMap<String, String>
-                                             parameters) {
+                                             parameters,
+                                     final URI callback) {
         Criteria searchCriteria = session.createCriteria(UserIdentity.class);
 
         searchCriteria.add(Restrictions.eq("type", authenticator.getType()));

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/authorize/AuthCodeHandler.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/authorize/AuthCodeHandler.java
@@ -124,16 +124,11 @@ public final class AuthCodeHandler implements IAuthorizeHandler {
         session.save(callbackState);
 
         // Generate the redirection url.
-        URI callback = uriInfo.getAbsolutePathBuilder()
-                .path("/callback")
-                .queryParam("state",
-                        IdUtil.toString(callbackState.getId()))
-                .build();
+        URI callback = buildCallback(uriInfo, callbackState);
 
         // Run the authenticator.
         return authImpl.delegate(auth, callback);
     }
-
 
     /**
      * Handle a callback response from the IdP (Authenticator). Provided with
@@ -150,9 +145,11 @@ public final class AuthCodeHandler implements IAuthorizeHandler {
                              final HttpSession browserSession,
                              final UriInfo uriInfo) {
 
+        URI callback = buildCallback(uriInfo, s);
+
         IAuthenticator a = getAuthenticator(s);
         UserIdentity i = a.authenticate(s.getAuthenticator(),
-                uriInfo.getPathParameters());
+                uriInfo.getPathParameters(), callback);
 
         // Build the token.
         OAuthToken t = new OAuthToken();

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/authorize/IAuthorizeHandler.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/authorize/IAuthorizeHandler.java
@@ -22,6 +22,7 @@ import net.krotscheck.kangaroo.authz.common.authenticator.IAuthenticator;
 import net.krotscheck.kangaroo.authz.common.database.entity.ApplicationScope;
 import net.krotscheck.kangaroo.authz.common.database.entity.Authenticator;
 import net.krotscheck.kangaroo.authz.common.database.entity.AuthenticatorState;
+import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
 
 import javax.servlet.http.HttpSession;
 import javax.ws.rs.core.Response;
@@ -81,4 +82,20 @@ public interface IAuthorizeHandler {
      * @return An authenticator Impl, available from the injection context.
      */
     IAuthenticator getAuthenticator(AuthenticatorState state);
+
+
+    /**
+     * Build the callback.
+     *
+     * @param info  URI/Request info, used to get the host context.
+     * @param state The authenticator state.
+     * @return The callback.
+     */
+    default URI buildCallback(final UriInfo info,
+                              final AuthenticatorState state) {
+        return info.getAbsolutePathBuilder()
+                .path("/callback")
+                .queryParam("state", IdUtil.toString(state.getId()))
+                .build();
+    }
 }

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/authorize/ImplicitHandler.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/authorize/ImplicitHandler.java
@@ -188,11 +188,7 @@ public final class ImplicitHandler implements IAuthorizeHandler {
         session.save(callbackState);
 
         // Generate the redirection url.
-        URI callback = uriInfo.getAbsolutePathBuilder()
-                .path("/callback")
-                .queryParam("state",
-                        IdUtil.toString(callbackState.getId()))
-                .build();
+        URI callback = buildCallback(uriInfo, callbackState);
 
         // Run the authenticator.
         return authImpl.delegate(auth, callback);
@@ -268,9 +264,11 @@ public final class ImplicitHandler implements IAuthorizeHandler {
                                      browserSession,
                              final UriInfo uriInfo) {
 
+        URI callback = buildCallback(uriInfo, s);
+
         IAuthenticator a = getAuthenticator(s);
         UserIdentity identity = a.authenticate(s.getAuthenticator(),
-                uriInfo.getPathParameters());
+                uriInfo.getPathParameters(), callback);
         Client client = s.getAuthenticator().getClient();
         SortedMap<String, ApplicationScope> issuedScopes = ValidationUtil
                 .validateScope(s.getClientScopes(),

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/token/OwnerCredentialsGrantHandler.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/token/OwnerCredentialsGrantHandler.java
@@ -101,8 +101,8 @@ public final class OwnerCredentialsGrantHandler
                         client.getAuthenticators());
 
         UserIdentity identity;
-        // Try to resolve a user identity.
-        identity = authenticator.authenticate(authConfig, formData);
+        // Try to resolve a user identity. No callback.
+        identity = authenticator.authenticate(authConfig, formData, null);
         if (identity == null) {
             throw new NotAuthorizedException(Response.status(Status
                     .UNAUTHORIZED).build());

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/IAuthenticatorTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/IAuthenticatorTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.common.authenticator;
+
+import net.krotscheck.kangaroo.authz.common.authenticator.exception.MisconfiguredAuthenticatorException;
+import net.krotscheck.kangaroo.authz.common.database.entity.Authenticator;
+import net.krotscheck.kangaroo.authz.common.database.entity.UserIdentity;
+import org.junit.Test;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import java.net.URI;
+import java.util.HashMap;
+
+/**
+ * Test the default behavior.
+ *
+ * @author Michael Krotscheck
+ */
+public final class IAuthenticatorTest {
+
+    /**
+     * Test the default "passing" behavior for this interface.
+     */
+    @Test
+    public void testDefaultPassingBehavior() {
+        IAuthenticator authenticator = new TestableAuthenticator();
+
+        // null input.
+        authenticator.validate(null);
+
+        // Null configuration
+        Authenticator auth = new Authenticator();
+        auth.setConfiguration(null);
+        authenticator.validate(auth);
+
+        // Empty configuration
+        auth.setConfiguration(new HashMap<>());
+        authenticator.validate(auth);
+    }
+
+    /**
+     * Test the default failing behavior for this interface.
+     */
+    @Test(expected = MisconfiguredAuthenticatorException.class)
+    public void testDefaultFailingBehavior() {
+        IAuthenticator authenticator = new TestableAuthenticator();
+        Authenticator auth = new Authenticator();
+        auth.getConfiguration().put("foo", "bar");
+        authenticator.validate(auth);
+    }
+
+    /**
+     * The testable authenticator.
+     */
+    public static final class TestableAuthenticator implements IAuthenticator {
+
+        /**
+         * Do nothing, we need to test the default behavior.
+         *
+         * @param configuration The authenticator configuration.
+         * @param callback      The full path to our redirection endpoint.
+         * @return null
+         */
+        @Override
+        public Response delegate(final Authenticator configuration,
+                                 final URI callback) {
+            return null;
+        }
+
+        /**
+         * Do nothing, we're here to test the default behavior.
+         *
+         * @param authenticator The authenticator configuration.
+         * @param parameters    Parameters for the authenticator, retrieved from
+         *                      an appropriate source.
+         * @param callback      The full path to our redirection endpoint.
+         * @return null
+         */
+        @Override
+        public UserIdentity authenticate(final Authenticator authenticator,
+                                         final MultivaluedMap<String, String>
+                                                 parameters,
+                                         final URI callback) {
+            return null;
+        }
+    }
+}
+    

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/password/PasswordAuthenticatorTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/password/PasswordAuthenticatorTest.java
@@ -140,7 +140,7 @@ public final class PasswordAuthenticatorTest extends DatabaseTest {
         MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
         params.add("username", "login");
         params.add("password", "password");
-        UserIdentity i = a.authenticate(context.getAuthenticator(), params);
+        UserIdentity i = a.authenticate(context.getAuthenticator(), params, null);
         Assert.assertEquals("login", i.getRemoteId());
     }
 
@@ -153,7 +153,7 @@ public final class PasswordAuthenticatorTest extends DatabaseTest {
     public void testAuthenticateNullConfig() throws Exception {
         IAuthenticator a = new PasswordAuthenticator(getSession());
         MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
-        a.authenticate(null, params);
+        a.authenticate(null, params, null);
     }
 
     /**
@@ -165,7 +165,7 @@ public final class PasswordAuthenticatorTest extends DatabaseTest {
     public void testAuthenticateNullParams() throws Exception {
         IAuthenticator a = new PasswordAuthenticator(getSession());
         Authenticator config = new Authenticator();
-        a.authenticate(config, null);
+        a.authenticate(config, null, null);
     }
 
     /**
@@ -179,7 +179,7 @@ public final class PasswordAuthenticatorTest extends DatabaseTest {
         MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
         params.add("username", "wrongIdentity");
         params.add("password", "password");
-        UserIdentity i = a.authenticate(context.getAuthenticator(), params);
+        UserIdentity i = a.authenticate(context.getAuthenticator(), params, null);
         Assert.assertNull(i);
     }
 
@@ -194,7 +194,7 @@ public final class PasswordAuthenticatorTest extends DatabaseTest {
         MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
         params.add("username", "login");
         params.add("password", "wrongpassword");
-        UserIdentity i = a.authenticate(context.getAuthenticator(), params);
+        UserIdentity i = a.authenticate(context.getAuthenticator(), params, null);
         Assert.assertNull(i);
     }
 }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/test/TestAuthenticatorTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/test/TestAuthenticatorTest.java
@@ -40,7 +40,6 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
-import java.security.InvalidParameterException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -140,7 +139,7 @@ public final class TestAuthenticatorTest extends DatabaseTest {
         Authenticator config = context.getAuthenticator();
         MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
 
-        UserIdentity i = a.authenticate(config, params);
+        UserIdentity i = a.authenticate(config, params, null);
 
         assertNotNull(i);
         assertNotNull(i.getId());
@@ -159,7 +158,7 @@ public final class TestAuthenticatorTest extends DatabaseTest {
         Authenticator config = context.getAuthenticator();
         MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
 
-        UserIdentity i = a.authenticate(config, params);
+        UserIdentity i = a.authenticate(config, params, null);
 
         assertNotNull(i);
         assertNotNull(i.getId());
@@ -185,7 +184,7 @@ public final class TestAuthenticatorTest extends DatabaseTest {
         Authenticator config = testContext.getAuthenticator();
         MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
 
-        UserIdentity i = a.authenticate(config, params);
+        UserIdentity i = a.authenticate(config, params, null);
 
         Assert.assertEquals(persistedIdentity, i);
     }


### PR DESCRIPTION
This patch adds passing the redirection-uri into the IAuthenticator,
as some of our authenticators may need the original redirection uri for
their callback validation.