### PR TITLE
Http Request Logging

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/logging/HttpResponseLoggingFilter.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/logging/HttpResponseLoggingFilter.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.logging;
+
+import com.google.common.net.HttpHeaders;
+import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder.ErrorResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Priority;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Response.Status.Family;
+import java.util.Optional;
+
+import static javax.ws.rs.core.Response.Status.Family.CLIENT_ERROR;
+import static javax.ws.rs.core.Response.Status.Family.REDIRECTION;
+import static javax.ws.rs.core.Response.Status.Family.SERVER_ERROR;
+
+/**
+ * This filter (running at priority 0) is a final-introspection filter that
+ * provides insight into the HTTP traffic of a running server.
+ */
+@Priority(0)
+public final class HttpResponseLoggingFilter
+        implements ContainerResponseFilter {
+
+    /**
+     * Logger instance.
+     */
+    private static Logger logger = LoggerFactory
+            .getLogger(HttpResponseLoggingFilter.class);
+
+    /**
+     * Provided the request and the response, log out some basic information
+     * during runtime.
+     *
+     * @param requestContext  The incoming request.
+     * @param responseContext The outgoing response.
+     */
+    @Override
+    public void filter(final ContainerRequestContext requestContext,
+                       final ContainerResponseContext responseContext) {
+        // Grab the request method
+        String method = requestContext.getMethod();
+        String path = requestContext.getUriInfo().getPath();
+        int status = responseContext.getStatus();
+
+        String message = extractResponseMessage(responseContext);
+        String logMessage = String.format("%s HTTP %s %s%s",
+                status, method, path, message).trim();
+
+        logger.info(logMessage);
+    }
+
+    /**
+     * Provided a response context, attempt to (safely) extract an error
+     * message, if appropriate.
+     *
+     * @param context The response to extract the message from.
+     * @return A string with the message, or emptystring.
+     */
+    private String extractResponseMessage(
+            final ContainerResponseContext context) {
+
+        // Enum switches can't be fully covered by jacoco.
+        Family f = context.getStatusInfo().getFamily();
+
+        if (f.equals(REDIRECTION)) {
+            return " -> " + Optional.ofNullable(context.getHeaders())
+                    .filter(h -> h.containsKey(HttpHeaders.LOCATION))
+                    .map(h -> h.getFirst(HttpHeaders.LOCATION))
+                    .map(Object::toString)
+                    .orElse("No location header provided");
+        }
+
+        if (f.equals(CLIENT_ERROR) || f.equals(SERVER_ERROR)) {
+            return ": " + Optional.ofNullable(context.getEntity())
+                    .map(e -> (ErrorResponse) e)
+                    .map(ErrorResponse::getErrorDescription)
+                    .orElse("No error entity detected.");
+        }
+
+        return "";
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/logging/LoggingFeature.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/logging/LoggingFeature.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.logging;
+
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+/**
+ * This feature's purpose is to intercept events within the jersey system, and
+ * log them to support generic operational.
+ *
+ * @author Michael Krotscheck
+ */
+public final class LoggingFeature implements Feature {
+
+    /**
+     * Register this feature.
+     */
+    @Override
+    public boolean configure(final FeatureContext context) {
+
+        // Jersey2 Logging feature, for trace-level debugging.
+        context.register(org.glassfish.jersey.logging.LoggingFeature.class);
+
+        // Our own INFO-level logger.
+        context.register(HttpResponseLoggingFilter.class);
+
+        return true;
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/logging/package-info.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/logging/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Logging events within the server.
+ */
+package net.krotscheck.kangaroo.common.logging;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/HibernateFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/HibernateFeatureTest.java
@@ -150,5 +150,3 @@ public final class HibernateFeatureTest extends KangarooJerseyTest {
     }
 
 }
-
-

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/logging/HttpResponseLoggingFilterTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/logging/HttpResponseLoggingFilterTest.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.logging;
+
+import ch.qos.logback.classic.Level;
+import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder;
+import net.krotscheck.kangaroo.common.jackson.JacksonFeature;
+import net.krotscheck.kangaroo.test.LoggingRule;
+import net.krotscheck.kangaroo.test.jersey.KangarooJerseyTest;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import java.net.URI;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Assert that the logging feature test.
+ *
+ * @author Michael Krotscheck
+ */
+public class HttpResponseLoggingFilterTest extends KangarooJerseyTest {
+
+    /**
+     * The logger rule.
+     */
+    @Rule
+    public final LoggingRule logs =
+            new LoggingRule(HttpResponseLoggingFilter.class, Level.ALL);
+
+    /**
+     * Clean the current logs.
+     */
+    @Before
+    public void clearLogs() {
+        // Clear the logs
+        logs.clear();
+    }
+
+    /**
+     * Build an application.
+     *
+     * @return A configured application.
+     */
+    @Override
+    protected ResourceConfig createApplication() {
+        ResourceConfig config = new ResourceConfig();
+        config.register(JacksonFeature.class);
+        config.register(HttpResponseLoggingFilter.class);
+        config.register(MockService.class);
+
+        return config;
+    }
+
+    /**
+     * Test 200 error codes.
+     */
+    @Test
+    public void test200ErrorCodes() {
+        target("/error/200")
+                .request()
+                .get();
+        List<String> messages = logs.getMessages();
+        assertEquals(1, messages.size());
+        assertEquals("200 HTTP GET error/200",
+                messages.get(0));
+    }
+
+    /**
+     * Test 3xx redirection codes.
+     */
+    @Test
+    public void test300RedirectionErrorCodes() {
+        target("/error/300")
+                .request()
+                .get();
+        List<String> messages = logs.getMessages();
+        assertEquals(1, messages.size());
+        assertEquals("303 HTTP GET error/300 -> https://example.com/",
+                messages.get(0));
+    }
+
+    /**
+     * Test 3xx redirection codes without any redirection header.
+     */
+    @Test
+    public void test300ErrorCodeWithNoLocation() {
+        target("/error/300-no-location")
+                .request()
+                .get();
+        List<String> messages = logs.getMessages();
+        assertEquals(1, messages.size());
+        assertEquals("300 HTTP GET error/300-no-location"
+                        + " -> No location header provided",
+                messages.get(0));
+    }
+
+    /**
+     * Test 400 error codes with valid response bodies.
+     */
+    @Test
+    public void test400ErrorCodesWithBody() {
+        target("/error/400")
+                .request()
+                .get();
+        List<String> messages = logs.getMessages();
+        assertEquals(1, messages.size());
+        assertEquals("400 HTTP GET error/400: Bad Request",
+                messages.get(0));
+    }
+
+    /**
+     * Test 400 error codes with no error body.
+     */
+    @Test
+    public void test400ErrorCodesNoBody() {
+        target("/error/400-no-body")
+                .request()
+                .get();
+        List<String> messages = logs.getMessages();
+        assertEquals(1, messages.size());
+        assertEquals("400 HTTP GET error/400-no-body: No"
+                        + " error entity detected.",
+                messages.get(0));
+    }
+
+    /**
+     * Test 500 error codes.
+     */
+    @Test
+    public void test500ErrorCodesWithBody() {
+        target("/error/500")
+                .request()
+                .get();
+        List<String> messages = logs.getMessages();
+        assertEquals(1, messages.size());
+        assertEquals("500 HTTP GET error/500: Internal Server Error",
+                messages.get(0));
+    }
+
+    /**
+     * Test 500 error codes.
+     */
+    @Test
+    public void test500ErrorCodesNoBody() {
+        target("/error/500-no-body")
+                .request()
+                .get();
+        List<String> messages = logs.getMessages();
+        assertEquals(1, messages.size());
+        assertEquals("500 HTTP GET error/500-no-body: No error"
+                        + " entity detected.",
+                messages.get(0));
+    }
+
+    /**
+     * Test entity, returning various different error codes. Test for logging.
+     *
+     * @author Michael Krotscheck
+     */
+    @Path("/error")
+    public static final class MockService {
+
+        /**
+         * Return a 2xx response.
+         *
+         * @return Nothing, error thrown.
+         */
+        @GET
+        @Path("/200")
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response return200() {
+            return Response.ok().build();
+        }
+
+        /**
+         * Return a 3xx response.
+         *
+         * @return Nothing, error thrown.
+         * @throws Exception e Should not be thrown.
+         */
+        @GET
+        @Path("/300")
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response return300() throws Exception {
+            return Response
+                    .seeOther(new URI("https://example.com/"))
+                    .build();
+        }
+
+        /**
+         * Return a 3xx response with no location header.
+         *
+         * @return Nothing, error thrown.
+         */
+        @GET
+        @Path("/300-no-location")
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response return300NoLocation() {
+            return Response.status(300).build();
+        }
+
+        /**
+         * Return a 4xx response.
+         *
+         * @return Nothing, error thrown.
+         */
+        @GET
+        @Path("/400")
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response return400() {
+            return ErrorResponseBuilder
+                    .from(Status.BAD_REQUEST)
+                    .build();
+        }
+
+        /**
+         * Return a 4xx response with no body.
+         *
+         * @return Nothing, error thrown.
+         */
+        @GET
+        @Path("/400-no-body")
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response return400NoBody() {
+            return Response
+                    .status(400)
+                    .build();
+        }
+
+        /**
+         * Return a 5xx response.
+         *
+         * @return Nothing, error thrown.
+         */
+        @GET
+        @Path("/500")
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response return500() {
+            return ErrorResponseBuilder
+                    .from(Status.INTERNAL_SERVER_ERROR)
+                    .build();
+        }
+
+        /**
+         * Return a 5xx response with no body.
+         *
+         * @return Nothing, error thrown.
+         */
+        @GET
+        @Path("/500-no-body")
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response return500NoBody() {
+            return Response.status(500).build();
+        }
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/logging/LoggingFeatureTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/logging/LoggingFeatureTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.logging;
+
+import ch.qos.logback.classic.Level;
+import net.krotscheck.kangaroo.common.jackson.JacksonFeature;
+import net.krotscheck.kangaroo.test.LoggingRule;
+import net.krotscheck.kangaroo.test.jersey.KangarooJerseyTest;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Feature loading test for the logging feature.
+ *
+ * @author Michael krotscheck
+ */
+public class LoggingFeatureTest extends KangarooJerseyTest {
+
+    /**
+     * The logger rule.
+     */
+    @Rule
+    public final LoggingRule logs =
+            new LoggingRule(HttpResponseLoggingFilter.class, Level.ALL);
+
+    /**
+     * Clean the current logs.
+     */
+    @Before
+    public void clearLogs() {
+        // Clear the logs
+        logs.clear();
+    }
+
+    /**
+     * Build an application.
+     *
+     * @return A configured application.
+     */
+    @Override
+    protected ResourceConfig createApplication() {
+        ResourceConfig config = new ResourceConfig();
+        config.register(JacksonFeature.class);
+        config.register(LoggingFeature.class);
+        config.register(MockService.class);
+
+        return config;
+    }
+
+    /**
+     * It should load the logging filter.
+     */
+    @Test
+    public void test200ErrorCodes() {
+        target("/error/200")
+                .request()
+                .get();
+        List<String> messages = logs.getMessages();
+        assertEquals(1, messages.size());
+        assertEquals("200 HTTP GET error/200",
+                messages.get(0));
+    }
+
+    /**
+     * Test entity, returning various different error codes. Test for logging.
+     *
+     * @author Michael Krotscheck
+     */
+    @Path("/error")
+    public static final class MockService {
+
+        /**
+         * Return a 2xx response.
+         *
+         * @return Nothing, error thrown.
+         */
+        @GET
+        @Path("/200")
+        @Produces(MediaType.APPLICATION_JSON)
+        public Response return200() {
+            return Response.ok().build();
+        }
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/logging/package-info.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/logging/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Unit tests for the logging feature.
+ */
+package net.krotscheck.kangaroo.common.logging;

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/LoggingRule.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/LoggingRule.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.test;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A JUnit rule, which permits selective capturing of logback log entries, based
+ * on class and logging level.
+ *
+ * @author Michael Krotscheck
+ */
+public final class LoggingRule implements TestRule {
+
+    /**
+     * The target class onto which to attach the new appender.
+     */
+    private final Class targetClass;
+
+    /**
+     * The logging level to record at.
+     */
+    private final Level level;
+
+    /**
+     * The current active debug appender.
+     */
+    private DebugAppender activeAppender;
+
+    /**
+     * Create a new instance of this logging rule for a specific class.
+     *
+     * @param targetClass The class to target.
+     * @param level       The logging level
+     */
+    public LoggingRule(final Class targetClass, final Level level) {
+        this.targetClass = targetClass;
+        this.level = level;
+    }
+
+    /**
+     * Create a mock appender, start recording events, run the test, and then
+     * detach.
+     *
+     * @param base        The base test.
+     * @param description The test description.
+     * @return The testing statement.
+     */
+    @Override
+    public Statement apply(final Statement base,
+                           final Description description) {
+        return new Statement() {
+
+            @Override
+            public void evaluate() throws Throwable {
+                Logger classLogger = (Logger)
+                        LoggerFactory.getLogger(targetClass);
+
+                activeAppender = new DebugAppender();
+                activeAppender.setContext(classLogger.getLoggerContext());
+                activeAppender.start();
+                Level old = classLogger.getLevel();
+                try {
+                    classLogger.addAppender(activeAppender);
+                    classLogger.setLevel(level);
+                    base.evaluate();
+                } finally {
+                    activeAppender.stop();
+                    classLogger.detachAppender(activeAppender);
+                    classLogger.setLevel(old);
+                    activeAppender = null;
+                }
+            }
+        };
+    }
+
+    /**
+     * Clear the message buffer.
+     */
+    public void clear() {
+        activeAppender.messages.clear();
+    }
+
+    /**
+     * Get all the messages currently in the cache.
+     *
+     * @return All messages.
+     */
+    public List<String> getMessages() {
+        return new ArrayList<>(activeAppender.messages);
+    }
+
+    /**
+     * A test appender.
+     *
+     * @param <E> Event for the logger (Usually LoggingEvent).
+     */
+    private static class DebugAppender<E> extends AppenderBase<E> {
+
+        /**
+         * List of captured messages.
+         */
+        private final List<String> messages = new ArrayList<>();
+
+        /**
+         * Return the name.
+         *
+         * @return The test name of the debug appender.
+         */
+        @Override
+        public String getName() {
+            return "TEST";
+        }
+
+        /**
+         * Take in an event object.
+         *
+         * @param eventObject The event to log.
+         */
+        @Override
+        protected void append(final E eventObject) {
+            ILoggingEvent event = (ILoggingEvent) eventObject;
+            messages.add(event.getFormattedMessage());
+        }
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jersey/KangarooTestContainerFactory.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jersey/KangarooTestContainerFactory.java
@@ -31,6 +31,8 @@ import org.glassfish.jersey.test.spi.TestContainer;
 import org.glassfish.jersey.test.spi.TestContainerException;
 import org.glassfish.jersey.test.spi.TestContainerFactory;
 import org.glassfish.jersey.test.spi.TestHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration;
@@ -47,8 +49,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * This container factory simulates, as closely as possible, a kangaroo
@@ -123,7 +123,7 @@ public final class KangarooTestContainerFactory
          * Logger.
          */
         private static final Logger LOGGER =
-                Logger.getLogger(KangarooTestContainer.class.getName());
+                LoggerFactory.getLogger(KangarooTestContainer.class.getName());
 
         /**
          * The deployment context for this container.
@@ -200,11 +200,11 @@ public final class KangarooTestContainerFactory
         @Override
         public void start() {
             if (server.isStarted()) {
-                LOGGER.log(Level.WARNING, "Ignoring start request"
+                LOGGER.warn("Ignoring start request"
                         + " - KangarooTestContainer is already started.");
 
             } else {
-                LOGGER.log(Level.FINE, "Starting KangarooTestContainer...");
+                LOGGER.debug("Starting KangarooTestContainer...");
                 try {
                     server.start();
 
@@ -213,7 +213,7 @@ public final class KangarooTestContainerFactory
                                 .port(server.getListener("grizzly")
                                         .getPort())
                                 .build();
-                        LOGGER.log(Level.INFO, "Started KangarooTestContainer"
+                        LOGGER.info("Started KangarooTestContainer"
                                 + " at the base URI " + baseUri);
                     }
                 } catch (final IOException ioe) {
@@ -228,10 +228,10 @@ public final class KangarooTestContainerFactory
         @Override
         public void stop() {
             if (server.isStarted()) {
-                LOGGER.log(Level.FINE, "Stopping KangarooTestContainer...");
+                LOGGER.debug("Stopping KangarooTestContainer...");
                 this.server.shutdownNow();
             } else {
-                LOGGER.log(Level.WARNING, "Ignoring stop request"
+                LOGGER.warn("Ignoring stop request"
                         + " - KangarooTestContainer is already stopped.");
             }
         }

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/AdminV1API.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/AdminV1API.java
@@ -44,11 +44,11 @@ import net.krotscheck.kangaroo.common.config.ConfigurationFeature;
 import net.krotscheck.kangaroo.common.exception.ExceptionFeature;
 import net.krotscheck.kangaroo.common.httpClient.HttpClientFeature;
 import net.krotscheck.kangaroo.common.jackson.JacksonFeature;
+import net.krotscheck.kangaroo.common.logging.LoggingFeature;
 import net.krotscheck.kangaroo.common.security.SecurityFeature;
 import net.krotscheck.kangaroo.common.status.StatusFeature;
 import net.krotscheck.kangaroo.common.swagger.SwaggerFeature;
 import net.krotscheck.kangaroo.common.timedtasks.TimedTasksFeature;
-import org.glassfish.jersey.logging.LoggingFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.ServerProperties;
 
@@ -169,7 +169,6 @@ public final class AdminV1API extends ResourceConfig {
         property(ServerProperties.WADL_FEATURE_DISABLE, true);
 
         // Common features.
-        register(LoggingFeature.class);          // Jersey2 Logging feature
         register(ConfigurationFeature.class);    // Configuration loader
         register(JacksonFeature.class);          // Data Type de/serialization.
         register(ExceptionFeature.class);        // Exception Mapping.
@@ -180,6 +179,7 @@ public final class AdminV1API extends ResourceConfig {
         register(AuthenticatorFeature.class);    // OAuth2 Authenticators
         register(AuthzCORSFeature.class);        // CORS feature.
         register(HttpClientFeature.class);       // Make Http requests.
+        register(LoggingFeature.class);          // API logging feature.
 
         // Swagger UI & API Documentation.
         register(new SwaggerFeature("net.krotscheck.kangaroo.authz.admin"));

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/OAuthAPI.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/OAuthAPI.java
@@ -37,11 +37,11 @@ import net.krotscheck.kangaroo.common.config.ConfigurationFeature;
 import net.krotscheck.kangaroo.common.exception.ExceptionFeature;
 import net.krotscheck.kangaroo.common.httpClient.HttpClientFeature;
 import net.krotscheck.kangaroo.common.jackson.JacksonFeature;
+import net.krotscheck.kangaroo.common.logging.LoggingFeature;
 import net.krotscheck.kangaroo.common.security.SecurityFeature;
 import net.krotscheck.kangaroo.common.status.StatusFeature;
 import net.krotscheck.kangaroo.common.swagger.SwaggerFeature;
 import net.krotscheck.kangaroo.common.timedtasks.TimedTasksFeature;
-import org.glassfish.jersey.logging.LoggingFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.ServerProperties;
 
@@ -61,7 +61,6 @@ public class OAuthAPI extends ResourceConfig {
         property(ServerProperties.WADL_FEATURE_DISABLE, true);
 
         // Common features.
-        register(LoggingFeature.class);          // Jersey2 Logging feature
         register(ConfigurationFeature.class);    // Configuration loader
         register(JacksonFeature.class);          // Data Type de/serialization.
         register(ExceptionFeature.class);        // Exception Mapping.
@@ -72,6 +71,7 @@ public class OAuthAPI extends ResourceConfig {
         register(AuthenticatorFeature.class);    // OAuth2 Authenticators
         register(AuthzCORSFeature.class);        // CORS feature.
         register(HttpClientFeature.class);       // Make Http requests.
+        register(LoggingFeature.class);          // API logging feature.
 
         // Swagger UI & API Documentation.
         register(new SwaggerFeature("net.krotscheck.kangaroo.authz.oauth2"));


### PR DESCRIPTION
This commit adds a new containt response filter, which will log
out regular HTTP traffic from the server at the INFO level. It wraps this
and the Jersey Logging Filter into a separate LoggingFeature, for proper
isolation and management.

Closes #430