### PR TITLE
Truncate milliseconds from dates.

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/listener/CreatedUpdatedListener.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/listener/CreatedUpdatedListener.java
@@ -56,6 +56,8 @@ public final class CreatedUpdatedListener
         Object entity = event.getEntity();
         Object[] state = event.getState();
         Calendar now = Calendar.getInstance(timeZone);
+        // Some databases don't support milliseconds.
+        now.set(Calendar.MILLISECOND, 0);
 
         if (entity instanceof ICreatedDateEntity) {
             String[] propertyNames = event.getPersister().getEntityMetamodel()


### PR DESCRIPTION
While not optimal - most token age calculations are second, not millisecond
based. Additionally, not all databases support that granularity of datestamp
data, so we're going to outright truncate them when created.