### PR TITLE
Change default working directory

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/Config.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/Config.java
@@ -18,6 +18,7 @@
 
 package net.krotscheck.kangaroo.server;
 
+import java.nio.file.Paths;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Map.Entry;
 
@@ -48,7 +49,8 @@ public final class Config {
      * throughout the application.
      */
     public static final Entry<String, String> WORKING_DIR = new
-            SimpleImmutableEntry<>("kangaroo.working_dir", "/var/lib/kangaroo");
+            SimpleImmutableEntry<>("kangaroo.working_dir",
+            Paths.get(".", "kangaroo").toAbsolutePath().normalize().toString());
 
     /**
      * Configuration property for an externally provided keystore.

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/ConfigTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/ConfigTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
+import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -54,6 +55,9 @@ public final class ConfigTest {
      */
     @Test
     public void testConfigurationValues() {
+        String currentWorkingPath = Paths.get(".", "kangaroo")
+                .toAbsolutePath().normalize().toString();
+
         assertEquals("kangaroo.host", Config.HOST.getKey());
         assertEquals("127.0.0.1", Config.HOST.getValue());
 
@@ -62,7 +66,7 @@ public final class ConfigTest {
 
         assertEquals("kangaroo.working_dir",
                 Config.WORKING_DIR.getKey());
-        assertEquals("/var/lib/kangaroo",
+        assertEquals(currentWorkingPath,
                 Config.WORKING_DIR.getValue());
 
         assertEquals("kangaroo.keystore_path",


### PR DESCRIPTION
This is a breaking change for the default configuration, though perhaps a welcome one.
The default working_dir of kangaroo was, by default, set to a directory that is not
automatically accessible to an average user. While our desired directory in a server
deployment should be /var/lib/kangaroo, for the sake of ease-of-use for new users,
we're switching this to `pwd` instead of one that would require sudo.

Closes #431