### PR TITLE
OAuth Tokens now keep track of issuing domain

### DIFF
--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/OAuthToken.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/common/database/entity/OAuthToken.java
@@ -165,6 +165,14 @@ public final class OAuthToken extends AbstractAuthzEntity implements Principal {
     private URI redirect;
 
     /**
+     * The host that issued this token, extracted from the servlet context.
+     * It's stored as the host name only, as the protocol may vary.
+     */
+    @Basic
+    @Column(name = "issuer")
+    private String issuer;
+
+    /**
      * List of the application's scopes.
      */
     @ManyToMany(fetch = FetchType.LAZY)
@@ -178,6 +186,24 @@ public final class OAuthToken extends AbstractAuthzEntity implements Principal {
     @MapKey(name = "name")
     @SortNatural
     private SortedMap<String, ApplicationScope> scopes = new TreeMap<>();
+
+    /**
+     * Get the issuer.
+     *
+     * @return The URL of the server that issued this token.
+     */
+    public String getIssuer() {
+        return issuer;
+    }
+
+    /**
+     * Set the URL of the server that issued this token.
+     *
+     * @param issuer The new issuer.
+     */
+    public void setIssuer(final String issuer) {
+        this.issuer = issuer;
+    }
 
     /**
      * Get the attached HTTP Session.
@@ -283,6 +309,15 @@ public final class OAuthToken extends AbstractAuthzEntity implements Principal {
      *
      * @param expiresIn The time, in seconds.
      */
+    public void setExpiresIn(final int expiresIn) {
+        this.expiresIn = (long) expiresIn;
+    }
+
+    /**
+     * Set the expiration time, in seconds, from the creation date.
+     *
+     * @param expiresIn The time, in seconds.
+     */
     @JsonSetter
     public void setExpiresIn(final long expiresIn) {
         this.expiresIn = expiresIn;
@@ -299,15 +334,6 @@ public final class OAuthToken extends AbstractAuthzEntity implements Principal {
         } else {
             this.expiresIn = expiresIn.longValue();
         }
-    }
-
-    /**
-     * Set the expiration time, in seconds, from the creation date.
-     *
-     * @param expiresIn The time, in seconds.
-     */
-    public void setExpiresIn(final int expiresIn) {
-        this.expiresIn = (long) expiresIn;
     }
 
     /**

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/AuthorizationService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/AuthorizationService.java
@@ -160,7 +160,7 @@ public final class AuthorizationService {
                     injector.getInstance(IAuthorizeHandler.class,
                             c.getType().toString());
 
-            Response response = handler.handle(uriInfo, httpSession, auth,
+            Response response = handler.handle(httpSession, auth,
                     redirect, scopes, state);
 
             // On success, rotate the session id.
@@ -213,7 +213,7 @@ public final class AuthorizationService {
                 throw new InvalidRequestException();
             }
 
-            Response response = handler.callback(s, httpSession, uriInfo);
+            Response response = handler.callback(s, httpSession);
 
             // On success, rotate the session id.
             request.changeSessionId();

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/authorize/IAuthorizeHandler.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/authorize/IAuthorizeHandler.java
@@ -41,8 +41,6 @@ public interface IAuthorizeHandler {
     /**
      * Handle a specific authorization grant request.
      *
-     * @param uriInfo        The original request, in case additional data
-     *                       is needed.
      * @param browserSession The browser session, maintained via cookies.
      * @param auth           The authenticator to use to process this
      *                       request.
@@ -53,8 +51,7 @@ public interface IAuthorizeHandler {
      * @param state          The client's requested state ID.
      * @return A response entity with the appropriate response.
      */
-    Response handle(UriInfo uriInfo,
-                    HttpSession browserSession,
+    Response handle(HttpSession browserSession,
                     Authenticator auth,
                     URI redirect,
                     SortedMap<String, ApplicationScope> scopes,
@@ -67,12 +64,10 @@ public interface IAuthorizeHandler {
      *
      * @param s              The request state previously saved by the client.
      * @param browserSession The browser session, maintained via cookies.
-     * @param uriInfo        The URI response from the third party IdP.
      * @return A response entity indicating success or failure.
      */
     Response callback(AuthenticatorState s,
-                      HttpSession browserSession,
-                      UriInfo uriInfo);
+                      HttpSession browserSession);
 
     /**
      * Provided a stored intermediate authenticator state, attempt to resolve

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/token/AuthorizationCodeGrantHandler.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/token/AuthorizationCodeGrantHandler.java
@@ -29,6 +29,8 @@ import org.glassfish.jersey.process.internal.RequestScoped;
 import org.hibernate.Session;
 
 import javax.inject.Inject;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
 import java.math.BigInteger;
 import java.net.URI;
 
@@ -48,13 +50,21 @@ public final class AuthorizationCodeGrantHandler {
     private final Session session;
 
     /**
+     * Current request URI.
+     */
+    private final UriInfo uriInfo;
+
+    /**
      * Create a new instance of this token handler.
      *
      * @param session Injected hibernate session.
+     * @param uriInfo The URI info for the current request.
      */
     @Inject
-    public AuthorizationCodeGrantHandler(final Session session) {
+    public AuthorizationCodeGrantHandler(final Session session,
+                                         @Context final UriInfo uriInfo) {
         this.session = session;
+        this.uriInfo = uriInfo;
     }
 
     /**
@@ -108,6 +118,7 @@ public final class AuthorizationCodeGrantHandler {
         newAuthToken.setExpiresIn(client.getAccessTokenExpireIn());
         newAuthToken.setScopes(authCode.getScopes());
         newAuthToken.setIdentity(authCode.getIdentity());
+        newAuthToken.setIssuer(uriInfo.getAbsolutePath().getHost());
 
         OAuthToken newRefreshToken = new OAuthToken();
         newRefreshToken.setClient(client);
@@ -116,6 +127,7 @@ public final class AuthorizationCodeGrantHandler {
         newRefreshToken.setScopes(authCode.getScopes());
         newRefreshToken.setAuthToken(newAuthToken);
         newRefreshToken.setIdentity(authCode.getIdentity());
+        newRefreshToken.setIssuer(uriInfo.getAbsolutePath().getHost());
 
         session.save(newAuthToken);
         session.save(newRefreshToken);

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/token/ClientCredentialsGrantHandler.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/token/ClientCredentialsGrantHandler.java
@@ -32,6 +32,8 @@ import org.glassfish.jersey.process.internal.RequestScoped;
 import org.hibernate.Session;
 
 import javax.inject.Inject;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
 import java.util.SortedMap;
 
 /**
@@ -49,13 +51,21 @@ public final class ClientCredentialsGrantHandler {
     private final Session session;
 
     /**
+     * Current request URI.
+     */
+    private final UriInfo uriInfo;
+
+    /**
      * Create a new instance of this token handler.
      *
      * @param session Injected hibernate session.
+     * @param uriInfo The URI info for the current request.
      */
     @Inject
-    public ClientCredentialsGrantHandler(final Session session) {
+    public ClientCredentialsGrantHandler(final Session session,
+                                         @Context final UriInfo uriInfo) {
         this.session = session;
+        this.uriInfo = uriInfo;
     }
 
     /**
@@ -94,6 +104,7 @@ public final class ClientCredentialsGrantHandler {
         token.setTokenType(OAuthTokenType.Bearer);
         token.setExpiresIn(client.getAccessTokenExpireIn());
         token.setScopes(requestedScopes);
+        token.setIssuer(uriInfo.getAbsolutePath().getHost());
 
         session.save(token);
 

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/token/OwnerCredentialsGrantHandler.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/token/OwnerCredentialsGrantHandler.java
@@ -38,8 +38,10 @@ import org.hibernate.Session;
 
 import javax.inject.Inject;
 import javax.ws.rs.NotAuthorizedException;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriInfo;
 import java.util.SortedMap;
 
 /**
@@ -57,6 +59,11 @@ public final class OwnerCredentialsGrantHandler {
     private final Session session;
 
     /**
+     * Current request URI.
+     */
+    private final UriInfo uriInfo;
+
+    /**
      * injection manager, injected.
      */
     private final InjectionManager injector;
@@ -65,12 +72,15 @@ public final class OwnerCredentialsGrantHandler {
      * Create a new instance of this token handler.
      *
      * @param session  Injected hibernate session.
+     * @param uriInfo  The URI info for the current request.
      * @param injector The injection manager.
      */
     @Inject
     public OwnerCredentialsGrantHandler(final Session session,
+                                        @Context final UriInfo uriInfo,
                                         final InjectionManager injector) {
         this.session = session;
+        this.uriInfo = uriInfo;
         this.injector = injector;
     }
 
@@ -126,6 +136,7 @@ public final class OwnerCredentialsGrantHandler {
         token.setExpiresIn(client.getAccessTokenExpireIn());
         token.setScopes(requestedScopes);
         token.setIdentity(identity);
+        token.setIssuer(uriInfo.getAbsolutePath().getHost());
 
         OAuthToken refreshToken = new OAuthToken();
         refreshToken.setClient(client);
@@ -134,6 +145,7 @@ public final class OwnerCredentialsGrantHandler {
         refreshToken.setScopes(token.getScopes());
         refreshToken.setAuthToken(token);
         refreshToken.setIdentity(identity);
+        refreshToken.setIssuer(uriInfo.getAbsolutePath().getHost());
 
         session.save(token);
         session.save(refreshToken);

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/token/RefreshTokenGrantHandler.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/token/RefreshTokenGrantHandler.java
@@ -110,6 +110,7 @@ public final class RefreshTokenGrantHandler {
         newAuthToken.setExpiresIn(client.getAccessTokenExpireIn());
         newAuthToken.setScopes(requestedScopes);
         newAuthToken.setIdentity(refreshToken.getIdentity());
+        newAuthToken.setIssuer(refreshToken.getIssuer());
 
         OAuthToken newRefreshToken = new OAuthToken();
         newRefreshToken.setClient(client);
@@ -118,6 +119,7 @@ public final class RefreshTokenGrantHandler {
         newRefreshToken.setScopes(requestedScopes);
         newRefreshToken.setIdentity(refreshToken.getIdentity());
         newRefreshToken.setAuthToken(newAuthToken);
+        newRefreshToken.setIssuer(refreshToken.getIssuer());
 
         session.save(newAuthToken);
         session.save(newRefreshToken);

--- a/kangaroo-server-authz/src/main/resources/liquibase/db.changelog-authz-1.2.0.yaml
+++ b/kangaroo-server-authz/src/main/resources/liquibase/db.changelog-authz-1.2.0.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: 3
+      author: krotscheck
+      changes:
+      - addColumn:
+          tableName: oauth_tokens
+          column:
+            name: issuer
+            type: varchar(255)
+      rollback:
+      - dropColumn:
+          tableName: oauth_tokens
+          columnName: issuer

--- a/kangaroo-server-authz/src/main/resources/liquibase/db.changelog-master.yaml
+++ b/kangaroo-server-authz/src/main/resources/liquibase/db.changelog-master.yaml
@@ -9,3 +9,5 @@ databaseChangeLog:
       file: liquibase/db.changelog-authz-1.0.0.yaml
   - include:
       file: liquibase/db.changelog-authz-1.1.0.yaml
+  - include:
+      file: liquibase/db.changelog-authz-1.2.0.yaml

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/OAuthTokenServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/OAuthTokenServiceCRUDTest.java
@@ -362,6 +362,7 @@ public final class OAuthTokenServiceCRUDTest
         t.setTokenType(OAuthTokenType.Authorization);
         t.setRedirect(redirect);
         t.setExpiresIn(client.getAuthorizationCodeExpiresIn());
+        t.setIssuer("localhost");
 
         if (identities.size() > 0) {
             t.setIdentity(identities.get(0));
@@ -386,6 +387,7 @@ public final class OAuthTokenServiceCRUDTest
         token.setExpiresIn(bearerToken.getClient().getRefreshTokenExpireIn());
         token.setScopes(context.getScopes());
         token.setIdentity(bearerToken.getIdentity());
+        token.setIssuer("localhost");
 
         return token;
     }
@@ -423,6 +425,7 @@ public final class OAuthTokenServiceCRUDTest
         token.setTokenType(OAuthTokenType.Bearer);
         token.setExpiresIn(client.getAccessTokenExpireIn());
         token.setScopes(context.getScopes());
+        token.setIssuer("localhost");
 
         // Identities should only be added if the type calls for it.
         if (identities.size() > 0

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/OAuthTokenTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/database/entity/OAuthTokenTest.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken.Deserializer;
 import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
 import net.krotscheck.kangaroo.common.jackson.ObjectMapperFactory;
@@ -34,7 +33,6 @@ import org.mockito.Mockito;
 
 import java.math.BigInteger;
 import java.net.URI;
-import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Iterator;
@@ -156,6 +154,20 @@ public final class OAuthTokenTest {
         Assert.assertNull(token.getRedirect());
         token.setRedirect(test);
         Assert.assertEquals(test, token.getRedirect());
+    }
+
+    /**
+     * Test setting the issuer.
+     *
+     * @throws Exception Should not be thrown.
+     */
+    @Test
+    public void testGetSetIssuer() throws Exception {
+        OAuthToken token = new OAuthToken();
+
+        Assert.assertNull(token.getIssuer());
+        token.setIssuer("test");
+        Assert.assertEquals("test", token.getIssuer());
     }
 
     /**
@@ -300,6 +312,7 @@ public final class OAuthTokenTest {
         token.setRedirect(new URI("http://example.com/"));
         token.setTokenType(OAuthTokenType.Authorization);
         token.setExpiresIn(100);
+        token.setIssuer("localhost");
 
         // De/serialize to json.
         ObjectMapper m = new ObjectMapperFactory().get();
@@ -331,6 +344,8 @@ public final class OAuthTokenTest {
         Assert.assertEquals(
                 IdUtil.toString(token.getIdentity().getId()),
                 node.get("identity").asText());
+        Assert.assertEquals(token.getIssuer(),
+                node.get("issuer").asText());
 
         // Enforce a given number of items.
         List<String> names = new ArrayList<>();
@@ -338,7 +353,7 @@ public final class OAuthTokenTest {
         while (nameIterator.hasNext()) {
             names.add(nameIterator.next());
         }
-        Assert.assertEquals(8, names.size());
+        Assert.assertEquals(9, names.size());
     }
 
     /**
@@ -358,6 +373,7 @@ public final class OAuthTokenTest {
         node.put("tokenType", "Authorization");
         node.put("expiresIn", 300);
         node.put("redirect", "http://example.com");
+        node.put("issuer", "localhost");
         node.put("identity", IdUtil.toString(IdUtil.next()));
         node.put("client", IdUtil.toString(IdUtil.next()));
         node.put("authToken", IdUtil.toString(IdUtil.next()));
@@ -381,6 +397,9 @@ public final class OAuthTokenTest {
         Assert.assertEquals(
                 c.getExpiresIn().longValue(),
                 node.get("expiresIn").asLong());
+        Assert.assertEquals(
+                c.getIssuer(),
+                node.get("issuer").asText());
         Assert.assertEquals(
                 c.getRedirect().toString(),
                 node.get("redirect").asText());

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/resource/token/ClientCredentialsGrantHandlerTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/resource/token/ClientCredentialsGrantHandlerTest.java
@@ -34,6 +34,12 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 
+import javax.ws.rs.core.UriInfo;
+import java.net.URI;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
 /**
  * These tests ensure coverage on the Client Credentials token token type
  * handler, covered in RFC6749.
@@ -93,10 +99,15 @@ public final class ClientCredentialsGrantHandlerTest extends DatabaseTest {
 
     /**
      * Setup the test.
+     *
+     * @throws Exception Should not be thrown.
      */
     @Before
-    public void initializeEnvironment() {
-        handler = new ClientCredentialsGrantHandler(getSession());
+    public void initializeEnvironment() throws Exception {
+        UriInfo info = mock(UriInfo.class);
+        URI absolutePath = new URI("http://example.com");
+        doReturn(absolutePath).when(info).getAbsolutePath();
+        handler = new ClientCredentialsGrantHandler(getSession(), info);
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/test/ApplicationBuilder.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/test/ApplicationBuilder.java
@@ -671,6 +671,7 @@ public final class ApplicationBuilder {
         context.token = new OAuthToken();
         context.token.setTokenType(type);
         context.token.setClient(client);
+        context.token.setIssuer("localhost");
 
         // Link to auth token
         if (authToken != null) {


### PR DESCRIPTION
Individual tokens are issued by a specific domain, and as the system continues to evolve
to offer token introspection, it's important to reveal which domain provided the token.