### PR TITLE
Private/Public client permissions moved into authentication filter

### DIFF
--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/authn/O2AuthDynamicFeature.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/authn/O2AuthDynamicFeature.java
@@ -85,20 +85,27 @@ public final class O2AuthDynamicFeature implements DynamicFeature {
         Boolean client = am.isAnnotationPresent(O2Client.class);
 
         if (client) {
+            O2Client annotation = am.getAnnotation(O2Client.class);
 
-            configuration.register(new O2ClientQueryParameterFilter(
-                    requestProvider, sessionProvider));
-            configuration.register(new O2ClientBasicAuthFilter(
-                    requestProvider, sessionProvider));
+            Boolean permitPrivate = annotation.permitPrivate();
+            Boolean permitPublic = annotation.permitPublic();
+
+            if (permitPublic) {
+                configuration.register(new O2ClientQueryParameterFilter(
+                        requestProvider, sessionProvider));
+            }
+            if (permitPrivate) {
+                configuration.register(new O2ClientBasicAuthFilter(
+                        requestProvider, sessionProvider));
+            }
+
             configuration.register(new O2ClientBodyFilter(
-                    requestProvider, sessionProvider));
+                    requestProvider, sessionProvider,
+                    permitPrivate, permitPublic));
         }
 
         if (client) {
-            O2Client annotation = am.getAnnotation(O2Client.class);
-            configuration.register(new O2AuthorizationFilter(
-                    annotation.permitPrivate(),
-                    annotation.permitPublic()));
+            configuration.register(new O2AuthorizationFilter());
         }
     }
 }

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/authn/authn/O2ClientBodyFilter.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/authn/authn/O2ClientBodyFilter.java
@@ -56,14 +56,31 @@ public final class O2ClientBodyFilter
         extends AbstractO2AuthenticationFilter {
 
     /**
+     * Permit private clients.
+     */
+    private final Boolean permitPrivate;
+
+    /**
+     * Permit public clients.
+     */
+    private final Boolean permitPublic;
+
+    /**
      * Create a new instance of this filter.
      *
      * @param requestProvider The request provider.
      * @param sessionProvider The session provider.
+     * @param permitPrivate   Whether to permit private clients.
+     * @param permitPublic    Whether to permit public clients.
      */
     public O2ClientBodyFilter(final Provider<ContainerRequest> requestProvider,
-                              final Provider<Session> sessionProvider) {
+                              final Provider<Session> sessionProvider,
+                              final Boolean permitPrivate,
+                              final Boolean permitPublic) {
         super(requestProvider, sessionProvider);
+
+        this.permitPrivate = permitPrivate;
+        this.permitPublic = permitPublic;
     }
 
     /**
@@ -132,6 +149,16 @@ public final class O2ClientBodyFilter
                 .filter(c -> Objects.equals(c.getClientSecret(),
                         creds.getValue()))
                 .orElseThrow(AccessDeniedException::new);
+
+        // Only permit public if flagged.
+        if (!permitPublic && client.isPublic()) {
+            throw new AccessDeniedException();
+        }
+
+        // Only permit private if flagged.
+        if (!permitPrivate && client.isPrivate()) {
+            throw new AccessDeniedException();
+        }
 
         // Valid client and auth.
         setPrincipal(new O2Principal(client));

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/authn/authz/O2AuthorizationFilter.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/authn/authz/O2AuthorizationFilter.java
@@ -41,26 +41,10 @@ public final class O2AuthorizationFilter
         implements ContainerRequestFilter {
 
     /**
-     * Whether to permit private clients.
-     */
-    private final boolean permitPrivate;
-
-    /**
-     * Whether to permit public clients.
-     */
-    private final boolean permitPublic;
-
-    /**
      * Create a new authorization filter, which rejects requests based on the
      * passed authorization flags.
-     *
-     * @param permitPrivate Whether to permit private clients.
-     * @param permitPublic  Whether to permit public clients.
      */
-    public O2AuthorizationFilter(final boolean permitPrivate,
-                                 final boolean permitPublic) {
-        this.permitPrivate = permitPrivate;
-        this.permitPublic = permitPublic;
+    public O2AuthorizationFilter() {
     }
 
     /**
@@ -79,18 +63,6 @@ public final class O2AuthorizationFilter
         }
 
         if (principal.getContext() == null) {
-            throw new AccessDeniedException();
-        }
-
-        boolean isPrivate = principal.getContext().isPrivate();
-
-        // Reject private clients if they're not permitted.
-        if (isPrivate && !permitPrivate) {
-            throw new AccessDeniedException();
-        }
-
-        // Reject public clients if they're not permitted.
-        if (!isPrivate && !permitPublic) {
             throw new AccessDeniedException();
         }
     }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/authn/authn/O2ClientBodyFilterTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/authn/authn/O2ClientBodyFilterTest.java
@@ -277,6 +277,30 @@ public class O2ClientBodyFilterTest extends ContainerTest {
     }
 
     /**
+     * Assert that a request with a valid ID of a public client, on a
+     * resource that does not permit public clients, is not permitted.
+     */
+    @Test
+    public void testPublicClientNotPermitted() {
+        Client c = TEST_DATA_RESOURCE.getAdminApplication()
+                .getBuilder()
+                .client(ClientType.AuthorizationGrant, false)
+                .build()
+                .getClient();
+
+        Form requestData = new Form();
+        requestData.param("client_id", IdUtil.toString(c.getId()));
+        Entity<Form> testEntity = Entity.entity(requestData,
+                APPLICATION_FORM_URLENCODED_TYPE);
+
+        Response r = target("/client/private")
+                .request()
+                .post(testEntity);
+
+        assertEquals(Status.UNAUTHORIZED.getStatusCode(), r.getStatus());
+    }
+
+    /**
      * Assert that a request with a valid ID and secret pass.
      */
     @Test
@@ -298,6 +322,31 @@ public class O2ClientBodyFilterTest extends ContainerTest {
                 .post(testEntity);
 
         assertEquals(Status.OK.getStatusCode(), r.getStatus());
+    }
+
+    /**
+     * Assert that a request with a valid ID of a private client, on a
+     * resource that does not permit private clients, is not permitted.
+     */
+    @Test
+    public void testPrivateClientNotPermitted() {
+        Client c = TEST_DATA_RESOURCE.getAdminApplication()
+                .getBuilder()
+                .client(ClientType.AuthorizationGrant, true)
+                .build()
+                .getClient();
+
+        Form requestData = new Form();
+        requestData.param("client_id", IdUtil.toString(c.getId()));
+        requestData.param("client_secret", c.getClientSecret());
+        Entity<Form> testEntity = Entity.entity(requestData,
+                APPLICATION_FORM_URLENCODED_TYPE);
+
+        Response r = target("/client/public")
+                .request()
+                .post(testEntity);
+
+        assertEquals(Status.UNAUTHORIZED.getStatusCode(), r.getStatus());
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/authn/authn/O2TestResource.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/authn/authn/O2TestResource.java
@@ -71,4 +71,30 @@ public final class O2TestResource {
     public Response authorizedPUT(@Context final SecurityContext c) {
         return Response.ok().build();
     }
+
+    /**
+     * A POST method that is private-only authorized.
+     *
+     * @param c The injected security context.
+     * @return The response.
+     */
+    @O2Client(permitPublic = false)
+    @POST
+    @Path("/client/private")
+    public Response authorizedPrivatePOST(@Context final SecurityContext c) {
+        return Response.ok().build();
+    }
+
+    /**
+     * A POST method that is private-only authorized.
+     *
+     * @param c The injected security context.
+     * @return The response.
+     */
+    @O2Client(permitPrivate = false)
+    @POST
+    @Path("/client/public")
+    public Response authorizedPublicPOST(@Context final SecurityContext c) {
+        return Response.ok().build();
+    }
 }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/authn/authz/O2AuthorizationFilterTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/authn/authz/O2AuthorizationFilterTest.java
@@ -68,7 +68,7 @@ public final class O2AuthorizationFilterTest {
      */
     @Test(expected = AccessDeniedException.class)
     public void assertFailWithWrongPrincipalType() {
-        O2AuthorizationFilter filter = new O2AuthorizationFilter(true, true);
+        O2AuthorizationFilter filter = new O2AuthorizationFilter();
 
         Principal principal = () -> "wrong type";
         doReturn(principal)
@@ -83,7 +83,7 @@ public final class O2AuthorizationFilterTest {
      */
     @Test(expected = AccessDeniedException.class)
     public void assertFailWithNoPrincipal() {
-        O2AuthorizationFilter filter = new O2AuthorizationFilter(true, true);
+        O2AuthorizationFilter filter = new O2AuthorizationFilter();
 
         doReturn(null)
                 .when(securityContext)
@@ -97,7 +97,7 @@ public final class O2AuthorizationFilterTest {
      */
     @Test(expected = AccessDeniedException.class)
     public void assertFailWithNoClient() {
-        O2AuthorizationFilter filter = new O2AuthorizationFilter(true, true);
+        O2AuthorizationFilter filter = new O2AuthorizationFilter();
 
         O2Principal p = new O2Principal();
 
@@ -113,47 +113,10 @@ public final class O2AuthorizationFilterTest {
      */
     @Test
     public void assertPassWithPublicClient() {
-        O2AuthorizationFilter filter = new O2AuthorizationFilter(true, true);
+        O2AuthorizationFilter filter = new O2AuthorizationFilter();
 
         Client c = new Client();
         c.setId(IdUtil.next());
-        O2Principal p = new O2Principal(c);
-
-        doReturn(p)
-                .when(securityContext)
-                .getUserPrincipal();
-
-        filter.filter(requestContext);
-    }
-
-    /**
-     * If we have a public client but it's not permitted, throw.
-     */
-    @Test(expected = AccessDeniedException.class)
-    public void assertFailWithNonpermittedPublicClient() {
-        O2AuthorizationFilter filter = new O2AuthorizationFilter(true, false);
-
-        Client c = new Client();
-        c.setId(IdUtil.next());
-        O2Principal p = new O2Principal(c);
-
-        doReturn(p)
-                .when(securityContext)
-                .getUserPrincipal();
-
-        filter.filter(requestContext);
-    }
-
-    /**
-     * If we have a private client but it's not permitted, throw.
-     */
-    @Test(expected = AccessDeniedException.class)
-    public void assertFailWithNonpermittedPrivateClient() {
-        O2AuthorizationFilter filter = new O2AuthorizationFilter(false, true);
-
-        Client c = new Client();
-        c.setId(IdUtil.next());
-        c.setClientSecret("private_secret");
         O2Principal p = new O2Principal(c);
 
         doReturn(p)


### PR DESCRIPTION
We should be able to have a single auth method permit private clients,
while other auth methods permit public clients. For example, bearer
token based auth for token introspection should allow any client,
while client auth must only permit private clients. As such,
this patch moves the client processing filter into the Authentication
filters, not the Authorization filters.