### PR TITLE
Permit hibernate to be configured by the environment properties

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateServiceRegistryFactory.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateServiceRegistryFactory.java
@@ -56,6 +56,7 @@ public final class HibernateServiceRegistryFactory
 
         return new StandardServiceRegistryBuilder()
                 .configure() // configures settings from hibernate.cfg.xml
+                .applySettings(System.getenv())
                 .applySettings(System.getProperties())
                 .build();
     }


### PR DESCRIPTION
This allows us to, in our docker container, set hibernate properties
directly and permit overriding thereof.