### PR TITLE
Increased screen size of chrome driver.

### DIFF
--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/SeleniumRule.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/SeleniumRule.java
@@ -87,6 +87,7 @@ public final class SeleniumRule implements TestRule {
                     final ChromeOptions chromeOptions = new ChromeOptions();
                     chromeOptions.setHeadless(true);
                     chromeOptions.addArguments("--disable-notifications");
+                    chromeOptions.addArguments("--window-size=1920,1080");
                     driver = new ChromeDriver(chromeOptions);
 
                     base.evaluate();


### PR DESCRIPTION
Facebook's buttons fall off the edge of the browser at smaller
resolutions. This fixes it.