### PR TITLE
Tests can use values from .my.cnf

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ supported.
 - Google Chrome v62 or greater
 - The google `chromedriver` available on your `$PATH`
 - A facebook application (unpublished is ok)
-- MySQL, exposed at `mysql://localhost:3306/`, with the root password blank.
+- MySQL, exposed at `mysql://localhost:3306/`, with the root password blank, 
+  or a `~/.my.cnf` client configuration with database creation credentials.
 
 The following environment variables should be set.
 

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/TestConfig.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/TestConfig.java
@@ -19,9 +19,11 @@
 package net.krotscheck.kangaroo.test;
 
 import net.krotscheck.kangaroo.test.rule.database.TestDB;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.HierarchicalINIConfiguration;
 import org.hibernate.dialect.H2Dialect;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import java.io.File;
 
 /**
  * This class exposes all runtime parameters that may be used to configure
@@ -86,12 +88,49 @@ public final class TestConfig {
     }
 
     /**
-     * Evaluate the Root Database Password (Where appropriate).
+     * Evaluate the MariaDB Root Database User (Where appropriate).
+     *
+     * @return The root database user.
+     */
+    public static String getMariaDBRootUser() {
+        // The root password can exist in several locations.
+        String home = System.getProperty("user.home");
+        File f = new File(home + "/.my.cnf");
+
+        // If there's a .my.cnf to access, use that.
+        try {
+            HierarchicalINIConfiguration configuration =
+                    new HierarchicalINIConfiguration(f);
+            return configuration
+                    .getSection("client")
+                    .getString("user");
+        } catch (ConfigurationException e) {
+            // Fallback to system properties.
+            return System.getProperty("hibernate.root.user", "root");
+        }
+    }
+
+    /**
+     * Evaluate the MariaDB Root Database Password (Where appropriate).
      *
      * @return The root database password.
      */
-    public static String getRootPassword() {
-        return System.getProperty("hibernate.root.password", "");
+    public static String getMariaDBRootPassword() {
+        // The root password can exist in several locations.
+        String home = System.getProperty("user.home");
+        File f = new File(home + "/.my.cnf");
+
+        // If there's a .my.cnf to access, use that.
+        try {
+            HierarchicalINIConfiguration configuration =
+                    new HierarchicalINIConfiguration(f);
+            return configuration
+                    .getSection("client")
+                    .getString("password");
+        } catch (ConfigurationException e) {
+            // Fallback to system properties.
+            return System.getProperty("hibernate.root.password", "");
+        }
     }
 
     /**

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/DatabaseResource.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/DatabaseResource.java
@@ -63,7 +63,7 @@ public final class DatabaseResource implements TestRule {
     public ITestDatabase createDatabase() {
         switch (TestConfig.getDatabase()) {
             case MARIADB:
-                database = new MariaDBTestDatabase("");
+                database = new MariaDBTestDatabase();
                 break;
             case H2:
             default:

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/database/MariaDBTestDatabase.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/database/MariaDBTestDatabase.java
@@ -18,6 +18,9 @@
 
 package net.krotscheck.kangaroo.test.rule.database;
 
+import net.krotscheck.kangaroo.test.TestConfig;
+import org.apache.lucene.util.TestUtil;
+
 import javax.ws.rs.core.UriBuilder;
 import java.io.IOException;
 import java.net.URI;
@@ -39,20 +42,6 @@ import java.sql.Statement;
  */
 public final class MariaDBTestDatabase extends AbstractTestDatabase
         implements ITestDatabase {
-
-    /**
-     * The root password for this database.
-     */
-    private final String rootPassword;
-
-    /**
-     * Create a new DB reference.
-     *
-     * @param rootPassword The root password for the database.
-     */
-    public MariaDBTestDatabase(final String rootPassword) {
-        this.rootPassword = rootPassword;
-    }
 
     /**
      * The name for the created database.
@@ -145,6 +134,9 @@ public final class MariaDBTestDatabase extends AbstractTestDatabase
     private Connection createRootConnection() {
         loadDriver();
         try {
+            String rootUser = TestConfig.getMariaDBRootUser();
+            String rootPassword = TestConfig.getMariaDBRootPassword();
+
             // Build a connection string without the database.
             String dbUrl = getJdbcConnectionString();
             dbUrl = dbUrl.substring("jdbc:".length());
@@ -154,7 +146,7 @@ public final class MariaDBTestDatabase extends AbstractTestDatabase
                     dbpath.getHost(),
                     dbpath.getPort());
 
-            return DriverManager.getConnection(rootJdbc, "root",
+            return DriverManager.getConnection(rootJdbc, rootUser,
                     rootPassword);
         } catch (SQLException e) {
             throw new RuntimeException("cannot connect to maria database",


### PR DESCRIPTION
This allows us to lock down our jenkins slave, by permitting the
test configuration to read the user/password configured on the build slave.