### PR TITLE
Introduce O2BearerTokenFilter

### DIFF
--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/authn/O2AuthDynamicFeature.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/authn/O2AuthDynamicFeature.java
@@ -18,6 +18,7 @@
 
 package net.krotscheck.kangaroo.authz.oauth2.authn;
 
+import net.krotscheck.kangaroo.authz.oauth2.authn.authn.O2BearerTokenFilter;
 import net.krotscheck.kangaroo.authz.oauth2.authn.authn.O2ClientBasicAuthFilter;
 import net.krotscheck.kangaroo.authz.oauth2.authn.authn.O2ClientBodyFilter;
 import net.krotscheck.kangaroo.authz.oauth2.authn.authn.O2ClientQueryParameterFilter;
@@ -83,12 +84,13 @@ public final class O2AuthDynamicFeature implements DynamicFeature {
                 new AnnotatedMethod(resourceInfo.getResourceMethod());
 
         Boolean client = am.isAnnotationPresent(O2Client.class);
+        Boolean token = am.isAnnotationPresent(O2BearerToken.class);
 
         if (client) {
-            O2Client annotation = am.getAnnotation(O2Client.class);
+            O2Client clientAT = am.getAnnotation(O2Client.class);
 
-            Boolean permitPrivate = annotation.permitPrivate();
-            Boolean permitPublic = annotation.permitPublic();
+            Boolean permitPrivate = clientAT.permitPrivate();
+            Boolean permitPublic = clientAT.permitPublic();
 
             if (permitPublic) {
                 configuration.register(new O2ClientQueryParameterFilter(
@@ -104,7 +106,17 @@ public final class O2AuthDynamicFeature implements DynamicFeature {
                     permitPrivate, permitPublic));
         }
 
-        if (client) {
+        if (token) {
+            O2BearerToken tokenAT = am.getAnnotation(O2BearerToken.class);
+            configuration.register(new O2BearerTokenFilter(
+                    requestProvider,
+                    sessionProvider,
+                    tokenAT.permitPrivate(),
+                    tokenAT.permitPublic()
+            ));
+        }
+
+        if (client || token) {
             configuration.register(new O2AuthorizationFilter());
         }
     }

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/authn/O2AuthScheme.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/authn/O2AuthScheme.java
@@ -39,6 +39,11 @@ public enum O2AuthScheme {
     ClientPrivate(true),
 
     /**
+     * This request was authorized via a bearer token.
+     */
+    BearerToken(true),
+
+    /**
      * No authentication was included.
      */
     None(false);

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/authn/O2BearerToken.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/authn/O2BearerToken.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.oauth2.authn;
+
+import javax.ws.rs.NameBinding;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation enables authentication via an already authorized bearer
+ * token.
+ *
+ * @author Michael Krotscheck
+ */
+@Target({ElementType.METHOD})
+@Retention(value = RetentionPolicy.RUNTIME)
+@NameBinding
+public @interface O2BearerToken {
+
+    /**
+     * Whether to permit private clients.
+     *
+     * @return True if private clients are permitted, otherwise false.
+     */
+    boolean permitPrivate() default true;
+
+    /**
+     * Whether to permit public clients.
+     *
+     * @return True if public clients are permitted, otherwise false.
+     */
+    boolean permitPublic() default true;
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/authn/authn/O2BearerTokenFilter.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/authn/authn/O2BearerTokenFilter.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.oauth2.authn.authn;
+
+import net.krotscheck.kangaroo.authz.common.database.entity.Client;
+import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
+import net.krotscheck.kangaroo.authz.oauth2.authn.O2Principal;
+import net.krotscheck.kangaroo.authz.oauth2.exception.RFC6749.AccessDeniedException;
+import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.hibernate.Session;
+
+import javax.annotation.Priority;
+import javax.inject.Provider;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import java.math.BigInteger;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+import static net.krotscheck.kangaroo.authz.common.database.entity.OAuthTokenType.Bearer;
+import static org.apache.http.HttpHeaders.AUTHORIZATION;
+
+
+/**
+ * This filter's job is to permit authentication on OAuth endpoints via an
+ * already issued bearer token. In this case, no special scope is required,
+ * however care should be taken at the resource endpoint to appropriately
+ * scope this style of request.
+ *
+ * @author Michael Krotscheck
+ */
+@Priority(Priorities.AUTHENTICATION)
+public final class O2BearerTokenFilter
+        extends AbstractO2AuthenticationFilter {
+
+    /**
+     * HTTP Bearer header matching.
+     */
+    private static final Pattern BEARER =
+            Pattern.compile("^Bearer ([a-f0-9]{32})$", CASE_INSENSITIVE);
+
+    /**
+     * Permit private clients.
+     */
+    private final Boolean permitPrivate;
+
+    /**
+     * Permit public clients.
+     */
+    private final Boolean permitPublic;
+
+    /**
+     * Create a new instance of this filter.
+     *
+     * @param requestProvider The request provider.
+     * @param sessionProvider The session provider.
+     * @param permitPrivate   Whether private clients are permitted.
+     * @param permitPublic    Whether public clients are permitted.
+     */
+    public O2BearerTokenFilter(final Provider<ContainerRequest> requestProvider,
+                               final Provider<Session> sessionProvider,
+                               final boolean permitPrivate,
+                               final boolean permitPublic) {
+        super(requestProvider, sessionProvider);
+        this.permitPrivate = permitPrivate;
+        this.permitPublic = permitPublic;
+    }
+
+    /**
+     * Extract the authorization header. If it turns out to be a Bearer auth
+     * client header, resolve that.
+     *
+     * @param request The request.
+     */
+    @Override
+    public void filter(final ContainerRequestContext request) {
+
+        // Is there an authorization header that matches the 'BEARER' pattern?
+        Matcher authHeader = Optional
+
+                // Pull the header.
+                .ofNullable(request.getHeaderString(AUTHORIZATION))
+                .map(String::trim)
+
+                // Try to match against it.
+                .map(BEARER::matcher)
+                .filter(Matcher::matches)
+
+                .orElse(null);
+
+        // No fitting auth header has been found. Pass it on to another handler.
+        if (authHeader == null) {
+            return;
+        }
+
+        // Pull and decode the id.
+        BigInteger bigId = Optional
+                .ofNullable(authHeader.group(1))
+                .map(IdUtil::fromString)
+                .orElseThrow(BadRequestException::new);
+
+        // If we have an ID, convert it into a non-expired bearer token.
+        OAuthToken token = Optional.of(bigId)
+                .map(id -> getSession().find(OAuthToken.class, id))
+                .filter(t -> t.getTokenType().equals(Bearer))
+                .filter(t -> !t.isExpired())
+                .orElseThrow(AccessDeniedException::new);
+
+        Client c = token.getClient();
+
+        if (!c.isPublic().equals(permitPublic)
+                && !c.isPrivate().equals(permitPrivate)) {
+            throw new AccessDeniedException();
+        }
+
+        setPrincipal(new O2Principal(token));
+    }
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/authn/authn/O2ClientBodyFilter.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/authn/authn/O2ClientBodyFilter.java
@@ -150,13 +150,9 @@ public final class O2ClientBodyFilter
                         creds.getValue()))
                 .orElseThrow(AccessDeniedException::new);
 
-        // Only permit public if flagged.
-        if (!permitPublic && client.isPublic()) {
-            throw new AccessDeniedException();
-        }
 
-        // Only permit private if flagged.
-        if (!permitPrivate && client.isPrivate()) {
+        if (!client.isPublic().equals(permitPublic)
+                && !client.isPrivate().equals(permitPrivate)) {
             throw new AccessDeniedException();
         }
 

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/authn/O2AuthDynamicFeatureTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/authn/O2AuthDynamicFeatureTest.java
@@ -24,6 +24,7 @@ import net.krotscheck.kangaroo.authz.admin.v1.test.rule.TestDataResource;
 import net.krotscheck.kangaroo.authz.common.database.DatabaseFeature;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
+import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.oauth2.authn.authn.O2TestResource;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
 import net.krotscheck.kangaroo.common.config.ConfigurationFeature;
@@ -38,6 +39,7 @@ import javax.ws.rs.core.Response.Status;
 
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static net.krotscheck.kangaroo.util.HttpUtil.authHeaderBasic;
+import static net.krotscheck.kangaroo.util.HttpUtil.authHeaderBearer;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -85,7 +87,7 @@ public final class O2AuthDynamicFeatureTest extends ContainerTest {
      */
     @Test
     public void testFailedAuth() {
-        Response r = target("/")
+        Response r = target("/client")
                 .request()
                 .get();
 
@@ -96,7 +98,7 @@ public final class O2AuthDynamicFeatureTest extends ContainerTest {
      * Assert that a request with a valid ID and secret pass.
      */
     @Test
-    public void testValidAuth() {
+    public void testValidClientAuth() {
         ApplicationContext context =
                 TEST_DATA_RESOURCE.getSecondaryApplication().getBuilder()
                         .client(ClientType.AuthorizationGrant, true)
@@ -105,7 +107,29 @@ public final class O2AuthDynamicFeatureTest extends ContainerTest {
 
         String header = authHeaderBasic(c.getId(), c.getClientSecret());
 
-        Response r = target("/")
+        Response r = target("/client")
+                .request()
+                .header(AUTHORIZATION, header)
+                .get();
+
+        assertEquals(Status.OK.getStatusCode(), r.getStatus());
+    }
+
+    /**
+     * Assert that a request with a valid bearer token passes.
+     */
+    @Test
+    public void testValidTokenAuth() {
+        ApplicationContext context =
+                TEST_DATA_RESOURCE.getSecondaryApplication().getBuilder()
+                        .client(ClientType.AuthorizationGrant, true)
+                        .bearerToken()
+                        .build();
+        OAuthToken t = context.getToken();
+
+        String header = authHeaderBearer(t.getId());
+
+        Response r = target("/token")
                 .request()
                 .header(AUTHORIZATION, header)
                 .get();

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/authn/O2AuthSchemeTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/authn/O2AuthSchemeTest.java
@@ -50,6 +50,9 @@ public class O2AuthSchemeTest {
         String implicit = m.writeValueAsString(O2AuthScheme.ClientPublic);
         assertEquals("\"ClientPublic\"", implicit);
 
+        String bearerToken = m.writeValueAsString(O2AuthScheme.BearerToken);
+        assertEquals("\"BearerToken\"", bearerToken);
+
         String owner = m.writeValueAsString(O2AuthScheme.None);
         assertEquals("\"None\"", owner);
     }
@@ -71,6 +74,10 @@ public class O2AuthSchemeTest {
                 m.readValue("\"ClientPublic\"", O2AuthScheme.class);
         assertSame(implicit, O2AuthScheme.ClientPublic);
 
+        O2AuthScheme bearerToken =
+                m.readValue("\"BearerToken\"", O2AuthScheme.class);
+        assertSame(bearerToken, O2AuthScheme.BearerToken);
+
         O2AuthScheme owner =
                 m.readValue("\"None\"", O2AuthScheme.class);
         assertSame(owner, O2AuthScheme.None);
@@ -90,6 +97,10 @@ public class O2AuthSchemeTest {
                 O2AuthScheme.valueOf("ClientPublic")
         );
         assertEquals(
+                O2AuthScheme.BearerToken,
+                O2AuthScheme.valueOf("BearerToken")
+        );
+        assertEquals(
                 O2AuthScheme.None,
                 O2AuthScheme.valueOf("None")
         );
@@ -101,6 +112,7 @@ public class O2AuthSchemeTest {
     @Test
     public void testType() {
         assertTrue(O2AuthScheme.ClientPrivate.isAuth());
+        assertTrue(O2AuthScheme.BearerToken.isAuth());
         assertFalse(O2AuthScheme.ClientPublic.isAuth());
         assertFalse(O2AuthScheme.None.isAuth());
     }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/authn/authn/O2BearerTokenFilterTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/authn/authn/O2BearerTokenFilterTest.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.oauth2.authn.authn;
+
+import net.krotscheck.kangaroo.authz.admin.v1.servlet.FirstRunContainerLifecycleListener;
+import net.krotscheck.kangaroo.authz.admin.v1.servlet.ServletConfigFactory;
+import net.krotscheck.kangaroo.authz.admin.v1.test.rule.TestDataResource;
+import net.krotscheck.kangaroo.authz.common.database.DatabaseFeature;
+import net.krotscheck.kangaroo.authz.common.database.entity.Client;
+import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
+import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
+import net.krotscheck.kangaroo.authz.common.database.entity.OAuthTokenType;
+import net.krotscheck.kangaroo.authz.oauth2.authn.O2AuthDynamicFeature;
+import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.common.config.ConfigurationFeature;
+import net.krotscheck.kangaroo.common.exception.ExceptionFeature;
+import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
+import net.krotscheck.kangaroo.test.jersey.ContainerTest;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import java.math.BigInteger;
+
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static net.krotscheck.kangaroo.util.HttpUtil.authHeaderBearer;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests for Bearer-token based authentication.
+ *
+ * @author Michael Krotscheck
+ */
+public final class O2BearerTokenFilterTest extends ContainerTest {
+
+    /**
+     * Preload data into the system.
+     */
+    @ClassRule
+    public static final TestDataResource TEST_DATA_RESOURCE =
+            new TestDataResource(HIBERNATE_RESOURCE);
+
+    /**
+     * Setup an application.
+     *
+     * @return A configured application.
+     */
+    @Override
+    protected ResourceConfig createApplication() {
+        ResourceConfig a = new ResourceConfig();
+
+        // Build a minimal application
+        a.register(ConfigurationFeature.class);
+        a.register(DatabaseFeature.class);
+        a.register(ExceptionFeature.class);
+        a.register(new ServletConfigFactory.Binder());
+        a.register(new FirstRunContainerLifecycleListener.Binder());
+
+        // Layer in the code under test. Taking the whole feature set here,
+        // because it's easier.
+        a.register(O2AuthDynamicFeature.class);
+
+        // Add our test resource.
+        a.register(O2TestResource.class);
+
+        return a;
+    }
+
+    /**
+     * Assert that a request with no authorization header fails.
+     */
+    @Test
+    public void testNoAuthorization() {
+        Response r = target("/token")
+                .request()
+                .get();
+
+        assertEquals(Status.UNAUTHORIZED.getStatusCode(), r.getStatus());
+    }
+
+    /**
+     * Assert that a request with an invalid header fails.
+     */
+    @Test
+    public void testInvalidAuthorizationHeader() {
+        Response r = target("/token")
+                .request()
+                .header(AUTHORIZATION, "Not A Valid header")
+                .get();
+
+        assertEquals(Status.UNAUTHORIZED.getStatusCode(), r.getStatus());
+    }
+
+    /**
+     * Assert that a request with a malformed Bearer header fails.
+     */
+    @Test
+    public void testInvalidBearerHeader() {
+        Response r = target("/token")
+                .request()
+                .header(AUTHORIZATION, "Bearer some_secluded_rendezvous")
+                .get();
+
+        assertEquals(Status.UNAUTHORIZED.getStatusCode(), r.getStatus());
+    }
+
+    /**
+     * Assert that a request with a malformed user/pass indicates a bad request.
+     */
+    @Test
+    public void testMalformedCredentialsHeader() {
+        String header =
+                authHeaderBearer("malformed_token");
+
+        Response r = target("/token")
+                .request()
+                .header(AUTHORIZATION, header)
+                .get();
+
+        assertEquals(Status.UNAUTHORIZED.getStatusCode(), r.getStatus());
+    }
+
+    /**
+     * Assert that a request with nonexistent credentials fails.
+     */
+    @Test
+    public void testNonexistentCredentialsHeader() {
+        BigInteger id = IdUtil.next();
+
+        String header = authHeaderBearer(id);
+
+        Response r = target("/token")
+                .request()
+                .header(AUTHORIZATION, header)
+                .get();
+
+        assertEquals(Status.UNAUTHORIZED.getStatusCode(), r.getStatus());
+    }
+
+    /**
+     * Assert that a request with a valid ID of a private client, but invalid
+     * secret fails.
+     */
+    @Test
+    public void testBadPasswordHeader() {
+        ApplicationContext context =
+                TEST_DATA_RESOURCE.getSecondaryApplication().getBuilder()
+                        .client(ClientType.AuthorizationGrant, true)
+                        .build();
+        Client c = context.getClient();
+
+        String header = authHeaderBearer(c.getId());
+
+        Response r = target("/token")
+                .request()
+                .header(AUTHORIZATION, header)
+                .get();
+
+        assertEquals(Status.UNAUTHORIZED.getStatusCode(), r.getStatus());
+    }
+
+    /**
+     * Assert that a request with a valid ID of a public client, and no
+     * secret fails.
+     */
+    @Test
+    public void testPublicClientHeader() {
+        ApplicationContext context =
+                TEST_DATA_RESOURCE.getSecondaryApplication().getBuilder()
+                        .client(ClientType.AuthorizationGrant, false)
+                        .build();
+        Client c = context.getClient();
+
+        String header = authHeaderBearer(c.getId());
+
+        Response r = target("/token")
+                .request()
+                .header(AUTHORIZATION, header)
+                .get();
+
+        assertEquals(Status.UNAUTHORIZED.getStatusCode(), r.getStatus());
+    }
+
+    /**
+     * Assert that a valid bearer token for a private client passes.
+     */
+    @Test
+    public void testValidRequestHeaderPrivate() {
+        ApplicationContext context =
+                TEST_DATA_RESOURCE
+                        .getSecondaryApplication()
+                        .getBuilder()
+                        .client(ClientType.AuthorizationGrant, true)
+                        .bearerToken()
+                        .build();
+        OAuthToken t = context.getToken();
+
+        String header = authHeaderBearer(t.getId());
+
+        Response r = target("/token/private")
+                .request()
+                .header(AUTHORIZATION, header)
+                .get();
+
+        assertEquals(Status.OK.getStatusCode(), r.getStatus());
+    }
+
+    /**
+     * Assert that a valid bearer token for a private client fails if not
+     * allowed.
+     */
+    @Test
+    public void testValidRequestHeaderPrivateNotPermitted() {
+        ApplicationContext context =
+                TEST_DATA_RESOURCE
+                        .getSecondaryApplication()
+                        .getBuilder()
+                        .client(ClientType.AuthorizationGrant, true)
+                        .bearerToken()
+                        .build();
+        OAuthToken t = context.getToken();
+
+        String header = authHeaderBearer(t.getId());
+
+        Response r = target("/token/public")
+                .request()
+                .header(AUTHORIZATION, header)
+                .get();
+
+        assertEquals(Status.UNAUTHORIZED.getStatusCode(), r.getStatus());
+    }
+
+    /**
+     * Assert that a bearer token for a public client passes if permitted.
+     */
+    @Test
+    public void testValidRequestHeaderPublic() {
+        ApplicationContext context =
+                TEST_DATA_RESOURCE
+                        .getSecondaryApplication()
+                        .getBuilder()
+                        .client(ClientType.AuthorizationGrant, false)
+                        .bearerToken()
+                        .build();
+        OAuthToken t = context.getToken();
+
+        String header = authHeaderBearer(t.getId());
+
+        Response r = target("/token/public")
+                .request()
+                .header(AUTHORIZATION, header)
+                .get();
+
+        assertEquals(Status.OK.getStatusCode(), r.getStatus());
+    }
+
+    /**
+     * Assert that a bearer token for a public client fails if not permitted.
+     */
+    @Test
+    public void testValidRequestHeaderPublicNotPermitted() {
+        ApplicationContext context =
+                TEST_DATA_RESOURCE
+                        .getSecondaryApplication()
+                        .getBuilder()
+                        .client(ClientType.Implicit, false)
+                        .bearerToken()
+                        .build();
+        OAuthToken t = context.getToken();
+
+        String header = authHeaderBearer(t.getId());
+
+        Response r = target("/token/private")
+                .request()
+                .header(AUTHORIZATION, header)
+                .get();
+
+        assertEquals(Status.UNAUTHORIZED.getStatusCode(), r.getStatus());
+    }
+
+    /**
+     * Assert that an expired token fails.
+     */
+    @Test
+    public void testExpiredToken() {
+        ApplicationContext context =
+                TEST_DATA_RESOURCE
+                        .getSecondaryApplication()
+                        .getBuilder()
+                        .client(ClientType.AuthorizationGrant, true)
+                        .token(OAuthTokenType.Bearer, true, null, null, null)
+                        .build();
+        OAuthToken t = context.getToken();
+
+        String header = authHeaderBearer(t.getId());
+
+        Response r = target("/token/private")
+                .request()
+                .header(AUTHORIZATION, header)
+                .get();
+
+        assertEquals(Status.UNAUTHORIZED.getStatusCode(), r.getStatus());
+    }
+
+    /**
+     * Assert that refresh tokens are not permitted.
+     */
+    @Test
+    public void testRefreshToken() {
+        ApplicationContext context =
+                TEST_DATA_RESOURCE
+                        .getSecondaryApplication()
+                        .getBuilder()
+                        .client(ClientType.AuthorizationGrant, true)
+                        .bearerToken()
+                        .refreshToken()
+                        .build();
+        OAuthToken t = context.getToken();
+
+        String header = authHeaderBearer(t.getId());
+
+        Response r = target("/token/private")
+                .request()
+                .header(AUTHORIZATION, header)
+                .get();
+
+        assertEquals(Status.UNAUTHORIZED.getStatusCode(), r.getStatus());
+    }
+
+    /**
+     * Assert that authorization codes are not permitted.
+     */
+    @Test
+    public void testAuthorizationCode() {
+        ApplicationContext context =
+                TEST_DATA_RESOURCE
+                        .getSecondaryApplication()
+                        .getBuilder()
+                        .client(ClientType.AuthorizationGrant, true)
+                        .authToken()
+                        .build();
+        OAuthToken t = context.getToken();
+
+        String header = authHeaderBearer(t.getId());
+
+        Response r = target("/token/private")
+                .request()
+                .header(AUTHORIZATION, header)
+                .get();
+
+        assertEquals(Status.UNAUTHORIZED.getStatusCode(), r.getStatus());
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/authn/authn/O2ClientBasicAuthFilterTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/authn/authn/O2ClientBasicAuthFilterTest.java
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertEquals;
  *
  * @author Michael Krotscheck
  */
-public class O2ClientBasicAuthFilterTest extends ContainerTest {
+public final class O2ClientBasicAuthFilterTest extends ContainerTest {
 
     /**
      * Preload data into the system.
@@ -87,7 +87,7 @@ public class O2ClientBasicAuthFilterTest extends ContainerTest {
      */
     @Test
     public void testNoAuthorization() {
-        Response r = target("/")
+        Response r = target("/client")
                 .request()
                 .get();
 
@@ -99,7 +99,7 @@ public class O2ClientBasicAuthFilterTest extends ContainerTest {
      */
     @Test
     public void testInvalidAuthorizationHeader() {
-        Response r = target("/")
+        Response r = target("/client")
                 .request()
                 .header(AUTHORIZATION, "Not A Valid header")
                 .get();
@@ -112,7 +112,7 @@ public class O2ClientBasicAuthFilterTest extends ContainerTest {
      */
     @Test
     public void testInvalidBasicHeader() {
-        Response r = target("/")
+        Response r = target("/client")
                 .request()
                 .header(AUTHORIZATION, "Basic some_secluded_rendezvous")
                 .get();
@@ -128,7 +128,7 @@ public class O2ClientBasicAuthFilterTest extends ContainerTest {
         String header =
                 authHeaderBasic("malformed_id", "malformed_pass");
 
-        Response r = target("/")
+        Response r = target("/client")
                 .request()
                 .header(AUTHORIZATION, header)
                 .get();
@@ -146,7 +146,7 @@ public class O2ClientBasicAuthFilterTest extends ContainerTest {
 
         String header = authHeaderBasic(id, IdUtil.toString(pass));
 
-        Response r = target("/")
+        Response r = target("/client")
                 .request()
                 .header(AUTHORIZATION, header)
                 .get();
@@ -168,7 +168,7 @@ public class O2ClientBasicAuthFilterTest extends ContainerTest {
 
         String header = authHeaderBasic(c.getId(), "invalid_pass");
 
-        Response r = target("/")
+        Response r = target("/client")
                 .request()
                 .header(AUTHORIZATION, header)
                 .get();
@@ -190,7 +190,7 @@ public class O2ClientBasicAuthFilterTest extends ContainerTest {
 
         String header = authHeaderBasic(c.getId(), "");
 
-        Response r = target("/")
+        Response r = target("/client")
                 .request()
                 .header(AUTHORIZATION, header)
                 .get();
@@ -211,7 +211,7 @@ public class O2ClientBasicAuthFilterTest extends ContainerTest {
 
         String header = authHeaderBasic(c.getId(), c.getClientSecret());
 
-        Response r = target("/")
+        Response r = target("/client")
                 .request()
                 .header(AUTHORIZATION, header)
                 .get();

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/authn/authn/O2ClientBodyFilterTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/authn/authn/O2ClientBodyFilterTest.java
@@ -51,7 +51,7 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Michael Krotscheck
  */
-public class O2ClientBodyFilterTest extends ContainerTest {
+public final class O2ClientBodyFilterTest extends ContainerTest {
 
     /**
      * Preload data into the system.
@@ -95,7 +95,7 @@ public class O2ClientBodyFilterTest extends ContainerTest {
         Entity<Form> testEntity = Entity.entity(requestData,
                 APPLICATION_FORM_URLENCODED_TYPE);
 
-        Response r = target("/")
+        Response r = target("/client")
                 .request()
                 .post(testEntity);
 
@@ -113,7 +113,7 @@ public class O2ClientBodyFilterTest extends ContainerTest {
         Entity<Form> testEntity = Entity.entity(requestData,
                 APPLICATION_FORM_URLENCODED_TYPE);
 
-        Response r = target("/")
+        Response r = target("/client")
                 .request()
                 .post(testEntity);
 
@@ -134,7 +134,7 @@ public class O2ClientBodyFilterTest extends ContainerTest {
         Entity<Map<String, String>> testEntity =
                 Entity.entity(requestData, APPLICATION_JSON_TYPE);
 
-        Response r = target("/")
+        Response r = target("/client")
                 .request()
                 .post(testEntity);
 
@@ -151,7 +151,7 @@ public class O2ClientBodyFilterTest extends ContainerTest {
         Entity<Form> testEntity = Entity.entity(requestData,
                 APPLICATION_FORM_URLENCODED_TYPE);
 
-        Response r = target("/")
+        Response r = target("/client")
                 .request()
                 .post(testEntity);
 
@@ -169,7 +169,7 @@ public class O2ClientBodyFilterTest extends ContainerTest {
         Entity<Form> testEntity = Entity.entity(requestData,
                 APPLICATION_FORM_URLENCODED_TYPE);
 
-        Response r = target("/")
+        Response r = target("/client")
                 .request()
                 .post(testEntity);
 
@@ -194,7 +194,7 @@ public class O2ClientBodyFilterTest extends ContainerTest {
         Entity<Form> testEntity = Entity.entity(requestData,
                 APPLICATION_FORM_URLENCODED_TYPE);
 
-        Response r = target("/")
+        Response r = target("/client")
                 .request()
                 .post(testEntity);
 
@@ -220,7 +220,7 @@ public class O2ClientBodyFilterTest extends ContainerTest {
         Entity<Form> testEntity = Entity.entity(requestData,
                 APPLICATION_FORM_URLENCODED_TYPE);
 
-        Response r = target("/")
+        Response r = target("/client")
                 .request()
                 .post(testEntity);
 
@@ -245,7 +245,7 @@ public class O2ClientBodyFilterTest extends ContainerTest {
         Entity<Form> testEntity = Entity.entity(requestData,
                 APPLICATION_FORM_URLENCODED_TYPE);
 
-        Response r = target("/")
+        Response r = target("/client")
                 .request()
                 .post(testEntity);
 
@@ -269,7 +269,7 @@ public class O2ClientBodyFilterTest extends ContainerTest {
         Entity<Form> testEntity = Entity.entity(requestData,
                 APPLICATION_FORM_URLENCODED_TYPE);
 
-        Response r = target("/")
+        Response r = target("/client")
                 .request()
                 .post(testEntity);
 
@@ -317,7 +317,7 @@ public class O2ClientBodyFilterTest extends ContainerTest {
         Entity<Form> testEntity = Entity.entity(requestData,
                 APPLICATION_FORM_URLENCODED_TYPE);
 
-        Response r = target("/")
+        Response r = target("/client")
                 .request()
                 .post(testEntity);
 
@@ -366,7 +366,7 @@ public class O2ClientBodyFilterTest extends ContainerTest {
         Entity<Form> testEntity = Entity.entity(requestData,
                 APPLICATION_FORM_URLENCODED_TYPE);
 
-        Response r = target("/")
+        Response r = target("/client")
                 .request()
                 .put(testEntity);
 

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/authn/authn/O2ClientQueryParameterFilterTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/authn/authn/O2ClientQueryParameterFilterTest.java
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertEquals;
  *
  * @author Michael Krotscheck
  */
-public class O2ClientQueryParameterFilterTest extends ContainerTest {
+public final class O2ClientQueryParameterFilterTest extends ContainerTest {
 
     /**
      * Preload data into the system.
@@ -87,7 +87,7 @@ public class O2ClientQueryParameterFilterTest extends ContainerTest {
      */
     @Test
     public void testNoParam() {
-        Response r = target("/")
+        Response r = target("/client")
                 .request()
                 .get();
 
@@ -99,7 +99,7 @@ public class O2ClientQueryParameterFilterTest extends ContainerTest {
      */
     @Test
     public void testNoClientAuthParams() {
-        Response r = target("/")
+        Response r = target("/client")
                 .queryParam("hello", "world")
                 .queryParam("hello", "kitty")
                 .request()
@@ -113,7 +113,7 @@ public class O2ClientQueryParameterFilterTest extends ContainerTest {
      */
     @Test
     public void testMalformedClientId() {
-        Response r = target("/")
+        Response r = target("/client")
                 .queryParam("client_id", "not_a_biginteger")
                 .request()
                 .get();
@@ -126,7 +126,7 @@ public class O2ClientQueryParameterFilterTest extends ContainerTest {
      */
     @Test
     public void testNonexistentClientId() {
-        Response r = target("/")
+        Response r = target("/client")
                 .queryParam("client_id", IdUtil.toString(IdUtil.next()))
                 .request()
                 .get();
@@ -146,7 +146,7 @@ public class O2ClientQueryParameterFilterTest extends ContainerTest {
         Client c2 = b.client(ClientType.Implicit, false)
                 .build().getClient();
 
-        Response r = target("/")
+        Response r = target("/client")
                 .queryParam("client_id", IdUtil.toString(c1.getId()))
                 .queryParam("client_id", IdUtil.toString(c2.getId()))
                 .request()
@@ -166,7 +166,7 @@ public class O2ClientQueryParameterFilterTest extends ContainerTest {
                 .build()
                 .getClient();
 
-        Response r = target("/")
+        Response r = target("/client")
                 .queryParam("client_id", IdUtil.toString(c.getId()))
                 .queryParam("client_secret", c.getClientSecret())
                 .request()
@@ -186,7 +186,7 @@ public class O2ClientQueryParameterFilterTest extends ContainerTest {
                 .build()
                 .getClient();
 
-        Response r = target("/")
+        Response r = target("/client")
                 .queryParam("client_id", IdUtil.toString(c.getId()))
                 .request()
                 .get();
@@ -209,7 +209,7 @@ public class O2ClientQueryParameterFilterTest extends ContainerTest {
         Entity<Form> testEntity = Entity.entity(requestData,
                 APPLICATION_FORM_URLENCODED_TYPE);
 
-        Response r = target("/")
+        Response r = target("/client")
                 .queryParam("client_id", IdUtil.toString(c.getId()))
                 .request()
                 .put(testEntity);
@@ -232,7 +232,7 @@ public class O2ClientQueryParameterFilterTest extends ContainerTest {
         Entity<Form> testEntity = Entity.entity(requestData,
                 APPLICATION_FORM_URLENCODED_TYPE);
 
-        Response r = target("/")
+        Response r = target("/client")
                 .queryParam("client_id", IdUtil.toString(c.getId()))
                 .request()
                 .post(testEntity);

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/authn/authn/O2TestResource.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/authn/authn/O2TestResource.java
@@ -18,6 +18,7 @@
 
 package net.krotscheck.kangaroo.authz.oauth2.authn.authn;
 
+import net.krotscheck.kangaroo.authz.oauth2.authn.O2BearerToken;
 import net.krotscheck.kangaroo.authz.oauth2.authn.O2Client;
 
 import javax.ws.rs.GET;
@@ -37,6 +38,20 @@ import javax.ws.rs.core.SecurityContext;
 public final class O2TestResource {
 
     /**
+     * A resource is both client and token authorized.
+     *
+     * @param c The injected security context.
+     * @return The response.
+     */
+    @O2BearerToken
+    @O2Client
+    @GET
+    @Path("/multi")
+    public Response multiAuthorizedGet(@Context final SecurityContext c) {
+        return Response.ok().build();
+    }
+
+    /**
      * A GET method that is client authorized.
      *
      * @param c The injected security context.
@@ -44,7 +59,8 @@ public final class O2TestResource {
      */
     @O2Client
     @GET
-    public Response authorizedGET(@Context final SecurityContext c) {
+    @Path("/client")
+    public Response clientAuthorizedGET(@Context final SecurityContext c) {
         return Response.ok().build();
     }
 
@@ -56,7 +72,8 @@ public final class O2TestResource {
      */
     @O2Client
     @POST
-    public Response authorizedPOST(@Context final SecurityContext c) {
+    @Path("/client")
+    public Response clientAuthorizedPOST(@Context final SecurityContext c) {
         return Response.ok().build();
     }
 
@@ -68,7 +85,8 @@ public final class O2TestResource {
      */
     @O2Client
     @PUT
-    public Response authorizedPUT(@Context final SecurityContext c) {
+    @Path("/client")
+    public Response clientAuthorizedPUT(@Context final SecurityContext c) {
         return Response.ok().build();
     }
 
@@ -95,6 +113,49 @@ public final class O2TestResource {
     @POST
     @Path("/client/public")
     public Response authorizedPublicPOST(@Context final SecurityContext c) {
+        return Response.ok().build();
+    }
+
+    /**
+     * A GET method that is bearer token authorized.
+     *
+     * @param c The injected security context.
+     * @return The response.
+     */
+    @O2BearerToken
+    @GET
+    @Path("/token")
+    public Response bearerAuthorizedGet(@Context final SecurityContext c) {
+        return Response.ok().build();
+    }
+
+    /**
+     * A GET method that is bearer token authorized, permitting only private
+     * clients.
+     *
+     * @param c The injected security context.
+     * @return The response.
+     */
+    @O2BearerToken(permitPrivate = false)
+    @GET
+    @Path("/token/public")
+    public Response bearerAuthorizedGetPrivate(
+            @Context final SecurityContext c) {
+        return Response.ok().build();
+    }
+
+    /**
+     * A GET method that is bearer token authorized, permitting only public
+     * clients.
+     *
+     * @param c The injected security context.
+     * @return The response.
+     */
+    @O2BearerToken(permitPublic = false)
+    @GET
+    @Path("/token/private")
+    public Response bearerAuthorizedGetPublic(
+            @Context final SecurityContext c) {
         return Response.ok().build();
     }
 }


### PR DESCRIPTION
This patch adds the O2BeareToken authentication filter, which will let us selectively
(via annotations) permit the use of bearer tokens to authorize a request. This can be used
in scenarios such as token introspection, where the authorizing token is the same
one that is being introspected.