### PR TITLE
Entities now deserialize using unix timestamp.

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/entity/AbstractEntity.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/entity/AbstractEntity.java
@@ -111,8 +111,7 @@ public abstract class AbstractEntity implements Cloneable,
             + ".CalendarTimestampType")
     @ApiModelProperty(
             readOnly = true,
-            example = "2017-11-16T02:39:27Z"
-    )
+            example = "2017-11-16T02:39:27Z")
     private Calendar createdDate;
 
     /**
@@ -123,8 +122,7 @@ public abstract class AbstractEntity implements Cloneable,
             + ".CalendarTimestampType")
     @ApiModelProperty(
             readOnly = true,
-            example = "2017-11-16T02:39:27Z"
-    )
+            example = "2017-11-16T02:39:27Z")
     private Calendar modifiedDate;
 
     /**

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/jackson/types/KangarooCustomTypesModule.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/jackson/types/KangarooCustomTypesModule.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.module.SimpleSerializers;
 import javax.inject.Singleton;
 import javax.ws.rs.ext.Provider;
 import java.math.BigInteger;
+import java.util.Calendar;
 
 /**
  * This Jackson Module registers all the necessary De/Serializers for proper
@@ -80,10 +81,14 @@ public final class KangarooCustomTypesModule extends Module {
         SimpleDeserializers des = new SimpleDeserializers();
         des.addDeserializer(BigInteger.class,
                 new Base16BigIntegerDeserializer());
+        des.addDeserializer(Calendar.class,
+                new UnixTimestampDeserializer());
 
         SimpleSerializers ser = new SimpleSerializers();
         ser.addSerializer(BigInteger.class,
                 new Base16BigIntegerSerializer());
+        ser.addSerializer(Calendar.class,
+                new UnixTimestampSerializer());
 
         context.addDeserializers(des);
         context.addSerializers(ser);

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/jackson/types/UnixTimestampDeserializer.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/jackson/types/UnixTimestampDeserializer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.jackson.types;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import javax.inject.Singleton;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.util.Calendar;
+
+/**
+ * Second-precision deserializer for UTC Calendar timestamps.
+ *
+ * @author Michael Krotscheck
+ */
+@Provider
+@Singleton
+public final class UnixTimestampDeserializer
+        extends JsonDeserializer<Calendar> {
+
+    /**
+     * Deserialize a JSON value (usually a string) into a byte array.
+     *
+     * @param p    The JSON parser.
+     * @param ctxt The serialization context.
+     * @return The value as a byte array.
+     * @throws IOException             Not thrown.
+     */
+    @Override
+    public Calendar deserialize(final JsonParser p,
+                                final DeserializationContext ctxt)
+            throws IOException {
+        long timestamp = p.getValueAsLong() * 1000;
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTimeInMillis(timestamp);
+        return calendar;
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/jackson/types/UnixTimestampSerializer.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/jackson/types/UnixTimestampSerializer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.jackson.types;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import javax.inject.Singleton;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.util.Calendar;
+
+/**
+ * Second-precision serializer for UTC Calendar timestamps.
+ *
+ * @author Michael Krotscheck
+ */
+@Provider
+@Singleton
+public final class UnixTimestampSerializer
+        extends JsonSerializer<Calendar> {
+
+    @Override
+    public void serialize(final Calendar value,
+                          final JsonGenerator gen,
+                          final SerializerProvider serializers)
+            throws IOException {
+        gen.writeNumber(value.getTimeInMillis() / 1000);
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/jackson/types/KangarooCustomTypesModuleTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/jackson/types/KangarooCustomTypesModuleTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.math.BigInteger;
+import java.util.Calendar;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -85,15 +86,22 @@ public final class KangarooCustomTypesModuleTest {
 
         TypeFactory t = TypeFactory.defaultInstance();
         JavaType bigIntegerType = t.constructType(BigInteger.class);
+        JavaType calendarType = t.constructType(Calendar.class);
 
         SimpleSerializers s = (SimpleSerializers) serializers.getValue();
         JsonSerializer byteSerializer =
                 s.findSerializer(null, bigIntegerType, null);
         assertTrue(byteSerializer instanceof Base16BigIntegerSerializer);
+        JsonSerializer calSerializer =
+                s.findSerializer(null, calendarType, null);
+        assertTrue(calSerializer instanceof UnixTimestampSerializer);
 
         SimpleDeserializers d = (SimpleDeserializers) deserializers.getValue();
         JsonDeserializer byteDeserializer =
                 d.findBeanDeserializer(bigIntegerType, null, null);
         assertTrue(byteDeserializer instanceof Base16BigIntegerDeserializer);
+        JsonDeserializer calDeserializer =
+                d.findBeanDeserializer(calendarType, null, null);
+        assertTrue(calDeserializer instanceof UnixTimestampDeserializer);
     }
 }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/jackson/types/UnixTimestampDeserializerTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/jackson/types/UnixTimestampDeserializerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.jackson.types;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import org.junit.Test;
+
+import java.util.Calendar;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test string-to-byte deserialization.
+ *
+ * @author Michael Krotscheck
+ */
+public class UnixTimestampDeserializerTest {
+
+    /**
+     * Assert that we can access this class as its generic type.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testGenericConstructor() throws Exception {
+        Calendar c = Calendar.getInstance();
+        c.set(Calendar.MILLISECOND, 0);
+
+        long unixTimestamp = c.getTimeInMillis() / 1000;
+        String idBody = String.format("%s", unixTimestamp);
+
+        JsonFactory f = new JsonFactory();
+        JsonParser preloadedParser = f.createParser(idBody);
+        preloadedParser.nextToken(); // Advance to the first value.
+
+        JsonDeserializer deserializer = new UnixTimestampDeserializer();
+        Calendar deserialized = (Calendar)
+                deserializer.deserialize(preloadedParser,
+                        mock(DeserializationContext.class));
+
+        assertEquals(c, deserialized);
+    }
+
+    /**
+     * Assert that deserialization works.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void deserialize() throws Exception {
+        Calendar c = Calendar.getInstance();
+        c.set(Calendar.MILLISECOND, 0);
+
+        long unixTimestamp = c.getTimeInMillis() / 1000;
+        String idBody = String.format("%s", unixTimestamp);
+
+        JsonFactory f = new JsonFactory();
+        JsonParser preloadedParser = f.createParser(idBody);
+        preloadedParser.nextToken(); // Advance to the first value.
+
+        UnixTimestampDeserializer deserializer = new UnixTimestampDeserializer();
+        Calendar deserialized = (Calendar)
+                deserializer.deserialize(preloadedParser,
+                        mock(DeserializationContext.class));
+
+        assertEquals(c, deserialized);
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/jackson/types/UnixTimestampSerializerTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/jackson/types/UnixTimestampSerializerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2017 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.jackson.types;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import org.junit.Test;
+
+import java.util.Calendar;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for the timestamp serializer.
+ *
+ * @author Michael Krotscheck
+ */
+public class UnixTimestampSerializerTest {
+
+    /**
+     * Assert that we can access this class as its generic type.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testGenericConstructor() throws Exception {
+        Calendar c = Calendar.getInstance();
+        long unixTimestamp = c.getTimeInMillis() / 1000;
+
+        JsonSerializer serializer = new UnixTimestampSerializer();
+        JsonGenerator generator = mock(JsonGenerator.class);
+
+        serializer.serialize(c, generator, null);
+
+        verify(generator).writeNumber(unixTimestamp);
+    }
+
+    /**
+     * Assert that deserialization works.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void deserialize() throws Exception {
+        Calendar c = Calendar.getInstance();
+        long unixTimestamp = c.getTimeInMillis() / 1000;
+
+        UnixTimestampSerializer serializer = new UnixTimestampSerializer();
+        JsonGenerator generator = mock(JsonGenerator.class);
+
+        serializer.serialize(c, generator, null);
+
+        verify(generator).writeNumber(unixTimestamp);
+    }
+
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/ApplicationScopeTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/ApplicationScopeTest.java
@@ -146,17 +146,15 @@ public final class ApplicationScopeTest {
         String output = m.writeValueAsString(a);
         JsonNode node = m.readTree(output);
 
-        DateFormat format = new ISO8601DateFormat();
-
         Assert.assertEquals(
                 IdUtil.toString(a.getId()),
                 node.get("id").asText());
         Assert.assertEquals(
-                format.format(a.getCreatedDate().getTime()),
-                node.get("createdDate").asText());
+                a.getCreatedDate().getTimeInMillis() / 1000,
+                node.get("createdDate").asLong());
         Assert.assertEquals(
-                format.format(a.getCreatedDate().getTime()),
-                node.get("modifiedDate").asText());
+                a.getModifiedDate().getTimeInMillis() / 1000,
+                node.get("modifiedDate").asLong());
         Assert.assertEquals(
                 IdUtil.toString(a.getApplication().getId()),
                 node.get("application").asText());
@@ -181,13 +179,11 @@ public final class ApplicationScopeTest {
     @Test
     public void testJacksonDeserializable() throws Exception {
         ObjectMapper m = new ObjectMapperFactory().get();
-        DateFormat format = new ISO8601DateFormat();
+        long timestamp = Calendar.getInstance().getTimeInMillis() / 1000;
         ObjectNode node = m.createObjectNode();
         node.put("id", IdUtil.toString(IdUtil.next()));
-        node.put("createdDate",
-                format.format(Calendar.getInstance().getTime()));
-        node.put("modifiedDate",
-                format.format(Calendar.getInstance().getTime()));
+        node.put("createdDate", timestamp);
+        node.put("modifiedDate", timestamp);
         node.put("name", "name");
         node.put("application", IdUtil.toString(IdUtil.next()));
 
@@ -198,11 +194,11 @@ public final class ApplicationScopeTest {
                 IdUtil.toString(a.getId()),
                 node.get("id").asText());
         Assert.assertEquals(
-                format.format(a.getCreatedDate().getTime()),
-                node.get("createdDate").asText());
+                a.getCreatedDate().getTimeInMillis() / 1000,
+                node.get("createdDate").asLong());
         Assert.assertEquals(
-                format.format(a.getModifiedDate().getTime()),
-                node.get("modifiedDate").asText());
+                a.getModifiedDate().getTimeInMillis() / 1000,
+                node.get("modifiedDate").asLong());
         Assert.assertEquals(
                 a.getName(),
                 node.get("name").asText());

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/ApplicationTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/ApplicationTest.java
@@ -207,7 +207,6 @@ public final class ApplicationTest {
 
         // De/serialize to json.
         ObjectMapper m = new ObjectMapperFactory().get();
-        DateFormat format = new ISO8601DateFormat();
         String output = m.writeValueAsString(a);
         JsonNode node = m.readTree(output);
 
@@ -215,11 +214,11 @@ public final class ApplicationTest {
                 IdUtil.toString(a.getId()),
                 node.get("id").asText());
         Assert.assertEquals(
-                format.format(a.getCreatedDate().getTime()),
-                node.get("createdDate").asText());
+                a.getCreatedDate().getTimeInMillis() / 1000,
+                node.get("createdDate").asLong());
         Assert.assertEquals(
-                format.format(a.getCreatedDate().getTime()),
-                node.get("modifiedDate").asText());
+                a.getModifiedDate().getTimeInMillis() / 1000,
+                node.get("modifiedDate").asLong());
         Assert.assertEquals(
                 IdUtil.toString(a.getOwner().getId()),
                 node.get("owner").asText());
@@ -253,13 +252,11 @@ public final class ApplicationTest {
     @Test
     public void testJacksonDeserializable() throws Exception {
         ObjectMapper m = new ObjectMapperFactory().get();
-        DateFormat format = new ISO8601DateFormat();
+        long timestamp = Calendar.getInstance().getTimeInMillis() / 1000;
         ObjectNode node = m.createObjectNode();
         node.put("id", IdUtil.toString(IdUtil.next()));
-        node.put("createdDate",
-                format.format(Calendar.getInstance().getTime()));
-        node.put("modifiedDate",
-                format.format(Calendar.getInstance().getTime()));
+        node.put("createdDate", timestamp);
+        node.put("modifiedDate", timestamp);
         node.put("name", "name");
         node.put("description", "description");
         node.put("owner", IdUtil.toString(IdUtil.next()));
@@ -271,11 +268,11 @@ public final class ApplicationTest {
                 IdUtil.toString(a.getId()),
                 node.get("id").asText());
         Assert.assertEquals(
-                format.format(a.getCreatedDate().getTime()),
-                node.get("createdDate").asText());
+                a.getCreatedDate().getTimeInMillis() / 1000,
+                node.get("createdDate").asLong());
         Assert.assertEquals(
-                format.format(a.getModifiedDate().getTime()),
-                node.get("modifiedDate").asText());
+                a.getModifiedDate().getTimeInMillis() / 1000,
+                node.get("modifiedDate").asLong());
         Assert.assertEquals(
                 a.getName(),
                 node.get("name").asText());

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/AuthenticatorTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/AuthenticatorTest.java
@@ -161,7 +161,6 @@ public final class AuthenticatorTest {
 
         // De/serialize to json.
         ObjectMapper m = new ObjectMapperFactory().get();
-        DateFormat format = new ISO8601DateFormat();
         String output = m.writeValueAsString(a);
         JsonNode node = m.readTree(output);
 
@@ -169,11 +168,11 @@ public final class AuthenticatorTest {
                 IdUtil.toString(a.getId()),
                 node.get("id").asText());
         Assert.assertEquals(
-                format.format(a.getCreatedDate().getTime()),
-                node.get("createdDate").asText());
+                a.getCreatedDate().getTimeInMillis() / 1000,
+                node.get("createdDate").asLong());
         Assert.assertEquals(
-                format.format(a.getCreatedDate().getTime()),
-                node.get("modifiedDate").asText());
+                a.getModifiedDate().getTimeInMillis() / 1000,
+                node.get("modifiedDate").asLong());
 
         Assert.assertEquals(
                 IdUtil.toString(a.getClient().getId()),
@@ -211,13 +210,11 @@ public final class AuthenticatorTest {
     @Test
     public void testJacksonDeserializable() throws Exception {
         ObjectMapper m = new ObjectMapperFactory().get();
-        DateFormat format = new ISO8601DateFormat();
+        long timestamp = Calendar.getInstance().getTimeInMillis() / 1000;
         ObjectNode node = m.createObjectNode();
         node.put("id", IdUtil.toString(IdUtil.next()));
-        node.put("createdDate",
-                format.format(Calendar.getInstance().getTime()));
-        node.put("modifiedDate",
-                format.format(Calendar.getInstance().getTime()));
+        node.put("createdDate", timestamp);
+        node.put("modifiedDate", timestamp);
         node.put("type", AuthenticatorType.Test.toString());
 
         ObjectNode configNode = m.createObjectNode();
@@ -232,11 +229,11 @@ public final class AuthenticatorTest {
                 IdUtil.toString(a.getId()),
                 node.get("id").asText());
         Assert.assertEquals(
-                format.format(a.getCreatedDate().getTime()),
-                node.get("createdDate").asText());
+                a.getCreatedDate().getTimeInMillis() / 1000,
+                node.get("createdDate").asLong());
         Assert.assertEquals(
-                format.format(a.getModifiedDate().getTime()),
-                node.get("modifiedDate").asText());
+                a.getModifiedDate().getTimeInMillis() / 1000,
+                node.get("modifiedDate").asLong());
 
         Assert.assertEquals(
                 a.getType().toString(),

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/ClientRedirectTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/ClientRedirectTest.java
@@ -113,7 +113,6 @@ public final class ClientRedirectTest {
 
         // De/serialize to json.
         ObjectMapper m = new ObjectMapperFactory().get();
-        DateFormat format = new ISO8601DateFormat();
         String output = m.writeValueAsString(r);
         JsonNode node = m.readTree(output);
 
@@ -121,11 +120,11 @@ public final class ClientRedirectTest {
                 IdUtil.toString(r.getId()),
                 node.get("id").asText());
         Assert.assertEquals(
-                format.format(r.getCreatedDate().getTime()),
-                node.get("createdDate").asText());
+                r.getCreatedDate().getTimeInMillis() / 1000,
+                node.get("createdDate").asLong());
         Assert.assertEquals(
-                format.format(r.getCreatedDate().getTime()),
-                node.get("modifiedDate").asText());
+                r.getModifiedDate().getTimeInMillis() / 1000,
+                node.get("modifiedDate").asLong());
 
         Assert.assertEquals(
                 r.getUri().toString(),
@@ -148,13 +147,11 @@ public final class ClientRedirectTest {
     @Test
     public void testJacksonDeserializable() throws Exception {
         ObjectMapper m = new ObjectMapperFactory().get();
-        DateFormat format = new ISO8601DateFormat();
+        long timestamp = Calendar.getInstance().getTimeInMillis() / 1000;
         ObjectNode node = m.createObjectNode();
         node.put("id", IdUtil.toString(IdUtil.next()));
-        node.put("createdDate",
-                format.format(Calendar.getInstance().getTime()));
-        node.put("modifiedDate",
-                format.format(Calendar.getInstance().getTime()));
+        node.put("createdDate", timestamp);
+        node.put("modifiedDate", timestamp);
         node.put("client", IdUtil.toString(IdUtil.next()));
         node.put("uri", "http://example.com/");
 
@@ -165,11 +162,11 @@ public final class ClientRedirectTest {
                 IdUtil.toString(r.getId()),
                 node.get("id").asText());
         Assert.assertEquals(
-                format.format(r.getCreatedDate().getTime()),
-                node.get("createdDate").asText());
+                r.getCreatedDate().getTimeInMillis() / 1000,
+                node.get("createdDate").asLong());
         Assert.assertEquals(
-                format.format(r.getModifiedDate().getTime()),
-                node.get("modifiedDate").asText());
+                r.getModifiedDate().getTimeInMillis() / 1000,
+                node.get("modifiedDate").asLong());
 
         Assert.assertEquals(
                 r.getUri().toString(),

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/ClientReferrerTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/ClientReferrerTest.java
@@ -113,7 +113,6 @@ public final class ClientReferrerTest {
 
         // De/serialize to json.
         ObjectMapper m = new ObjectMapperFactory().get();
-        DateFormat format = new ISO8601DateFormat();
         String output = m.writeValueAsString(r);
         JsonNode node = m.readTree(output);
 
@@ -121,11 +120,11 @@ public final class ClientReferrerTest {
                 IdUtil.toString(r.getId()),
                 node.get("id").asText());
         Assert.assertEquals(
-                format.format(r.getCreatedDate().getTime()),
-                node.get("createdDate").asText());
+                r.getCreatedDate().getTimeInMillis() / 1000,
+                node.get("createdDate").asLong());
         Assert.assertEquals(
-                format.format(r.getCreatedDate().getTime()),
-                node.get("modifiedDate").asText());
+                r.getModifiedDate().getTimeInMillis() / 1000,
+                node.get("modifiedDate").asLong());
 
         Assert.assertEquals(
                 r.getUri().toString(),
@@ -148,13 +147,11 @@ public final class ClientReferrerTest {
     @Test
     public void testJacksonDeserializable() throws Exception {
         ObjectMapper m = new ObjectMapperFactory().get();
-        DateFormat format = new ISO8601DateFormat();
+        long timestamp = Calendar.getInstance().getTimeInMillis() / 1000;
         ObjectNode node = m.createObjectNode();
         node.put("id", IdUtil.toString(IdUtil.next()));
-        node.put("createdDate",
-                format.format(Calendar.getInstance().getTime()));
-        node.put("modifiedDate",
-                format.format(Calendar.getInstance().getTime()));
+        node.put("createdDate", timestamp);
+        node.put("modifiedDate", timestamp);
         node.put("client", IdUtil.toString(IdUtil.next()));
         node.put("uri", "http://example.com/");
 
@@ -165,11 +162,11 @@ public final class ClientReferrerTest {
                 IdUtil.toString(r.getId()),
                 node.get("id").asText());
         Assert.assertEquals(
-                format.format(r.getCreatedDate().getTime()),
-                node.get("createdDate").asText());
+                r.getCreatedDate().getTimeInMillis() / 1000,
+                node.get("createdDate").asLong());
         Assert.assertEquals(
-                format.format(r.getModifiedDate().getTime()),
-                node.get("modifiedDate").asText());
+                r.getModifiedDate().getTimeInMillis() / 1000,
+                node.get("modifiedDate").asLong());
 
         Assert.assertEquals(
                 r.getUri().toString(),

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/ClientTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/ClientTest.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client.Deserializer;
 import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
 import net.krotscheck.kangaroo.common.jackson.ObjectMapperFactory;
@@ -34,7 +33,6 @@ import org.mockito.Mockito;
 
 import java.math.BigInteger;
 import java.net.URI;
-import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
@@ -346,7 +344,6 @@ public final class ClientTest {
 
         // De/serialize to json.
         ObjectMapper m = new ObjectMapperFactory().get();
-        DateFormat format = new ISO8601DateFormat();
         String output = m.writeValueAsString(c);
         JsonNode node = m.readTree(output);
 
@@ -354,11 +351,11 @@ public final class ClientTest {
                 IdUtil.toString(c.getId()),
                 node.get("id").asText());
         Assert.assertEquals(
-                format.format(c.getCreatedDate().getTime()),
-                node.get("createdDate").asText());
+                c.getCreatedDate().getTimeInMillis() / 1000,
+                node.get("createdDate").asLong());
         Assert.assertEquals(
-                format.format(c.getCreatedDate().getTime()),
-                node.get("modifiedDate").asText());
+                c.getModifiedDate().getTimeInMillis() / 1000,
+                node.get("modifiedDate").asLong());
 
         Assert.assertEquals(
                 IdUtil.toString(c.getApplication().getId()),
@@ -405,13 +402,11 @@ public final class ClientTest {
     @Test
     public void testJacksonDeserializable() throws Exception {
         ObjectMapper m = new ObjectMapperFactory().get();
-        DateFormat format = new ISO8601DateFormat();
+        long timestamp = Calendar.getInstance().getTimeInMillis() / 1000;
         ObjectNode node = m.createObjectNode();
         node.put("id", IdUtil.toString(IdUtil.next()));
-        node.put("createdDate",
-                format.format(Calendar.getInstance().getTime()));
-        node.put("modifiedDate",
-                format.format(Calendar.getInstance().getTime()));
+        node.put("createdDate", timestamp);
+        node.put("modifiedDate", timestamp);
         node.put("name", "name");
         node.put("type", "Implicit");
         node.put("clientSecret", "clientSecret");
@@ -429,11 +424,11 @@ public final class ClientTest {
                 IdUtil.toString(c.getId()),
                 node.get("id").asText());
         Assert.assertEquals(
-                format.format(c.getCreatedDate().getTime()),
-                node.get("createdDate").asText());
+                c.getCreatedDate().getTimeInMillis() / 1000,
+                node.get("createdDate").asLong());
         Assert.assertEquals(
-                format.format(c.getModifiedDate().getTime()),
-                node.get("modifiedDate").asText());
+                c.getModifiedDate().getTimeInMillis() / 1000,
+                node.get("modifiedDate").asLong());
 
         Assert.assertEquals(
                 c.getName(),

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/OAuthTokenTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/OAuthTokenTest.java
@@ -303,7 +303,6 @@ public final class OAuthTokenTest {
 
         // De/serialize to json.
         ObjectMapper m = new ObjectMapperFactory().get();
-        DateFormat format = new ISO8601DateFormat();
         String output = m.writeValueAsString(token);
         JsonNode node = m.readTree(output);
 
@@ -311,11 +310,11 @@ public final class OAuthTokenTest {
                 IdUtil.toString(token.getId()),
                 node.get("id").asText());
         Assert.assertEquals(
-                format.format(token.getCreatedDate().getTime()),
-                node.get("createdDate").asText());
+                token.getCreatedDate().getTimeInMillis() / 1000,
+                node.get("createdDate").asLong());
         Assert.assertEquals(
-                format.format(token.getCreatedDate().getTime()),
-                node.get("modifiedDate").asText());
+                token.getModifiedDate().getTimeInMillis() / 1000,
+                node.get("modifiedDate").asLong());
 
         Assert.assertEquals(
                 token.getTokenType().toString(),
@@ -350,13 +349,11 @@ public final class OAuthTokenTest {
     @Test
     public void testJacksonDeserializable() throws Exception {
         ObjectMapper m = new ObjectMapperFactory().get();
-        DateFormat format = new ISO8601DateFormat();
+        long timestamp = Calendar.getInstance().getTimeInMillis() / 1000;
         ObjectNode node = m.createObjectNode();
         node.put("id", IdUtil.toString(IdUtil.next()));
-        node.put("createdDate",
-                format.format(Calendar.getInstance().getTime()));
-        node.put("modifiedDate",
-                format.format(Calendar.getInstance().getTime()));
+        node.put("createdDate", timestamp);
+        node.put("modifiedDate", timestamp);
         node.put("accessToken", "accessToken");
         node.put("tokenType", "Authorization");
         node.put("expiresIn", 300);
@@ -372,11 +369,11 @@ public final class OAuthTokenTest {
                 IdUtil.toString(c.getId()),
                 node.get("id").asText());
         Assert.assertEquals(
-                format.format(c.getCreatedDate().getTime()),
-                node.get("createdDate").asText());
+                c.getCreatedDate().getTimeInMillis() / 1000,
+                node.get("createdDate").asLong());
         Assert.assertEquals(
-                format.format(c.getModifiedDate().getTime()),
-                node.get("modifiedDate").asText());
+                c.getModifiedDate().getTimeInMillis() / 1000,
+                node.get("modifiedDate").asLong());
 
         Assert.assertEquals(
                 c.getTokenType().toString(),

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/RoleTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/RoleTest.java
@@ -151,7 +151,6 @@ public final class RoleTest {
 
         // De/serialize to json.
         ObjectMapper m = new ObjectMapperFactory().get();
-        DateFormat format = new ISO8601DateFormat();
         String output = m.writeValueAsString(role);
         JsonNode node = m.readTree(output);
 
@@ -159,11 +158,11 @@ public final class RoleTest {
                 IdUtil.toString(role.getId()),
                 node.get("id").asText());
         Assert.assertEquals(
-                format.format(role.getCreatedDate().getTime()),
-                node.get("createdDate").asText());
+                role.getCreatedDate().getTimeInMillis() / 1000,
+                node.get("createdDate").asLong());
         Assert.assertEquals(
-                format.format(role.getCreatedDate().getTime()),
-                node.get("modifiedDate").asText());
+                role.getModifiedDate().getTimeInMillis() / 1000,
+                node.get("modifiedDate").asLong());
 
         Assert.assertEquals(
                 IdUtil.toString(role.getApplication().getId()),
@@ -192,13 +191,11 @@ public final class RoleTest {
     @Test
     public void testJacksonDeserializable() throws Exception {
         ObjectMapper m = new ObjectMapperFactory().get();
-        DateFormat format = new ISO8601DateFormat();
+        long timestamp = Calendar.getInstance().getTimeInMillis() / 1000;
         ObjectNode node = m.createObjectNode();
         node.put("id", IdUtil.toString(IdUtil.next()));
-        node.put("createdDate",
-                format.format(Calendar.getInstance().getTime()));
-        node.put("modifiedDate",
-                format.format(Calendar.getInstance().getTime()));
+        node.put("createdDate", timestamp);
+        node.put("modifiedDate", timestamp);
         node.put("name", "name");
         node.put("application", IdUtil.toString(IdUtil.next()));
 
@@ -209,11 +206,11 @@ public final class RoleTest {
                 IdUtil.toString(c.getId()),
                 node.get("id").asText());
         Assert.assertEquals(
-                format.format(c.getCreatedDate().getTime()),
-                node.get("createdDate").asText());
+                c.getCreatedDate().getTimeInMillis() / 1000,
+                node.get("createdDate").asLong());
         Assert.assertEquals(
-                format.format(c.getModifiedDate().getTime()),
-                node.get("modifiedDate").asText());
+                c.getModifiedDate().getTimeInMillis() / 1000,
+                node.get("modifiedDate").asLong());
 
         Assert.assertEquals(
                 c.getName(),

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/UserIdentityTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/UserIdentityTest.java
@@ -199,7 +199,6 @@ public final class UserIdentityTest {
 
         // De/serialize to json.
         ObjectMapper m = new ObjectMapperFactory().get();
-        DateFormat format = new ISO8601DateFormat();
         String output = m.writeValueAsString(identity);
         JsonNode node = m.readTree(output);
 
@@ -207,11 +206,11 @@ public final class UserIdentityTest {
                 IdUtil.toString(identity.getId()),
                 node.get("id").asText());
         Assert.assertEquals(
-                format.format(identity.getCreatedDate().getTime()),
-                node.get("createdDate").asText());
+                identity.getCreatedDate().getTimeInMillis() / 1000,
+                node.get("createdDate").asLong());
         Assert.assertEquals(
-                format.format(identity.getCreatedDate().getTime()),
-                node.get("modifiedDate").asText());
+                identity.getModifiedDate().getTimeInMillis() / 1000,
+                node.get("modifiedDate").asLong());
 
         Assert.assertEquals(
                 identity.getType().toString(),
@@ -255,13 +254,11 @@ public final class UserIdentityTest {
     @Test
     public void testJacksonDeserializable() throws Exception {
         ObjectMapper m = new ObjectMapperFactory().get();
-        DateFormat format = new ISO8601DateFormat();
+        long timestamp = Calendar.getInstance().getTimeInMillis() / 1000;
         ObjectNode node = m.createObjectNode();
         node.put("id", IdUtil.toString(IdUtil.next()));
-        node.put("createdDate",
-                format.format(Calendar.getInstance().getTime()));
-        node.put("modifiedDate",
-                format.format(Calendar.getInstance().getTime()));
+        node.put("createdDate", timestamp);
+        node.put("modifiedDate", timestamp);
         node.put("remoteId", "remoteId");
         node.put("authenticator", IdUtil.toString(IdUtil.next()));
         node.put("user", IdUtil.toString(IdUtil.next()));
@@ -278,11 +275,11 @@ public final class UserIdentityTest {
                 IdUtil.toString(a.getId()),
                 node.get("id").asText());
         Assert.assertEquals(
-                format.format(a.getCreatedDate().getTime()),
-                node.get("createdDate").asText());
+                a.getCreatedDate().getTimeInMillis() / 1000,
+                node.get("createdDate").asLong());
         Assert.assertEquals(
-                format.format(a.getModifiedDate().getTime()),
-                node.get("modifiedDate").asText());
+                a.getModifiedDate().getTimeInMillis() / 1000,
+                node.get("modifiedDate").asLong());
 
         Assert.assertEquals(
                 a.getRemoteId(),

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/UserTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/UserTest.java
@@ -154,7 +154,6 @@ public final class UserTest {
 
         // De/serialize to json.
         ObjectMapper m = new ObjectMapperFactory().get();
-        DateFormat format = new ISO8601DateFormat();
         String output = m.writeValueAsString(user);
         JsonNode node = m.readTree(output);
 
@@ -162,11 +161,11 @@ public final class UserTest {
                 IdUtil.toString(user.getId()),
                 node.get("id").asText());
         Assert.assertEquals(
-                format.format(user.getCreatedDate().getTime()),
-                node.get("createdDate").asText());
+                user.getCreatedDate().getTimeInMillis() / 1000,
+                node.get("createdDate").asLong());
         Assert.assertEquals(
-                format.format(user.getModifiedDate().getTime()),
-                node.get("modifiedDate").asText());
+                user.getModifiedDate().getTimeInMillis() / 1000,
+                node.get("modifiedDate").asLong());
 
         Assert.assertEquals(
                 IdUtil.toString(user.getRole().getId()),
@@ -195,13 +194,11 @@ public final class UserTest {
     @Test
     public void testJacksonDeserializable() throws Exception {
         ObjectMapper m = new ObjectMapperFactory().get();
-        DateFormat format = new ISO8601DateFormat();
+        long timestamp = Calendar.getInstance().getTimeInMillis() / 1000;
         ObjectNode node = m.createObjectNode();
         node.put("id", IdUtil.toString(IdUtil.next()));
-        node.put("createdDate",
-                format.format(Calendar.getInstance().getTime()));
-        node.put("modifiedDate",
-                format.format(Calendar.getInstance().getTime()));
+        node.put("createdDate", timestamp);
+        node.put("modifiedDate", timestamp);
         node.put("application", IdUtil.toString(IdUtil.next()));
 
         String output = m.writeValueAsString(node);
@@ -211,11 +208,11 @@ public final class UserTest {
                 IdUtil.toString(user.getId()),
                 node.get("id").asText());
         Assert.assertEquals(
-                format.format(user.getCreatedDate().getTime()),
-                node.get("createdDate").asText());
+                user.getCreatedDate().getTimeInMillis() / 1000,
+                node.get("createdDate").asLong());
         Assert.assertEquals(
-                format.format(user.getModifiedDate().getTime()),
-                node.get("modifiedDate").asText());
+                user.getModifiedDate().getTimeInMillis() / 1000,
+                node.get("modifiedDate").asLong());
         Assert.assertEquals(
                 IdUtil.toString(user.getApplication().getId()),
                 node.get("application").asText());


### PR DESCRIPTION
All entities now use a common Second-precision de/serializer for
date instances. This is largely because the OAuth2 specification
only uses seconds, and as such it makes more sense for us to use
a single format across all endpoints.