### PR TITLE
Working Directory

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/Config.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/Config.java
@@ -44,6 +44,13 @@ public final class Config {
             SimpleImmutableEntry<>("kangaroo.port", 8080);
 
     /**
+     * The filesystem path used for the server's working directory. Used
+     * throughout the application.
+     */
+    public static final Entry<String, String> WORKING_DIR = new
+            SimpleImmutableEntry<>("kangaroo.working_dir", "/var/lib/kangaroo");
+
+    /**
      * Configuration property for an externally provided keystore.
      */
     public static final Entry<String, String> KEYSTORE_PATH = new

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/ServerFactory.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/ServerFactory.java
@@ -80,6 +80,13 @@ public final class ServerFactory {
                 .desc("The port on which this port should listen.")
                 .build();
 
+        Option workingDir = Option.builder()
+                .longOpt(Config.WORKING_DIR.getKey())
+                .argName(Config.WORKING_DIR.getKey())
+                .hasArg()
+                .desc("The server's working directory.")
+                .build();
+
         Option keystorePath = Option.builder()
                 .longOpt(Config.KEYSTORE_PATH.getKey())
                 .argName(Config.KEYSTORE_PATH.getKey())
@@ -126,6 +133,7 @@ public final class ServerFactory {
 
         CLI_OPTIONS.addOption(bindHost);
         CLI_OPTIONS.addOption(bindPort);
+        CLI_OPTIONS.addOption(workingDir);
         CLI_OPTIONS.addOption(keystorePath);
         CLI_OPTIONS.addOption(keystorePass);
         CLI_OPTIONS.addOption(keystoreType);

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/ServerFactory.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/ServerFactory.java
@@ -300,22 +300,26 @@ public final class ServerFactory {
      * Attempt to load the configured keystore for this running instance, and
      * return it.
      *
-     * @param ksPath    Path to the keystore. If not provided, a key will be
-     *                  generated.
-     * @param ksPass    Keystore Password.
-     * @param ksType    Keystore Type.
-     * @param certAlias Certificate alias.
-     * @param certPass  Certificate key password.
+     * @param workingDir Server working directory.
+     * @param ksPath     Path to the keystore. If not provided, a key will be
+     *                   generated.
+     * @param ksPass     Keystore Password.
+     * @param ksType     Keystore Type.
+     * @param certAlias  Certificate alias.
+     * @param certPass   Certificate key password.
      * @return A KeystoreProvider, unless an error occurs.
      */
-    private IKeystoreProvider getKeystore(final String ksPath,
+    private IKeystoreProvider getKeystore(final String workingDir,
+                                          final String ksPath,
                                           final String ksPass,
                                           final String ksType,
                                           final String certAlias,
                                           final String certPass) {
 
         if (StringUtils.isEmpty(ksPath)) {
-            return new GeneratedKeystoreProvider(ksPass, certPass, certAlias);
+
+            return new GeneratedKeystoreProvider(workingDir, ksPass, certPass,
+                    certAlias);
         }
         return new FSKeystoreProvider(ksPath, ksPass, ksType);
     }
@@ -338,10 +342,12 @@ public final class ServerFactory {
                 Config.CERT_ALIAS.getValue());
         String certPass = config.getString(Config.CERT_KEY_PASS.getKey(),
                 Config.CERT_KEY_PASS.getValue());
+        String workingDir = config.getString(Config.WORKING_DIR.getKey(),
+                Config.WORKING_DIR.getValue());
 
         // Build and store the keystore.
-        IKeystoreProvider ksProvider = getKeystore(ksPath, ksPass, ksType,
-                certAlias, certPass);
+        IKeystoreProvider ksProvider = getKeystore(workingDir, ksPath, ksPass,
+                ksType, certAlias, certPass);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ksProvider.writeTo(baos);
 

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/HibernateFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/HibernateFeatureTest.java
@@ -18,6 +18,8 @@
 
 package net.krotscheck.kangaroo.common.hibernate;
 
+import net.krotscheck.kangaroo.common.config.ConfigurationFeature;
+import net.krotscheck.kangaroo.server.Config;
 import net.krotscheck.kangaroo.test.jersey.KangarooJerseyTest;
 import net.krotscheck.kangaroo.test.rule.DatabaseResource;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -26,7 +28,9 @@ import org.hibernate.SessionFactory;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.SearchFactory;
 import org.hibernate.service.ServiceRegistry;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -52,13 +56,19 @@ public final class HibernateFeatureTest extends KangarooJerseyTest {
     public static final TestRule DATABASE = new DatabaseResource();
 
     /**
-     * Run a service request.
+     * Setup the test.
      */
-    @Test
-    public void testService() {
-        target("/test")
-                .request(MediaType.APPLICATION_JSON)
-                .get();
+    @Before
+    public void setupTest() {
+        System.setProperty(Config.WORKING_DIR.getKey(), "./target");
+    }
+
+    /**
+     * Teardown the test.
+     */
+    @After
+    public void teardownTest() {
+        System.clearProperty(Config.WORKING_DIR.getKey());
     }
 
     /**
@@ -69,10 +79,21 @@ public final class HibernateFeatureTest extends KangarooJerseyTest {
     @Override
     protected ResourceConfig createApplication() {
         ResourceConfig config = new ResourceConfig();
+        config.register(ConfigurationFeature.class);
         config.register(HibernateFeature.class);
         config.register(TestService.class);
 
         return config;
+    }
+
+    /**
+     * Run a service request.
+     */
+    @Test
+    public void testService() {
+        target("/test")
+                .request(MediaType.APPLICATION_JSON)
+                .get();
     }
 
     /**

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/HibernateFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/HibernateFeatureTest.java
@@ -19,7 +19,6 @@
 package net.krotscheck.kangaroo.common.hibernate;
 
 import net.krotscheck.kangaroo.common.config.ConfigurationFeature;
-import net.krotscheck.kangaroo.server.Config;
 import net.krotscheck.kangaroo.test.jersey.KangarooJerseyTest;
 import net.krotscheck.kangaroo.test.rule.DatabaseResource;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -28,9 +27,7 @@ import org.hibernate.SessionFactory;
 import org.hibernate.search.FullTextSession;
 import org.hibernate.search.SearchFactory;
 import org.hibernate.service.ServiceRegistry;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -54,22 +51,6 @@ public final class HibernateFeatureTest extends KangarooJerseyTest {
      */
     @ClassRule
     public static final TestRule DATABASE = new DatabaseResource();
-
-    /**
-     * Setup the test.
-     */
-    @Before
-    public void setupTest() {
-        System.setProperty(Config.WORKING_DIR.getKey(), "./target");
-    }
-
-    /**
-     * Teardown the test.
-     */
-    @After
-    public void teardownTest() {
-        System.clearProperty(Config.WORKING_DIR.getKey());
-    }
 
     /**
      * Configure the application.

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/FulltextSearchFactoryFactoryTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/FulltextSearchFactoryFactoryTest.java
@@ -19,8 +19,8 @@
 package net.krotscheck.kangaroo.common.hibernate.factory;
 
 import net.krotscheck.kangaroo.common.config.SystemConfiguration;
-import net.krotscheck.kangaroo.server.Config;
 import net.krotscheck.kangaroo.test.rule.DatabaseResource;
+import net.krotscheck.kangaroo.test.rule.WorkingDirectoryRule;
 import org.glassfish.jersey.internal.inject.InjectionManager;
 import org.glassfish.jersey.internal.inject.Injections;
 import org.hibernate.Session;
@@ -32,6 +32,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 
@@ -49,6 +50,12 @@ public final class FulltextSearchFactoryFactoryTest {
     public static final TestRule DATABASE = new DatabaseResource();
 
     /**
+     * Ensure that we have a working directory.
+     */
+    @Rule
+    public final TestRule workingDirectory = new WorkingDirectoryRule();
+
+    /**
      * The jersey application injector.
      */
     private InjectionManager injector;
@@ -58,8 +65,6 @@ public final class FulltextSearchFactoryFactoryTest {
      */
     @Before
     public void setup() {
-        System.setProperty(Config.WORKING_DIR.getKey(), "./target");
-
         injector = Injections.createInjectionManager();
         injector.register(new SystemConfiguration.Binder());
         injector.register(new HibernateServiceRegistryFactory.Binder());
@@ -77,8 +82,6 @@ public final class FulltextSearchFactoryFactoryTest {
     public void teardown() {
         injector.shutdown();
         injector = null;
-
-        System.clearProperty(Config.WORKING_DIR.getKey());
     }
 
     /**

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/FulltextSessionFactoryTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/FulltextSessionFactoryTest.java
@@ -19,8 +19,8 @@
 package net.krotscheck.kangaroo.common.hibernate.factory;
 
 import net.krotscheck.kangaroo.common.config.SystemConfiguration;
-import net.krotscheck.kangaroo.server.Config;
 import net.krotscheck.kangaroo.test.rule.DatabaseResource;
+import net.krotscheck.kangaroo.test.rule.WorkingDirectoryRule;
 import org.glassfish.jersey.internal.inject.InjectionManager;
 import org.glassfish.jersey.internal.inject.Injections;
 import org.hibernate.Session;
@@ -31,6 +31,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 
@@ -48,6 +49,12 @@ public final class FulltextSessionFactoryTest {
     public static final TestRule DATABASE = new DatabaseResource();
 
     /**
+     * Ensure that we have a working directory.
+     */
+    @Rule
+    public final TestRule workingDirectory = new WorkingDirectoryRule();
+
+    /**
      * The jersey application injector.
      */
     private InjectionManager injector;
@@ -57,8 +64,6 @@ public final class FulltextSessionFactoryTest {
      */
     @Before
     public void setup() {
-        System.setProperty(Config.WORKING_DIR.getKey(), "./target");
-
         injector = Injections.createInjectionManager();
         injector.register(new SystemConfiguration.Binder());
         injector.register(new HibernateServiceRegistryFactory.Binder());
@@ -75,8 +80,6 @@ public final class FulltextSessionFactoryTest {
     public void teardown() {
         injector.shutdown();
         injector = null;
-
-        System.clearProperty(Config.WORKING_DIR.getKey());
     }
 
     /**

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateServiceRegistryFactoryTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateServiceRegistryFactoryTest.java
@@ -20,9 +20,9 @@ package net.krotscheck.kangaroo.common.hibernate.factory;
 
 
 import net.krotscheck.kangaroo.common.config.SystemConfiguration;
-import net.krotscheck.kangaroo.server.Config;
 import net.krotscheck.kangaroo.test.TestConfig;
 import net.krotscheck.kangaroo.test.rule.DatabaseResource;
+import net.krotscheck.kangaroo.test.rule.WorkingDirectoryRule;
 import org.glassfish.jersey.internal.inject.InjectionManager;
 import org.glassfish.jersey.internal.inject.Injections;
 import org.hibernate.boot.MetadataSources;
@@ -30,10 +30,9 @@ import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.MariaDBDialect;
 import org.hibernate.service.ServiceRegistry;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 
@@ -55,20 +54,10 @@ public final class HibernateServiceRegistryFactoryTest {
     public static final TestRule DATABASE = new DatabaseResource();
 
     /**
-     * Setup the test.
+     * Ensure that we have a working directory.
      */
-    @Before
-    public void setupTest() {
-        System.setProperty(Config.WORKING_DIR.getKey(), "./target");
-    }
-
-    /**
-     * Teardown the test.
-     */
-    @After
-    public void teardownTest() {
-        System.clearProperty(Config.WORKING_DIR.getKey());
-    }
+    @Rule
+    public final TestRule workingDirectory = new WorkingDirectoryRule();
 
     /**
      * Test provide and dispose.

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateSessionFactoryFactoryTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateSessionFactoryFactoryTest.java
@@ -21,6 +21,7 @@ package net.krotscheck.kangaroo.common.hibernate.factory;
 import net.krotscheck.kangaroo.common.config.SystemConfiguration;
 import net.krotscheck.kangaroo.server.Config;
 import net.krotscheck.kangaroo.test.rule.DatabaseResource;
+import net.krotscheck.kangaroo.test.rule.WorkingDirectoryRule;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.internal.inject.InjectionManager;
 import org.glassfish.jersey.internal.inject.Injections;
@@ -54,6 +55,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 
@@ -74,20 +76,10 @@ public final class HibernateSessionFactoryFactoryTest {
     public static final TestRule DATABASE = new DatabaseResource();
 
     /**
-     * Setup the test.
+     * Ensure that we have a working directory.
      */
-    @Before
-    public void setupTest() {
-        System.setProperty(Config.WORKING_DIR.getKey(), "./target");
-    }
-
-    /**
-     * Teardown the test.
-     */
-    @After
-    public void teardownTest() {
-        System.clearProperty(Config.WORKING_DIR.getKey());
-    }
+    @Rule
+    public final TestRule workingDirectory = new WorkingDirectoryRule();
 
     /**
      * The jersey application injector.
@@ -99,8 +91,6 @@ public final class HibernateSessionFactoryFactoryTest {
      */
     @Before
     public void setup() {
-        System.setProperty(Config.WORKING_DIR.getKey(), "./target");
-
         injector = Injections.createInjectionManager();
         injector.register(new SystemConfiguration.Binder());
         injector.register(new HibernateServiceRegistryFactory.Binder());
@@ -116,8 +106,6 @@ public final class HibernateSessionFactoryFactoryTest {
     public void teardown() {
         injector.shutdown();
         injector = null;
-
-        System.clearProperty(Config.WORKING_DIR.getKey());
     }
 
     /**

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateSessionFactoryTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/factory/HibernateSessionFactoryTest.java
@@ -19,23 +19,19 @@
 package net.krotscheck.kangaroo.common.hibernate.factory;
 
 import net.krotscheck.kangaroo.common.config.SystemConfiguration;
-import net.krotscheck.kangaroo.server.Config;
 import net.krotscheck.kangaroo.test.rule.DatabaseResource;
+import net.krotscheck.kangaroo.test.rule.WorkingDirectoryRule;
 import org.glassfish.jersey.internal.inject.InjectionManager;
 import org.glassfish.jersey.internal.inject.Injections;
-import org.glassfish.jersey.server.ApplicationHandler;
-import org.glassfish.jersey.server.ResourceConfig;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
-
-import javax.ws.rs.core.Feature;
-import javax.ws.rs.core.FeatureContext;
 
 /**
  * The hibernate session factory test.
@@ -51,6 +47,12 @@ public final class HibernateSessionFactoryTest {
     public static final TestRule DATABASE = new DatabaseResource();
 
     /**
+     * Ensure that we have a working directory.
+     */
+    @Rule
+    public final TestRule workingDirectory = new WorkingDirectoryRule();
+
+    /**
      * The jersey application injector.
      */
     private InjectionManager injector;
@@ -60,8 +62,6 @@ public final class HibernateSessionFactoryTest {
      */
     @Before
     public void setup() {
-        System.setProperty(Config.WORKING_DIR.getKey(), "./target");
-
         injector = Injections.createInjectionManager();
         injector.register(new SystemConfiguration.Binder());
         injector.register(new HibernateServiceRegistryFactory.Binder());
@@ -77,8 +77,6 @@ public final class HibernateSessionFactoryTest {
     public void teardown() {
         injector.shutdown();
         injector = null;
-
-        System.clearProperty(Config.WORKING_DIR.getKey());
     }
 
     /**

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/ConfigTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/ConfigTest.java
@@ -57,6 +57,11 @@ public class ConfigTest {
         Assert.assertEquals("kangaroo.port", Config.PORT.getKey());
         Assert.assertEquals((Integer) 8080, Config.PORT.getValue());
 
+        Assert.assertEquals("kangaroo.working_dir",
+                Config.WORKING_DIR.getKey());
+        Assert.assertEquals("/var/lib/kangaroo",
+                Config.WORKING_DIR.getValue());
+
         Assert.assertEquals("kangaroo.keystore_path",
                 Config.KEYSTORE_PATH.getKey());
         Assert.assertNull(Config.KEYSTORE_PATH.getValue());

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/ConfigurationBuilderTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/ConfigurationBuilderTest.java
@@ -48,6 +48,7 @@ public final class ConfigurationBuilderTest {
                 .addCommandlineArgs(new String[]{
                         "-h=example.com",
                         "-p=9000",
+                        "--kangaroo.working_dir=/opt/kangaroo",
                         "--kangaroo.keystore_path=/foo/bar",
                         "--kangaroo.keystore_password=keystore_password",
                         "--kangaroo.keystore_type=JKS",
@@ -61,6 +62,8 @@ public final class ConfigurationBuilderTest {
                 Config.HOST.getKey()), "example.com");
         Assert.assertEquals(config.getInt(
                 Config.PORT.getKey()), 9000);
+        Assert.assertEquals(config.getString(
+                Config.WORKING_DIR.getKey()), "/opt/kangaroo");
         Assert.assertEquals(config.getString(
                 Config.KEYSTORE_PATH.getKey()), "/foo/bar");
         Assert.assertEquals(config.getString(
@@ -101,6 +104,7 @@ public final class ConfigurationBuilderTest {
 
         Assert.assertNull(config.getString(Config.HOST.getKey()));
         Assert.assertNull(config.getString(Config.PORT.getKey()));
+        Assert.assertNull(config.getString(Config.WORKING_DIR.getKey()));
         Assert.assertNull(config.getString(Config.KEYSTORE_PATH.getKey()));
         Assert.assertNull(config.getString(Config.KEYSTORE_PASS.getKey()));
         Assert.assertNull(config.getString(Config.KEYSTORE_TYPE.getKey()));
@@ -117,6 +121,7 @@ public final class ConfigurationBuilderTest {
         Map<String, Object> defaults = new HashMap<>();
         defaults.put(Config.HOST.getKey(), "example.com");
         defaults.put(Config.PORT.getKey(), "1000");
+        defaults.put(Config.WORKING_DIR.getKey(), "/foo/bar");
 
         Configuration config = new ConfigurationBuilder()
                 .withDefaults(defaults)
@@ -129,6 +134,8 @@ public final class ConfigurationBuilderTest {
                 config.getString(Config.HOST.getKey()));
         Assert.assertEquals(1000,
                 config.getInt(Config.PORT.getKey()));
+        Assert.assertEquals("/foo/bar",
+                config.getString(Config.WORKING_DIR.getKey()));
     }
 
     /**
@@ -148,6 +155,8 @@ public final class ConfigurationBuilderTest {
                 Config.HOST.getKey()), "example.com");
         Assert.assertEquals(config.getInt(
                 Config.PORT.getKey()), 9000);
+        Assert.assertEquals(config.getString(
+                Config.WORKING_DIR.getKey()), "/opt/kangaroo");
         Assert.assertEquals(config.getString(
                 Config.KEYSTORE_PATH.getKey()), "/foo/bar");
         Assert.assertEquals(config.getString(
@@ -174,6 +183,7 @@ public final class ConfigurationBuilderTest {
 
         Assert.assertNull(config.getString(Config.HOST.getKey()));
         Assert.assertNull(config.getString(Config.PORT.getKey()));
+        Assert.assertNull(config.getString(Config.WORKING_DIR.getKey()));
         Assert.assertNull(config.getString(Config.KEYSTORE_PATH.getKey()));
         Assert.assertNull(config.getString(Config.KEYSTORE_PASS.getKey()));
         Assert.assertNull(config.getString(Config.KEYSTORE_TYPE.getKey()));
@@ -199,6 +209,7 @@ public final class ConfigurationBuilderTest {
 
         Assert.assertNull(config.getString(Config.HOST.getKey()));
         Assert.assertNull(config.getString(Config.PORT.getKey()));
+        Assert.assertNull(config.getString(Config.WORKING_DIR.getKey()));
         Assert.assertNull(config.getString(Config.KEYSTORE_PATH.getKey()));
         Assert.assertNull(config.getString(Config.KEYSTORE_PASS.getKey()));
         Assert.assertNull(config.getString(Config.KEYSTORE_TYPE.getKey()));

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/ServerFactoryTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/ServerFactoryTest.java
@@ -256,8 +256,6 @@ public class ServerFactoryTest {
      */
     @Test
     public void testConfigureServer() throws Exception {
-        Path appRoot = Paths.get("src/test/resources/html/index");
-
         ServerFactory f = new ServerFactory()
                 .configureServer(s -> {
                     s.getServerConfiguration().setSessionTimeoutSeconds(1000);

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jersey/KangarooJerseyTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jersey/KangarooJerseyTest.java
@@ -19,6 +19,7 @@
 package net.krotscheck.kangaroo.test.jersey;
 
 import net.krotscheck.kangaroo.common.jackson.JacksonFeature;
+import net.krotscheck.kangaroo.test.rule.WorkingDirectoryRule;
 import org.glassfish.grizzly.http.server.ServerConfiguration;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
@@ -54,6 +55,12 @@ public abstract class KangarooJerseyTest extends JerseyTest {
             SLF4JBridgeHandler.install();
         }
     }
+
+    /**
+     * Ensure that we have a working directory.
+     */
+    @Rule
+    public final TestRule workingDirectory = new WorkingDirectoryRule();
 
     /**
      * Rules applicable to each test.

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/HibernateResource.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/HibernateResource.java
@@ -20,7 +20,10 @@ package net.krotscheck.kangaroo.test.rule;
 
 import net.krotscheck.kangaroo.common.hibernate.factory.HibernateServiceRegistryFactory;
 import net.krotscheck.kangaroo.common.hibernate.listener.CreatedUpdatedListener;
+import net.krotscheck.kangaroo.server.Config;
 import net.krotscheck.kangaroo.test.rule.hibernate.TestDirectoryProvider;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.PropertiesConfiguration;
 import org.hibernate.SessionFactory;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.event.service.spi.EventListenerRegistry;
@@ -57,6 +60,20 @@ public class HibernateResource implements TestRule {
      * Internal session factory, reconstructed for every test run.
      */
     private SessionFactory sessionFactory;
+
+    /**
+     * Override system configuration.
+     */
+    private Configuration systemConfiguration;
+
+    /**
+     * Constructor.
+     */
+    public HibernateResource() {
+        systemConfiguration = new PropertiesConfiguration();
+        systemConfiguration.setProperty(Config.WORKING_DIR.getKey(),
+                "./target");
+    }
 
     /**
      * Create and return a hibernate session factory the test database.
@@ -131,7 +148,8 @@ public class HibernateResource implements TestRule {
         sessionFactory = null;
 
         logger.debug("Disposing ServiceRegistry");
-        new HibernateServiceRegistryFactory().dispose(registry);
+        new HibernateServiceRegistryFactory(systemConfiguration)
+                .dispose(registry);
     }
 
     /**
@@ -140,7 +158,8 @@ public class HibernateResource implements TestRule {
     private void createHibernateConnection() {
         // Create the session factory.
         logger.debug("Creating ServiceRegistry");
-        registry = new HibernateServiceRegistryFactory().get();
+        registry = new HibernateServiceRegistryFactory(systemConfiguration)
+                .get();
 
         logger.debug("Creating SessionFactory");
         sessionFactory = new MetadataSources(registry)

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/HibernateResource.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/HibernateResource.java
@@ -64,16 +64,8 @@ public class HibernateResource implements TestRule {
     /**
      * Override system configuration.
      */
-    private Configuration systemConfiguration;
-
-    /**
-     * Constructor.
-     */
-    public HibernateResource() {
-        systemConfiguration = new PropertiesConfiguration();
-        systemConfiguration.setProperty(Config.WORKING_DIR.getKey(),
-                "./target");
-    }
+    private final Configuration systemConfiguration
+            = new PropertiesConfiguration();
 
     /**
      * Create and return a hibernate session factory the test database.

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/WorkingDirectoryRule.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/rule/WorkingDirectoryRule.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.test.rule;
+
+import com.google.common.io.Files;
+import net.krotscheck.kangaroo.server.Config;
+import org.apache.commons.io.FileUtils;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.io.File;
+
+/**
+ * This JUnit4 Rule creates, and tears down, a kangaroo 'working' directory,
+ * and updates the necessary systme properties.
+ *
+ * @author Michael Krotscheck
+ */
+public final class WorkingDirectoryRule implements TestRule {
+
+    /**
+     * The working directory.
+     */
+    private File workingDir;
+
+    /**
+     * Get the working directory.
+     *
+     * @return The working dir, guaranteed to exist and be unique.
+     */
+    public File getWorkingDir() {
+        return workingDir;
+    }
+
+    /**
+     * Modifies the method-running {@link Statement} to implement this
+     * test-running rule.
+     *
+     * @param base        The {@link Statement} to be modified
+     * @param description A {@link Description} of the test implemented in
+     *                    {@code base}
+     * @return a new statement, which may be the same as {@code base},
+     * a wrapper around {@code base}, or a completely new Statement.
+     */
+    @Override
+    public Statement apply(final Statement base,
+                           final Description description) {
+        return new Statement() {
+
+            @Override
+            public void evaluate() throws Throwable {
+                workingDir = Files.createTempDir();
+                System.setProperty(Config.WORKING_DIR.getKey(),
+                        workingDir.getAbsolutePath());
+                try {
+                    // Evaluate the next round of tests.
+                    base.evaluate();
+                } finally {
+                    System.clearProperty(Config.WORKING_DIR.getKey());
+                    FileUtils.deleteDirectory(workingDir);
+                }
+
+            }
+        };
+    }
+}

--- a/kangaroo-common/src/test/resources/config/test.properties
+++ b/kangaroo-common/src/test/resources/config/test.properties
@@ -17,6 +17,7 @@
 
 kangaroo.host=example.com
 kangaroo.port=9000
+kangaroo.working_dir=/opt/kangaroo
 kangaroo.keystore_path=/foo/bar
 kangaroo.keystore_password=keystore_password
 kangaroo.keystore_type=JKS

--- a/kangaroo-common/src/test/resources/hibernate.cfg.xml
+++ b/kangaroo-common/src/test/resources/hibernate.cfg.xml
@@ -22,12 +22,6 @@
 
 <hibernate-configuration>
   <session-factory>
-    <property name="hibernate.connection.url">jdbc:h2:file:./target/h2.test.db</property>
-    <property name="hibernate.connection.username">oid</property>
-    <property name="hibernate.connection.password">oid</property>
-    <property name="hibernate.connection.driver_class">org.h2.Driver</property>
-    <property name="hibernate.dialect">org.hibernate.dialect.H2Dialect</property>
-
     <!-- Generic hibernate configuration -->
     <property name="current_session_context_class">
       org.hibernate.context.internal.ThreadLocalSessionContext

--- a/kangaroo-server-authz/src/main/resources/hibernate.cfg.xml
+++ b/kangaroo-server-authz/src/main/resources/hibernate.cfg.xml
@@ -22,12 +22,6 @@
 
 <hibernate-configuration>
   <session-factory>
-    <property name="hibernate.connection.url">jdbc:h2:file:/var/lib/kangaroo-authz/h2.db</property>
-    <property name="hibernate.connection.username">oid</property>
-    <property name="hibernate.connection.password">oid</property>
-    <property name="hibernate.connection.driver_class">org.h2.Driver</property>
-    <property name="hibernate.dialect">org.hibernate.dialect.H2Dialect</property>
-
     <!-- Generic hibernate configuration -->
     <property name="current_session_context_class">
       org.hibernate.context.internal.ThreadLocalSessionContext

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/AuthenticatorFeatureTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/AuthenticatorFeatureTest.java
@@ -19,6 +19,7 @@
 package net.krotscheck.kangaroo.authz.common.authenticator;
 
 import net.krotscheck.kangaroo.authz.common.database.DatabaseFeature;
+import net.krotscheck.kangaroo.common.config.ConfigurationFeature;
 import net.krotscheck.kangaroo.common.hibernate.HibernateFeature;
 import net.krotscheck.kangaroo.common.httpClient.HttpClientFeature;
 import net.krotscheck.kangaroo.test.jersey.ContainerTest;
@@ -52,6 +53,7 @@ public final class AuthenticatorFeatureTest extends ContainerTest {
     protected ResourceConfig createApplication() {
         ResourceConfig a = new ResourceConfig();
         a.register(HttpClientFeature.class);
+        a.register(ConfigurationFeature.class);
         a.register(DatabaseFeature.class);
         a.register(HibernateFeature.class);
         a.register(AuthenticatorFeature.class);

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/DatabaseFeatureTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/DatabaseFeatureTest.java
@@ -18,6 +18,7 @@
 
 package net.krotscheck.kangaroo.authz.common.database;
 
+import net.krotscheck.kangaroo.common.config.ConfigurationFeature;
 import net.krotscheck.kangaroo.common.hibernate.listener.CreatedUpdatedListener;
 import net.krotscheck.kangaroo.test.jersey.ContainerTest;
 import org.glassfish.jersey.internal.inject.InjectionManager;
@@ -51,6 +52,7 @@ public final class DatabaseFeatureTest extends ContainerTest {
     @Override
     protected ResourceConfig createApplication() {
         ResourceConfig a = new ResourceConfig();
+        a.register(ConfigurationFeature.class);
         a.register(DatabaseFeature.class);
         a.register(MockService.class);
         return a;


### PR DESCRIPTION
This pull request creates the notion of a "Working Directory" nominally at `/var/run/kangaroo` that contains runtime resources for the server. These resources (at this time) only include the generated h2 database (if running in h2 mode) and the generated self-signed server certificate store (if none was provided), however it can be expanded in the future for other purposes (lucene indexes for instance).

The most notable improvement is that state will be maintained between restarts with no special configuration. The h2 database will remain, as will the certificate.

Closes #375 