### PR TITLE
BigInteger parsing now distinguishes between path and query/form params

### DIFF
--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/id/Base16BigIntegerConverterProviderTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/id/Base16BigIntegerConverterProviderTest.java
@@ -20,6 +20,7 @@ package net.krotscheck.kangaroo.common.hibernate.id;
 
 import org.junit.Test;
 
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.NotFoundException;
@@ -34,7 +35,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 /**
- * Tests for the data provider.
+ * Test for the base 16 data conversion handler.
  *
  * @author Michael Krotscheck
  */
@@ -198,10 +199,10 @@ public final class Base16BigIntegerConverterProviderTest {
     }
 
     /**
-     * The string-to-biginteger converter.
+     * Fail a conversion using a path annotation.
      */
     @Test(expected = NotFoundException.class)
-    public void testConvertString() {
+    public void testFailConvertPath() {
         Annotation[] annotations = new Annotation[]{pathAnnotation};
 
         ParamConverter converter = converterProvider
@@ -211,10 +212,36 @@ public final class Base16BigIntegerConverterProviderTest {
     }
 
     /**
-     * Test convert with an error.
+     * Fail a conversion using a form annotation.
+     */
+    @Test(expected = BadRequestException.class)
+    public void testFailConvertForm() {
+        Annotation[] annotations = new Annotation[]{formAnnotation};
+
+        ParamConverter converter = converterProvider
+                .getConverter(BigInteger.class, null, annotations);
+
+        converter.fromString("not_a_valid_string");
+    }
+
+    /**
+     * Fail a conversion using a query annotation.
+     */
+    @Test(expected = BadRequestException.class)
+    public void testFailConvertQuery() {
+        Annotation[] annotations = new Annotation[]{queryAnnotation};
+
+        ParamConverter converter = converterProvider
+                .getConverter(BigInteger.class, null, annotations);
+
+        converter.fromString("not_a_valid_string");
+    }
+
+    /**
+     * Test a valid conversion.
      */
     @Test
-    public void testConvertFromStringError() {
+    public void testValidConversion() {
         Annotation[] annotations = new Annotation[]{pathAnnotation};
 
         ParamConverter converter = converterProvider
@@ -223,5 +250,6 @@ public final class Base16BigIntegerConverterProviderTest {
         BigInteger id = IdUtil.next();
         BigInteger converted = (BigInteger)
                 converter.fromString(IdUtil.toString(id));
+        assertEquals(id, converted);
     }
 }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceBrowseTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceBrowseTest.java
@@ -485,7 +485,7 @@ public abstract class AbstractServiceBrowseTest<T extends AbstractAuthzEntity>
                         HttpUtil.authHeaderBearer(adminAppToken.getId()))
                 .get();
 
-        assertErrorResponse(response, Status.NOT_FOUND);
+        assertErrorResponse(response, Status.BAD_REQUEST);
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceSearchTest.java
@@ -548,7 +548,6 @@ public abstract class AbstractServiceSearchTest<T extends AbstractAuthzEntity>
     /**
      * Test that searches by an invalid owner.
      */
-    // TODO(krotscheck): This should return a 400.
     @Test
     public final void testSearchByInvalidOwner() {
         OAuthToken token = getAdminToken();
@@ -569,7 +568,6 @@ public abstract class AbstractServiceSearchTest<T extends AbstractAuthzEntity>
     /**
      * Test that searches by malformed owners returns a 404.
      */
-    // TODO(krotscheck): This should return a 400.
     @Test
     public final void testSearchByMalformedOwner() {
         Map<String, String> params = new HashMap<>();
@@ -577,7 +575,7 @@ public abstract class AbstractServiceSearchTest<T extends AbstractAuthzEntity>
         params.put("owner", "malformed");
 
         Response r = search(params, getAdminToken());
-        assertErrorResponse(r, Status.NOT_FOUND);
+        assertErrorResponse(r, Status.BAD_REQUEST);
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AuthenticatorServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AuthenticatorServiceSearchTest.java
@@ -273,7 +273,6 @@ public final class AuthenticatorServiceSearchTest
     /**
      * Test that an malformed client throws an error.
      */
-    // TODO(krotscheck): This should return a 400.
     @Test
     public void testSearchByMalformedApplication() {
         Map<String, String> params = new HashMap<>();
@@ -281,7 +280,7 @@ public final class AuthenticatorServiceSearchTest
         params.put("client", "malformed");
 
         Response r = search(params, getAdminToken());
-        assertErrorResponse(r, Status.NOT_FOUND);
+        assertErrorResponse(r, Status.BAD_REQUEST);
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientServiceSearchTest.java
@@ -268,7 +268,6 @@ public final class ClientServiceSearchTest
     /**
      * Test that an malformed application throws an error.
      */
-    // TODO(krotscheck): This should return a 400.
     @Test
     public void testSearchByMalformedApplication() {
         Map<String, String> params = new HashMap<>();
@@ -276,7 +275,7 @@ public final class ClientServiceSearchTest
         params.put("application", "malformed");
 
         Response r = search(params, getAdminToken());
-        assertErrorResponse(r, Status.NOT_FOUND);
+        assertErrorResponse(r, Status.BAD_REQUEST);
     }
 }
 

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/OAuthTokenServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/OAuthTokenServiceSearchTest.java
@@ -271,7 +271,6 @@ public final class OAuthTokenServiceSearchTest
     /**
      * Test that an malformed user throws an error.
      */
-    // TODO(krotscheck): This should return a 400.
     @Test
     public void testSearchByMalformedUser() {
         Map<String, String> params = new HashMap<>();
@@ -279,7 +278,7 @@ public final class OAuthTokenServiceSearchTest
         params.put("user", "malformed");
 
         Response r = search(params, getAdminToken());
-        assertErrorResponse(r, Status.NOT_FOUND);
+        assertErrorResponse(r, Status.BAD_REQUEST);
     }
 
     /**
@@ -354,7 +353,6 @@ public final class OAuthTokenServiceSearchTest
     /**
      * Test that an malformed identity throws an error.
      */
-    // TODO(krotscheck): This should return a 400.
     @Test
     public void testSearchByMalformedIdentity() {
         Map<String, String> params = new HashMap<>();
@@ -362,7 +360,7 @@ public final class OAuthTokenServiceSearchTest
         params.put("identity", "malformed");
 
         Response r = search(params, getAdminToken());
-        assertErrorResponse(r, Status.NOT_FOUND);
+        assertErrorResponse(r, Status.BAD_REQUEST);
     }
 
     /**
@@ -433,7 +431,6 @@ public final class OAuthTokenServiceSearchTest
     /**
      * Test that an malformed client throws an error.
      */
-    // TODO(krotscheck): This should return a 400.
     @Test
     public void testSearchByMalformedClient() {
         Map<String, String> params = new HashMap<>();
@@ -441,7 +438,7 @@ public final class OAuthTokenServiceSearchTest
         params.put("client", "malformed");
 
         Response r = search(params, getAdminToken());
-        assertErrorResponse(r, Status.NOT_FOUND);
+        assertErrorResponse(r, Status.BAD_REQUEST);
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleServiceSearchTest.java
@@ -262,7 +262,6 @@ public final class RoleServiceSearchTest
     /**
      * Test that an malformed application throws an error.
      */
-    // TODO(krotscheck): This should return a 400.
     @Test
     public void testSearchByMalformedApplication() {
         Map<String, String> params = new HashMap<>();
@@ -270,6 +269,6 @@ public final class RoleServiceSearchTest
         params.put("application", "malformed");
 
         Response r = search(params, getAdminToken());
-        assertErrorResponse(r, Status.NOT_FOUND);
+        assertErrorResponse(r, Status.BAD_REQUEST);
     }
 }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserIdentityServiceBrowseTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserIdentityServiceBrowseTest.java
@@ -281,7 +281,7 @@ public final class UserIdentityServiceBrowseTest
         params.put("user", "malformed");
         Response r = browse(params, getAdminToken());
 
-        assertErrorResponse(r, Status.NOT_FOUND);
+        assertErrorResponse(r, Status.BAD_REQUEST);
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserIdentityServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserIdentityServiceSearchTest.java
@@ -268,7 +268,6 @@ public final class UserIdentityServiceSearchTest
     /**
      * Test that an malformed application throws an error.
      */
-    // TODO(krotscheck): This should return a 400.
     @Test
     public void testSearchByMalformedUser() {
         Map<String, String> params = new HashMap<>();
@@ -276,7 +275,7 @@ public final class UserIdentityServiceSearchTest
         params.put("user", "malformed");
 
         Response r = search(params, getAdminToken());
-        assertErrorResponse(r, Status.NOT_FOUND);
+        assertErrorResponse(r, Status.BAD_REQUEST);
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserServiceSearchTest.java
@@ -262,7 +262,6 @@ public final class UserServiceSearchTest
     /**
      * Test that an malformed application throws an error.
      */
-    // TODO(krotscheck): This should return a 400.
     @Test
     public void testSearchByMalformedApplication() {
         Map<String, String> params = new HashMap<>();
@@ -270,7 +269,7 @@ public final class UserServiceSearchTest
         params.put("application", "malformed");
 
         Response r = search(params, getAdminToken());
-        assertErrorResponse(r, Status.NOT_FOUND);
+        assertErrorResponse(r, Status.BAD_REQUEST);
     }
 
     /**
@@ -348,7 +347,6 @@ public final class UserServiceSearchTest
     /**
      * Test that an malformed role throws an error.
      */
-    // TODO(krotscheck): This should return a 400.
     @Test
     public void testSearchByMalformedRole() {
         Map<String, String> params = new HashMap<>();
@@ -356,6 +354,6 @@ public final class UserServiceSearchTest
         params.put("role", "malformed");
 
         Response r = search(params, getAdminToken());
-        assertErrorResponse(r, Status.NOT_FOUND);
+        assertErrorResponse(r, Status.BAD_REQUEST);
     }
 }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/Section410AuthorizationCodeGrantTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/Section410AuthorizationCodeGrantTest.java
@@ -1451,12 +1451,12 @@ public final class Section410AuthorizationCodeGrantTest
         Response r = target("/token").request().post(postEntity);
 
         // Assert various response-specific parameters.
-        Assert.assertEquals(Status.NOT_FOUND.getStatusCode(), r.getStatus());
+        Assert.assertEquals(Status.BAD_REQUEST.getStatusCode(), r.getStatus());
         Assert.assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
 
         // Validate the query parameters received.
         ErrorResponse entity = r.readEntity(ErrorResponse.class);
-        Assert.assertEquals("not_found", entity.getError());
+        Assert.assertEquals("bad_request", entity.getError());
         Assert.assertNotNull(entity.getErrorDescription());
     }
 

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/Section600RefreshTokenTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc6749/Section600RefreshTokenTest.java
@@ -394,12 +394,12 @@ public final class Section600RefreshTokenTest
         Response r = target("/token").request().post(postEntity);
 
         // Assert various response-specific parameters.
-        assertEquals(Status.NOT_FOUND.getStatusCode(), r.getStatus());
+        assertEquals(Status.BAD_REQUEST.getStatusCode(), r.getStatus());
         assertEquals(MediaType.APPLICATION_JSON_TYPE, r.getMediaType());
 
         // Validate the query parameters received.
         ErrorResponse entity = r.readEntity(ErrorResponse.class);
-        assertEquals("not_found", entity.getError());
+        assertEquals("bad_request", entity.getError());
         assertNotNull(entity.getErrorDescription());
     }
 


### PR DESCRIPTION
Path params will throw NotFoundExceptions, while the latter will throw
BadRequestExceptions.