### PR TITLE
Switch audience to be application id

### DIFF
--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/IntrospectionResponseEntity.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/IntrospectionResponseEntity.java
@@ -140,7 +140,7 @@ public final class IntrospectionResponseEntity {
 
         this.tokenType = token.getTokenType();
         this.clientId = token.getClient().getId();
-        this.aud = token.getClient().getId();
+        this.aud = token.getClient().getApplication().getId();
         this.jti = token.getId();
 
         if (token.getIdentity() != null) {

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/resource/IntrospectionResponseEntityTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/resource/IntrospectionResponseEntityTest.java
@@ -20,6 +20,7 @@ package net.krotscheck.kangaroo.authz.oauth2.resource;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.ApplicationScope;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
@@ -62,8 +63,12 @@ public final class IntrospectionResponseEntityTest {
         Calendar now = Calendar.getInstance();
         now.set(Calendar.MILLISECOND, 0);
 
+        Application a = new Application();
+        a.setId(IdUtil.next());
+
         Client c = new Client();
         c.setId(IdUtil.next());
+        c.setApplication(a);
 
         OAuthToken token = new OAuthToken();
         token.setId(IdUtil.next());
@@ -153,7 +158,8 @@ public final class IntrospectionResponseEntityTest {
         assertEquals(!token.isExpired(), entity.isActive());
         assertEquals(token.getId(), entity.getJti());
         assertEquals(token.getCreatedDate(), entity.getNbf());
-        assertEquals(token.getClient().getId(), entity.getAud());
+        assertEquals(token.getClient().getApplication().getId(),
+                entity.getAud());
         assertEquals(entity.getIss(), token.getIssuer());
 
         Calendar expires = (Calendar) token.getCreatedDate().clone();
@@ -190,7 +196,8 @@ public final class IntrospectionResponseEntityTest {
         assertEquals(!token.isExpired(), entity.isActive());
         assertEquals(token.getId(), entity.getJti());
         assertEquals(token.getCreatedDate(), entity.getNbf());
-        assertEquals(token.getClient().getId(), entity.getAud());
+        assertEquals(token.getClient().getApplication().getId(),
+                entity.getAud());
         assertEquals(entity.getIss(), token.getIssuer());
 
         Calendar expires = (Calendar) token.getCreatedDate().clone();
@@ -227,7 +234,8 @@ public final class IntrospectionResponseEntityTest {
         assertEquals(!token.isExpired(), entity.isActive());
         assertEquals(token.getId(), entity.getJti());
         assertEquals(token.getCreatedDate(), entity.getNbf());
-        assertEquals(token.getClient().getId(), entity.getAud());
+        assertEquals(token.getClient().getApplication().getId(),
+                entity.getAud());
         assertEquals(entity.getIss(), token.getIssuer());
 
         Calendar expires = (Calendar) token.getCreatedDate().clone();
@@ -264,7 +272,8 @@ public final class IntrospectionResponseEntityTest {
         assertEquals(!token.isExpired(), entity.isActive());
         assertEquals(token.getId(), entity.getJti());
         assertEquals(token.getCreatedDate(), entity.getNbf());
-        assertEquals(token.getClient().getId(), entity.getAud());
+        assertEquals(token.getClient().getApplication().getId(),
+                entity.getAud());
         assertEquals(entity.getIss(), token.getIssuer());
 
         Calendar expires = (Calendar) token.getCreatedDate().clone();

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc7662/TokenIntrospectionTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc7662/TokenIntrospectionTest.java
@@ -246,7 +246,8 @@ public final class TokenIntrospectionTest extends ContainerTest {
         assertEquals(!token.isExpired(), entity.isActive());
         assertEquals(token.getId(), entity.getJti());
         assertEquals(created, entity.getNbf());
-        assertEquals(token.getClient().getId(), entity.getAud());
+        assertEquals(token.getClient().getApplication().getId(),
+                entity.getAud());
 
         Calendar expires = (Calendar) created.clone();
         expires.add(Calendar.SECOND, token.getExpiresIn().intValue());


### PR DESCRIPTION
Since application-level correlation is actually pretty important
at the client API level, we're switching the "audience" of the token
to be the application to which this token was issued. This provides
a global, unique scope within which the token, and its scopes, may
be evaluated.