### PR TITLE
Removed Grizzly name and version

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/ServerFactory.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/ServerFactory.java
@@ -289,6 +289,9 @@ public final class ServerFactory {
         // Map the path to the processor.
         final ServerConfiguration serverConfiguration =
                 server.getServerConfiguration();
+        serverConfiguration.setHttpServerName("Kangaroo");
+        serverConfiguration.setHttpServerVersion("");
+
         serverConfiguration.setPassTraceRequest(true);
         serverConfiguration.setDefaultQueryEncoding(Charsets.UTF8_CHARSET);
         serverLambdas.forEach(s -> s.operation(server));


### PR DESCRIPTION
Exposing version is a security issue. Replaced Grizzly with Kangaroo,
removed version entirely.