### PR TITLE
O2AuthorizationFilter can now selectively reject public or private clients

### DIFF
--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/authn/O2AuthDynamicFeature.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/authn/O2AuthDynamicFeature.java
@@ -85,6 +85,7 @@ public final class O2AuthDynamicFeature implements DynamicFeature {
         Boolean client = am.isAnnotationPresent(O2Client.class);
 
         if (client) {
+
             configuration.register(new O2ClientQueryParameterFilter(
                     requestProvider, sessionProvider));
             configuration.register(new O2ClientBasicAuthFilter(
@@ -92,8 +93,12 @@ public final class O2AuthDynamicFeature implements DynamicFeature {
             configuration.register(new O2ClientBodyFilter(
                     requestProvider, sessionProvider));
         }
+
         if (client) {
-            configuration.register(new O2AuthorizationFilter());
+            O2Client annotation = am.getAnnotation(O2Client.class);
+            configuration.register(new O2AuthorizationFilter(
+                    annotation.permitPrivate(),
+                    annotation.permitPublic()));
         }
     }
 }

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/authn/O2Client.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/authn/O2Client.java
@@ -35,4 +35,17 @@ import java.lang.annotation.Target;
 @NameBinding
 public @interface O2Client {
 
+    /**
+     * Whether to permit private clients.
+     *
+     * @return True if private clients are permitted, otherwise false.
+     */
+    boolean permitPrivate() default true;
+
+    /**
+     * Whether to permit public clients.
+     *
+     * @return True if public clients are permitted, otherwise false.
+     */
+    boolean permitPublic() default true;
 }


### PR DESCRIPTION
This change to the annotation, and filter, permits us to create
OAuth resources which may only be accessed by private clients.