### PR TITLE
Add LinkedIn Authenticator support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@ pipeline {
     environment {
         KANGAROO_FB_APP = credentials('jenkins_facebook_app')
         KANGAROO_GOOGLE_APP = credentials('jenkins_google_app')
+        KANGAROO_LINKEDIN_APP = credentials('jenkins_linkedin_app')
         KANGAROO_GOOGLE_ACCOUNT = credentials('jenkins_google_account')
     }
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ supported.
 - The google `chromedriver` available on your `$PATH`
 - A facebook application (unpublished is ok)
 - A testing google email account and oauth2 application.
+- A testing linkedin account (use the google credentials)
+- A testing linkedin application.
 - MySQL, exposed at `mysql://localhost:3306/`, with the root password blank, 
   or a `~/.my.cnf` client configuration with database creation credentials.
 
@@ -44,6 +46,9 @@ The following environment variables should be set.
 ```bash
 export KANGAROO_FB_APP_USR=<your_facebook_app_id>
 export KANGAROO_FB_APP_PSW=<your_facebook_app_secret>
+
+export KANGAROO_LINKEDIN_APP_USR=<your_google_login>
+export KANGAROO_LINKEDIN_APP_PSW=<your_google_password>
 
 export KANGAROO_GOOGLE_ACCOUNT_USR=<your_google_login>
 export KANGAROO_GOOGLE_ACCOUNT_PSW=<your_google_password>

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/TestConfig.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/TestConfig.java
@@ -190,6 +190,24 @@ public final class TestConfig {
     }
 
     /**
+     * Evaluate the linkedin test app id. Must be set.
+     *
+     * @return The linkedin app id.
+     */
+    public static String getLinkedInAppId() {
+        return System.getenv("KANGAROO_LINKEDIN_APP_USR");
+    }
+
+    /**
+     * Evaluate the linkedin test app secret. Must be set.
+     *
+     * @return The linkedin app secret.
+     */
+    public static String getLinkedInAppSecret() {
+        return System.getenv("KANGAROO_LINKEDIN_APP_PSW");
+    }
+
+    /**
      * Evaluate the google test app id. Must be set.
      *
      * @return The google app id.

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/AuthenticatorFeature.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/AuthenticatorFeature.java
@@ -20,6 +20,7 @@ package net.krotscheck.kangaroo.authz.common.authenticator;
 
 import net.krotscheck.kangaroo.authz.common.authenticator.facebook.FacebookAuthenticator;
 import net.krotscheck.kangaroo.authz.common.authenticator.google.GoogleAuthenticator;
+import net.krotscheck.kangaroo.authz.common.authenticator.linkedin.LinkedInAuthenticator;
 import net.krotscheck.kangaroo.authz.common.authenticator.password.PasswordAuthenticator;
 import net.krotscheck.kangaroo.authz.common.authenticator.test.TestAuthenticator;
 
@@ -44,6 +45,7 @@ public final class AuthenticatorFeature implements Feature {
         context.register(new PasswordAuthenticator.Binder());
         context.register(new GoogleAuthenticator.Binder());
         context.register(new FacebookAuthenticator.Binder());
+        context.register(new LinkedInAuthenticator.Binder());
 
         return true;
     }

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/AuthenticatorType.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/AuthenticatorType.java
@@ -39,6 +39,12 @@ public enum AuthenticatorType {
     Google(true),
 
     /**
+     * This authenticator uses LinkedIn's OAuth2 protocol as a simple IdP,
+     * discarding the received tokens after use.
+     */
+    LinkedIn(true),
+
+    /**
      * This type describes the password authenticator, which drives our Owner
      * Credentials flow. It is considered a private authenticator type, and
      * should not be permitted to be manually set via the admin API.

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/linkedin/LinkedInAuthenticator.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/linkedin/LinkedInAuthenticator.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.common.authenticator.linkedin;
+
+import com.google.common.base.Strings;
+import com.google.common.util.concurrent.Uninterruptibles;
+import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorType;
+import net.krotscheck.kangaroo.authz.common.authenticator.IAuthenticator;
+import net.krotscheck.kangaroo.authz.common.authenticator.exception.ThirdPartyErrorException;
+import net.krotscheck.kangaroo.authz.common.authenticator.oauth2.AbstractOAuth2Authenticator;
+import net.krotscheck.kangaroo.authz.common.authenticator.oauth2.OAuth2IdPToken;
+import net.krotscheck.kangaroo.authz.common.authenticator.oauth2.OAuth2User;
+import net.krotscheck.kangaroo.util.HttpUtil;
+import org.apache.commons.lang3.StringUtils;
+import org.glassfish.jersey.internal.inject.AbstractBinder;
+import org.glassfish.jersey.process.internal.RequestScoped;
+
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status.Family;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This authenticator permits using LinkedIn as an IdP. It does not pass the
+ * linkedin token through; only uses it to query basic profile information
+ * and verify identity.
+ *
+ * @author Michael Krotscheck
+ */
+public final class LinkedInAuthenticator
+        extends AbstractOAuth2Authenticator {
+
+    /**
+     * LinkedIn's auth endpoint.
+     *
+     * @return The absolute URL to linkedin's auth endpoint.
+     */
+    @Override
+    protected String getAuthEndpoint() {
+        return "https://www.linkedin.com/oauth/v2/authorization";
+    }
+
+    /**
+     * LinkedIn's token endpoint.
+     *
+     * @return The absolute URL to linkedin's token endpoint.
+     */
+    @Override
+    protected String getTokenEndpoint() {
+        return "https://www.linkedin.com/oauth/v2/accessToken";
+    }
+
+    /**
+     * List of scopes that we need from linkedin.
+     *
+     * @return A static list of scopes.
+     */
+    @Override
+    protected String getScopes() {
+        return StringUtils.join(new String[]{
+                "r_basicprofile",
+                "r_emailaddress"
+        }, " ");
+    }
+
+    /**
+     * Retrieve the user info from LinkedIn.
+     *
+     * @param token The OAuth token.
+     * @return The remote user data from LinkedIn.
+     */
+    @Override
+    protected OAuth2User loadUserIdentity(final OAuth2IdPToken token) {
+        int count = 0;
+        int maxTries = 5;
+
+        while (true) {
+            try {
+                return tryUserLoad(token);
+            } catch (ThirdPartyErrorException e) {
+                if (++count == maxTries) {
+                    throw e;
+                }
+                Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    /**
+     * Try to load the user from linkedin. If it fails, throw an exception.
+     *
+     * @param token The oauth2 token to use.
+     * @return The user, or an exception.
+     */
+    private OAuth2User tryUserLoad(final OAuth2IdPToken token) {
+        Response r = getClient()
+                .target("https://api.linkedin.com/v1/people/~"
+                        + ":(id,first-name,last-name,email-address)")
+                .request()
+                .header("x-li-format", "json")
+                .header(HttpHeaders.AUTHORIZATION,
+                        HttpUtil.authHeaderBearer(token.getAccessToken()))
+                .get();
+
+        try {
+            // If this is an error...
+            if (r.getStatusInfo().getFamily().equals(Family.SUCCESSFUL)) {
+                LinkedInUserEntity gUser =
+                        r.readEntity(LinkedInUserEntity.class);
+                if (Strings.isNullOrEmpty(gUser.getId())) {
+                    throw new ThirdPartyErrorException();
+                }
+                return gUser.asGenericUser();
+            } else {
+                Map<String, String> params = r.readEntity(MAP_TYPE);
+                throw new ThirdPartyErrorException(params);
+            }
+        } catch (ProcessingException e) {
+            throw new ThirdPartyErrorException();
+        } finally {
+            r.close();
+        }
+    }
+
+    /**
+     * HK2 Binder for our injector context.
+     */
+    public static final class Binder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bind(LinkedInAuthenticator.class)
+                    .to(IAuthenticator.class)
+                    .named(AuthenticatorType.LinkedIn.name())
+                    .in(RequestScoped.class);
+        }
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/linkedin/LinkedInUserEntity.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/linkedin/LinkedInUserEntity.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.common.authenticator.linkedin;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import net.krotscheck.kangaroo.authz.common.authenticator.oauth2.OAuth2User;
+
+import java.util.HashMap;
+
+/**
+ * A reduced-size POJO of data we're expecting back from linkedin.
+ *
+ * @author Michael Krotscheck
+ */
+final class LinkedInUserEntity {
+
+    /**
+     * The id of this person's user account.
+     */
+    private String id;
+
+    /**
+     * The person's primary email address listed on their profile.
+     */
+    private String emailAddress;
+
+    /**
+     * The person's first name.
+     */
+    private String firstName;
+
+    /**
+     * The person's last name.
+     */
+    private String lastName;
+
+    /**
+     * Get the user's first name.
+     *
+     * @return The user's first name.
+     */
+    public String getFirstName() {
+        return firstName;
+    }
+
+    /**
+     * Set the user's first name.
+     *
+     * @param firstName The first name.
+     */
+    public void setFirstName(final String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * Get the application specific user id of this user.
+     *
+     * @return The user id.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Set the application-specific user id for this user.
+     *
+     * @param id The user id.
+     */
+    public void setId(final String id) {
+        this.id = id;
+    }
+
+    /**
+     * Get the email for this user.
+     *
+     * @return The user's email.
+     */
+    public String getEmailAddress() {
+        return emailAddress;
+    }
+
+    /**
+     * Set the email for this user.
+     *
+     * @param emailAddress The user's email.
+     */
+    public void setEmailAddress(final String emailAddress) {
+        this.emailAddress = emailAddress;
+    }
+
+    /**
+     * Get the last name.
+     *
+     * @return The last name.
+     */
+    public String getLastName() {
+        return lastName;
+    }
+
+    /**
+     * Set the last name.
+     *
+     * @param lastName New last name.
+     */
+    public void setLastName(final String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * Convert the facebook user to the common user type.
+     *
+     * @return A map of claims.
+     */
+    @JsonIgnore
+    public OAuth2User asGenericUser() {
+        HashMap<String, String> outputMap = new HashMap<>();
+        outputMap.put("emailAddress", emailAddress);
+        outputMap.put("firstName", firstName);
+        outputMap.put("lastName", lastName);
+
+        OAuth2User user = new OAuth2User();
+        user.setId(getId());
+        user.setClaims(outputMap);
+        return user;
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/linkedin/package-info.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/linkedin/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Login with LinkedIn.
+ */
+package net.krotscheck.kangaroo.authz.common.authenticator.linkedin;

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/oauth2/AbstractOAuth2Authenticator.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/authenticator/oauth2/AbstractOAuth2Authenticator.java
@@ -350,6 +350,7 @@ public abstract class AbstractOAuth2Authenticator implements IAuthenticator {
         // Build the request payload
         Form f = new Form();
         f.param("client_id", clientId);
+        f.param("client_secret", clientSecret);
         f.param("code", authorizationCode);
         f.param("grant_type", "authorization_code");
         f.param("redirect_uri", redirectUrl.toString());

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/AuthenticatorTypeTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/AuthenticatorTypeTest.java
@@ -37,7 +37,8 @@ public final class AuthenticatorTypeTest {
             if (type.in(AuthenticatorType.Password,
                     AuthenticatorType.Test,
                     AuthenticatorType.Google,
-                    AuthenticatorType.Facebook)) {
+                    AuthenticatorType.Facebook,
+                    AuthenticatorType.LinkedIn)) {
                 Assert.assertTrue(type.isPrivate());
             } else {
                 Assert.assertFalse(type.isPrivate());
@@ -89,6 +90,10 @@ public final class AuthenticatorTypeTest {
         Assert.assertEquals(
                 AuthenticatorType.Google,
                 AuthenticatorType.valueOf("Google")
+        );
+        Assert.assertEquals(
+                AuthenticatorType.LinkedIn,
+                AuthenticatorType.valueOf("LinkedIn")
         );
     }
 }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/linkedin/LinkedInAuthenticatorTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/linkedin/LinkedInAuthenticatorTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.common.authenticator.linkedin;
+
+import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorType;
+import net.krotscheck.kangaroo.authz.common.authenticator.exception.ThirdPartyErrorException;
+import net.krotscheck.kangaroo.authz.common.authenticator.oauth2.AbstractOAuth2Authenticator;
+import net.krotscheck.kangaroo.authz.common.authenticator.oauth2.OAuth2IdPToken;
+import net.krotscheck.kangaroo.authz.common.authenticator.oauth2.OAuth2User;
+import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
+import net.krotscheck.kangaroo.authz.test.ApplicationBuilder;
+import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.test.jersey.DatabaseTest;
+import net.krotscheck.kangaroo.test.rule.TestDataResource;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation.Builder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for the linkedin authenticator.
+ *
+ * @author Michael Krotscheck
+ */
+public final class LinkedInAuthenticatorTest
+        extends DatabaseTest {
+
+    /**
+     * DB Context, constructed for testing.
+     */
+    private static ApplicationContext context;
+
+    /**
+     * Test data loading for this test.
+     */
+    @ClassRule
+    public static final TestRule TEST_DATA_RULE =
+            new TestDataResource(HIBERNATE_RESOURCE) {
+                /**
+                 * Initialize the test data.
+                 */
+                @Override
+                protected void loadTestData(final Session session) {
+                    Map<String, String> fbConfig = new HashMap<>();
+                    fbConfig.put(AbstractOAuth2Authenticator.CLIENT_ID_KEY,
+                            "id");
+                    fbConfig.put(AbstractOAuth2Authenticator.CLIENT_SECRET_KEY,
+                            "secret");
+
+                    context = ApplicationBuilder.newApplication(session)
+                            .client(ClientType.AuthorizationGrant)
+                            .role("some_role")
+                            .authenticator(AuthenticatorType.LinkedIn, fbConfig)
+                            .build();
+                }
+            };
+
+    /**
+     * A mock client.
+     */
+    private Client client;
+
+    /**
+     * A mock web target.
+     */
+    private WebTarget webTarget;
+
+    /**
+     * A mock invocation builder.
+     */
+    private Builder builder;
+
+    /**
+     * A mock get response.
+     */
+    private Response getResponse;
+
+    /**
+     * A mock client.
+     */
+    private LinkedInAuthenticator linkedinAuth;
+
+    /**
+     * Set up our mocks.
+     */
+    @Before
+    public void bootstrap() {
+        getSession().beginTransaction();
+
+        this.client = mock(Client.class);
+        this.webTarget = mock(WebTarget.class);
+        this.builder = mock(Builder.class);
+        this.getResponse = mock(Response.class);
+
+        doReturn(webTarget).when(client).target(anyString());
+        doReturn(builder).when(webTarget).request();
+        doReturn(builder).when(builder).header(any(), any());
+        doReturn(getResponse).when(builder).get();
+        doReturn(Status.OK).when(getResponse).getStatusInfo();
+
+        this.linkedinAuth = new LinkedInAuthenticator();
+        this.linkedinAuth.setClient(client);
+        this.linkedinAuth.setSession(getSession());
+    }
+
+    /**
+     * Set up our mocks.
+     */
+    @After
+    public void cleanup() {
+        Transaction t = getSession().getTransaction();
+        if (t.isActive()) {
+            t.commit();
+        }
+    }
+
+    /**
+     * Test the various get() methods.
+     */
+    @Test
+    public void testStaticAccessors() {
+        assertEquals("https://www.linkedin.com/oauth/v2/authorization",
+                linkedinAuth.getAuthEndpoint());
+        assertEquals("https://www.linkedin.com/oauth/v2/accessToken",
+                linkedinAuth.getTokenEndpoint());
+        assertEquals("r_basicprofile r_emailaddress",
+                linkedinAuth.getScopes());
+    }
+
+    /**
+     * Test a basic user load.
+     */
+    @Test
+    public void testLoadUser() {
+        OAuth2IdPToken result = new OAuth2IdPToken();
+        result.setAccessToken("linkedin_access_token");
+
+        LinkedInUserEntity user = new LinkedInUserEntity();
+        user.setId("test_id");
+        user.setFirstName("test name");
+        user.setLastName("test last name");
+        user.setEmailAddress("test email");
+
+        doReturn(user).when(getResponse).readEntity(LinkedInUserEntity.class);
+
+        OAuth2User returnedUser = linkedinAuth.loadUserIdentity(result);
+        assertEquals(returnedUser.getId(), user.getId());
+        assertEquals("test last name",
+                returnedUser.getClaims().get("lastName"));
+        assertEquals("test name",
+                returnedUser.getClaims().get("firstName"));
+        assertEquals("test email",
+                returnedUser.getClaims().get("emailAddress"));
+    }
+
+    /**
+     * Assert that if the user response returns with an error, it's recast
+     * to the client.
+     */
+    @Test(expected = ThirdPartyErrorException.class)
+    public void testLoadUserWithRemoteError() {
+        OAuth2IdPToken result = new OAuth2IdPToken();
+        result.setAccessToken("linkedin_access_token");
+
+        Map<String, String> response = new HashMap<>();
+        response.put("error", "test");
+        response.put("error_description", "description");
+
+        doReturn(Status.BAD_REQUEST).when(getResponse).getStatusInfo();
+        doReturn(response).when(getResponse)
+                .readEntity(LinkedInAuthenticator.MAP_TYPE);
+
+        linkedinAuth.loadUserIdentity(result);
+    }
+
+    /**
+     * Assert that if the user response returns with an unparseable
+     * response, it throws a simple error.
+     */
+    @Test(expected = ThirdPartyErrorException.class)
+    public void testLoadUserUnparseable() {
+        OAuth2IdPToken result = new OAuth2IdPToken();
+        result.setAccessToken("linkedin_access_token");
+
+        doThrow(ProcessingException.class)
+                .when(getResponse).readEntity(LinkedInUserEntity.class);
+
+        linkedinAuth.loadUserIdentity(result);
+    }
+
+    /**
+     * Assert that if the user response returns with no remote id, throw it
+     * back to the user.
+     */
+    @Test(expected = ThirdPartyErrorException.class)
+    public void testLoadUserNoResponse() {
+        OAuth2IdPToken idPToken = new OAuth2IdPToken();
+        idPToken.setAccessToken("linkedin_access_token");
+
+        LinkedInUserEntity result = new LinkedInUserEntity(); // no id
+        doReturn(result).when(getResponse).readEntity(LinkedInUserEntity.class);
+
+        linkedinAuth.loadUserIdentity(idPToken);
+    }
+
+    /**
+     * If we cannot close the user client... assume that it's an uncast error,
+     * caught by the generic 5xx handler.
+     */
+    @Test(expected = Exception.class)
+    public void testLoadUserErrorOnClose() {
+        OAuth2IdPToken idPToken = new OAuth2IdPToken();
+        idPToken.setAccessToken("linkedin_access_token");
+
+        LinkedInUserEntity testUser = new LinkedInUserEntity();
+        testUser.setId(RandomStringUtils.randomAlphanumeric(10));
+        testUser.setFirstName("Some Random Name");
+        testUser.setLastName("Some Last Name");
+        testUser.setEmailAddress("lol@example.com");
+        doReturn(testUser).when(getResponse)
+                .readEntity(LinkedInUserEntity.class);
+
+        doThrow(Exception.class).when(getResponse).close();
+
+        MultivaluedStringMap params = new MultivaluedStringMap();
+        params.putSingle("code", "valid_code");
+        linkedinAuth.loadUserIdentity(idPToken);
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/linkedin/LinkedInUserEntityTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/linkedin/LinkedInUserEntityTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.common.authenticator.linkedin;
+
+import net.krotscheck.kangaroo.authz.common.authenticator.oauth2.OAuth2User;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Unit tests for the linkedin user entity PoJo. Not all available properties
+ * are serialized, only the ones that matter right now.
+ *
+ * @author Michael Krotscheck
+ */
+public final class LinkedInUserEntityTest {
+
+    /**
+     * Assert we can get/set the first name.
+     */
+    @Test
+    public void getSetFirstName() {
+        String randomValue = RandomStringUtils.randomAlphabetic(30);
+        LinkedInUserEntity token = new LinkedInUserEntity();
+
+        assertNull(token.getFirstName());
+        token.setFirstName(randomValue);
+        assertEquals(randomValue, token.getFirstName());
+    }
+
+    /**
+     * Assert we can get/set the last name.
+     */
+    @Test
+    public void getSetLastName() {
+        String randomValue = RandomStringUtils.randomAlphabetic(30);
+        LinkedInUserEntity token = new LinkedInUserEntity();
+
+        assertNull(token.getLastName());
+        token.setLastName(randomValue);
+        assertEquals(randomValue, token.getLastName());
+    }
+
+    /**
+     * Assert we can get/set the id.
+     */
+    @Test
+    public void getSetId() {
+        String randomValue = RandomStringUtils.randomAlphabetic(30);
+        LinkedInUserEntity token = new LinkedInUserEntity();
+
+        assertNull(token.getId());
+        token.setId(randomValue);
+        assertEquals(randomValue, token.getId());
+    }
+
+    /**
+     * Assert we can get/set the email.
+     */
+    @Test
+    public void getSetEmail() {
+        String randomValue = RandomStringUtils.randomAlphabetic(30);
+        LinkedInUserEntity token = new LinkedInUserEntity();
+
+        assertNull(token.getEmailAddress());
+        token.setEmailAddress(randomValue);
+        assertEquals(randomValue, token.getEmailAddress());
+    }
+
+    /**
+     * Assert that we can convert an entity to claims.
+     */
+    @Test
+    public void testAsGenericUser() {
+        LinkedInUserEntity token = new LinkedInUserEntity();
+
+        token.setId(RandomStringUtils.randomAlphabetic(30));
+        token.setFirstName(RandomStringUtils.randomAlphabetic(30));
+        token.setLastName(RandomStringUtils.randomAlphabetic(30));
+        token.setEmailAddress(RandomStringUtils.randomAlphabetic(30));
+
+        OAuth2User user = token.asGenericUser();
+
+        assertEquals(token.getId(),
+                user.getId());
+        assertEquals(token.getFirstName(),
+                user.getClaims().get("firstName"));
+        assertEquals(token.getLastName(),
+                user.getClaims().get("lastName"));
+        assertEquals(token.getEmailAddress(),
+                user.getClaims().get("emailAddress"));
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/linkedin/package-info.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/linkedin/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Unit tests for the linkedin authenticator.
+ */
+package net.krotscheck.kangaroo.authz.common.authenticator.linkedin;


### PR DESCRIPTION
This patch builds on the existing OAuth2 authentication, to
support LinkedIn as an IdP.