### PR TITLE
Added our own CSRF protections.

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/security/CsrfProtectionFilter.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/security/CsrfProtectionFilter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.security;
+
+import com.google.common.collect.Sets;
+
+import javax.annotation.Priority;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import java.util.Set;
+
+/**
+ * A CSRFProtection filter which, unlike Jersey2's, uses the X-Requested-With
+ * header as a check. To check whether this code still needs to exist, please
+ * see: https://github.com/jersey/jersey/issues/3717
+ *
+ * @author Michael Krotscheck
+ */
+@Priority(Priorities.AUTHENTICATION)
+public final class CsrfProtectionFilter implements ContainerRequestFilter {
+
+    /**
+     * The header we use as a sanity check.
+     */
+    private static final String HEADER = "X-Requested-With";
+
+    /**
+     * Short list of methods to ignore.
+     */
+    private static final Set<String> METHODS_TO_IGNORE =
+            Sets.newHashSet("GET", "OPTIONS", "HEAD");
+
+    /**
+     * Check the request for the header.
+     *
+     * @param request The request context.
+     */
+    @Override
+    public void filter(final ContainerRequestContext request) {
+        if (METHODS_TO_IGNORE.contains(request.getMethod())) {
+            return;
+        }
+
+        if (request.getHeaders().containsKey(HEADER)) {
+            return;
+        }
+
+        throw new BadRequestException();
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/security/SecurityFeature.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/security/SecurityFeature.java
@@ -18,8 +18,6 @@
 
 package net.krotscheck.kangaroo.common.security;
 
-import org.glassfish.jersey.server.filter.CsrfProtectionFilter;
-
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/security/CsrfProtectionFilterTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/security/CsrfProtectionFilterTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.security;
+
+import com.google.common.collect.Sets;
+import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.container.ContainerRequestContext;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for our custom protection filter.
+ *
+ * @author Michael Krotscheck
+ */
+public final class CsrfProtectionFilterTest {
+
+    /**
+     * Mock request.
+     */
+    private ContainerRequestContext mockContext;
+
+    /**
+     * Setup the test.
+     */
+    @Before
+    public void setup() {
+        mockContext = mock(ContainerRequestContext.class);
+    }
+
+    /**
+     * Assert that GET/OPTIONS/HEAD are ignored.
+     */
+    @Test
+    public void assertIgnoresBasicMethods() {
+        CsrfProtectionFilter filter = new CsrfProtectionFilter();
+
+        Sets.newHashSet("GET", "OPTIONS", "HEAD")
+                .forEach((method) -> {
+                    doReturn(method).when(mockContext).getMethod();
+                    filter.filter(mockContext);
+                });
+    }
+
+    /**
+     * Assert that the filter will fail the request if no header is included.
+     */
+    @Test(expected = BadRequestException.class)
+    public void assertFailsWithoutHeader() {
+        CsrfProtectionFilter filter = new CsrfProtectionFilter();
+        doReturn("POST").when(mockContext).getMethod();
+
+        MultivaluedStringMap map = new MultivaluedStringMap();
+        doReturn(map).when(mockContext).getHeaders();
+        filter.filter(mockContext);
+    }
+
+    /**
+     * Ensure that the header passes.
+     */
+    @Test
+    public void assertPassesWithHeader() {
+        CsrfProtectionFilter filter = new CsrfProtectionFilter();
+        doReturn("POST").when(mockContext).getMethod();
+
+        MultivaluedStringMap map = new MultivaluedStringMap();
+        map.putSingle("X-Requested-With", "Test");
+        doReturn(map).when(mockContext).getHeaders();
+        filter.filter(mockContext);
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jersey/CsrfProtectionFilter.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jersey/CsrfProtectionFilter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.test.jersey;
+
+import org.mockito.internal.util.collections.Sets;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import java.util.Set;
+
+/**
+ * A client API filter which automatically applies the X-Requested-With header.
+ *
+ * @author Michael Krotscheck
+ */
+public final class CsrfProtectionFilter implements ClientRequestFilter {
+
+    /**
+     * Name of the header this filter will attach to the request.
+     */
+    public static final String HEADER = "X-Requested-With";
+
+    /**
+     * Request methods to ignore.
+     */
+    private static final Set<String> METHODS_TO_IGNORE
+            = Sets.newSet("GET", "OPTIONS", "HEAD");
+
+    /**
+     * Apply the header.
+     *
+     * @param request The request.
+     */
+    @Override
+    public void filter(final ClientRequestContext request) {
+        if (!METHODS_TO_IGNORE.contains(request.getMethod())
+                && !request.getHeaders().containsKey(HEADER)) {
+            request.getHeaders().add(HEADER, "Kangaroo Test Harness");
+        }
+    }
+}
+

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jersey/KangarooJerseyTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jersey/KangarooJerseyTest.java
@@ -22,7 +22,6 @@ import net.krotscheck.kangaroo.common.jackson.JacksonFeature;
 import org.glassfish.grizzly.http.server.ServerConfiguration;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
-import org.glassfish.jersey.client.filter.CsrfProtectionFilter;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.glassfish.jersey.test.DeploymentContext;


### PR DESCRIPTION
The default CSRF filter that ships with jersey uses a non-standard
header of X-Requested-By instead of the OSRF standard X-Requested-With.
We've built our own to replace it.