### PR TITLE
Set terminal output width to 120 characters

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/ConfigurationBuilder.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/ConfigurationBuilder.java
@@ -118,6 +118,7 @@ public final class ConfigurationBuilder {
             cmd = parser.parse(commandlineOptions, args, false);
         } catch (ParseException e) {
             HelpFormatter formater = new HelpFormatter();
+            formater.setWidth(120);
             formater.printHelp("Main", commandlineOptions);
             throw new RuntimeException();
         }


### PR DESCRIPTION
I'd rather not do any sophisticated terminal width detection just eyt.