### PR TITLE
Bugfix: Display swagger UI, reduce reflections output.

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/swagger/SwaggerContainerLifecycleListener.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/swagger/SwaggerContainerLifecycleListener.java
@@ -92,6 +92,7 @@ public final class SwaggerContainerLifecycleListener
         beanConfig.setResourcePackage(classPath);
         beanConfig.setScannerId(scannerId);
         beanConfig.setBasePath(basePath);
+        beanConfig.setUsePathBasedConfig(true);
         beanConfig.setScan(true);
     }
 

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/swagger/SwaggerUIService.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/swagger/SwaggerUIService.java
@@ -18,18 +18,13 @@
 
 package net.krotscheck.kangaroo.common.swagger;
 
-import org.apache.commons.io.IOUtils;
-
 import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -46,30 +41,22 @@ public final class SwaggerUIService {
     /**
      * Files available to be served out of the swagger directory.
      */
-    private final List<String> files = new ArrayList<>();
+    private final List<String> files = Arrays.asList(
+            "favicon-16x16.png",
+            "favicon-32x32.png",
+            "index.html",
+            "oauth2-redirect.html",
+            "swagger-ui.css",
+            "swagger-ui.js",
+            "swagger-ui-bundle.js",
+            "swagger-ui-standalone-preset.js"
+    );
 
     /**
      * The classloader used to resolve any existing resources from the
      * swagger bundle.
      */
     private final ClassLoader classLoader = getClass().getClassLoader();
-
-    /**
-     * Create a new instance of the UI service.
-     *
-     * @throws IOException Thrown if the files cannot be read.
-     */
-    public SwaggerUIService() throws IOException {
-        ClassLoader classLoader = SwaggerUIService.class.getClassLoader();
-        InputStream dir = classLoader.getResourceAsStream("swagger");
-        BufferedReader in = new BufferedReader(new InputStreamReader(dir));
-        String line;
-
-        while ((line = in.readLine()) != null) {
-            files.add(line);
-        }
-        IOUtils.closeQuietly(dir);
-    }
 
     /**
      * If the root resource is requested, return index.html.

--- a/kangaroo-common/src/main/resources/logback.xml
+++ b/kangaroo-common/src/main/resources/logback.xml
@@ -32,7 +32,8 @@
     <appender-ref ref="STDOUT"/>
   </root>
 
-  <!-- Hibernate -->
+  <!-- Disable certain loggers -->
   <logger name="org.hibernate.orm.deprecation" level="OFF"/>
+  <logger name="org.reflections.Reflections" level="OFF"/>
 
 </configuration>

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/IntrospectionService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/IntrospectionService.java
@@ -20,6 +20,7 @@ package net.krotscheck.kangaroo.authz.oauth2.resource;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.oauth2.authn.O2AuthScheme;
@@ -91,6 +92,7 @@ public final class IntrospectionService {
     @O2BearerToken()
     @ApiOperation(value = "OAuth2 Introspection endpoint.")
     public Response introspectionRequest(
+            @ApiParam(type = "string")
             @FormParam("token") final BigInteger tokenId) {
 
         // Pull the principal, to check the style of introspection request


### PR DESCRIPTION
The reflections API likes to dump a lot of useless data when
initializing during the swagger scan, which is unecessary. I've disabled this,
as well as removed classpath-based loading for the swagger UI feature (which,
it turns out, doesn't work in the standalone Jar).