### PR TITLE
Switch from 204 to 205 on delete response

### DIFF
--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ApplicationService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ApplicationService.java
@@ -57,6 +57,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 import java.math.BigInteger;
 import java.net.URI;
 import java.util.Objects;
@@ -339,7 +340,7 @@ public final class ApplicationService extends AbstractService {
         // Let's hope they now what they're doing.
         s.delete(a);
 
-        return Response.noContent().build();
+        return Response.status(Status.RESET_CONTENT).build();
     }
 
     /**

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AuthenticatorService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AuthenticatorService.java
@@ -60,6 +60,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 import java.math.BigInteger;
 import java.net.URI;
 
@@ -389,7 +390,7 @@ public final class AuthenticatorService extends AbstractService {
         // Let's hope they know what they're doing.
         s.delete(authenticator);
 
-        return Response.noContent().build();
+        return Response.status(Status.RESET_CONTENT).build();
     }
 
     /**

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientRedirectService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientRedirectService.java
@@ -328,7 +328,7 @@ public final class ClientRedirectService extends AbstractService {
         s.delete(redirect);
         s.update(client);
 
-        return Response.noContent().build();
+        return Response.status(Status.RESET_CONTENT).build();
     }
 
     /**

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientReferrerService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientReferrerService.java
@@ -330,7 +330,7 @@ public final class ClientReferrerService extends AbstractService {
         s.delete(referrer);
         s.update(client);
 
-        return Response.noContent().build();
+        return Response.status(Status.RESET_CONTENT).build();
     }
 
     /**

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientService.java
@@ -377,7 +377,7 @@ public final class ClientService extends AbstractService {
         // Let's hope they now what they're doing.
         s.delete(client);
 
-        return Response.noContent().build();
+        return Response.status(Status.RESET_CONTENT).build();
     }
 
     /**

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/OAuthTokenService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/OAuthTokenService.java
@@ -62,6 +62,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 import java.math.BigInteger;
 import java.net.URI;
 
@@ -426,7 +427,7 @@ public final class OAuthTokenService extends AbstractService {
         // Let's hope they know what they're doing.
         s.delete(token);
 
-        return Response.noContent().build();
+        return Response.status(Status.RESET_CONTENT).build();
     }
 
     /**

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleScopeService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleScopeService.java
@@ -177,7 +177,7 @@ public final class RoleScopeService extends AbstractService {
         role.getScopes().remove(scope.getName());
         s.update(role);
 
-        return Response.noContent().build();
+        return Response.status(Status.RESET_CONTENT).build();
     }
 
     /**

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleService.java
@@ -57,6 +57,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 import java.math.BigInteger;
 import java.net.URI;
 
@@ -365,7 +366,7 @@ public final class RoleService extends AbstractService {
         // Let's hope they now what they're doing.
         s.delete(role);
 
-        return Response.noContent().build();
+        return Response.status(Status.RESET_CONTENT).build();
     }
 
     /**

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ScopeService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ScopeService.java
@@ -58,6 +58,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 import java.math.BigInteger;
 import java.net.URI;
 
@@ -380,7 +381,7 @@ public final class ScopeService extends AbstractService {
         // Let's hope they now what they're doing.
         s.delete(a);
 
-        return Response.noContent().build();
+        return Response.status(Status.RESET_CONTENT).build();
     }
 
     /**

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserIdentityService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserIdentityService.java
@@ -60,6 +60,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 import java.math.BigInteger;
 import java.net.URI;
 
@@ -414,7 +415,7 @@ public final class UserIdentityService extends AbstractService {
         // Let's hope they know what they're doing.
         s.delete(identity);
 
-        return Response.noContent().build();
+        return Response.status(Status.RESET_CONTENT).build();
     }
 
     /**

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserService.java
@@ -56,6 +56,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 import java.math.BigInteger;
 import java.net.URI;
 
@@ -379,7 +380,7 @@ public final class UserService extends AbstractService {
         // Let's hope they now what they're doing.
         s.delete(user);
 
-        return Response.noContent().build();
+        return Response.status(Status.RESET_CONTENT).build();
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceCRUDTest.java
@@ -632,7 +632,7 @@ public abstract class AbstractServiceCRUDTest<T extends AbstractAuthzEntity>
         Response r = deleteEntity(testingEntity, adminAppToken);
 
         if (isAccessible(testingEntity, adminAppToken)) {
-            assertEquals(Status.NO_CONTENT.getStatusCode(),
+            assertEquals(Status.RESET_CONTENT.getStatusCode(),
                     r.getStatus());
         } else {
             assertErrorResponse(r, Status.NOT_FOUND);

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleServiceCRUDTest.java
@@ -813,7 +813,7 @@ public final class RoleServiceCRUDTest
                 .delete();
 
         if (isAccessible(newScope, token)) {
-            assertEquals(Status.NO_CONTENT.getStatusCode(),
+            assertEquals(Status.RESET_CONTENT.getStatusCode(),
                     r.getStatus());
 
             getSession().refresh(editedRole);
@@ -1040,7 +1040,7 @@ public final class RoleServiceCRUDTest
                 .delete();
 
         if (shouldSucceed) {
-            assertEquals(Status.NO_CONTENT.getStatusCode(),
+            assertEquals(Status.RESET_CONTENT.getStatusCode(),
                     r.getStatus());
 
             getSession().refresh(editedRole);

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ScopeServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ScopeServiceCRUDTest.java
@@ -491,7 +491,7 @@ public final class ScopeServiceCRUDTest
         Response r = deleteEntity(scope, getAdminToken());
 
         if (isAccessible(scope, getAdminToken())) {
-            assertEquals(Status.NO_CONTENT.getStatusCode(),
+            assertEquals(Status.RESET_CONTENT.getStatusCode(),
                     r.getStatus());
         } else {
             ErrorResponse response = r.readEntity(ErrorResponse.class);


### PR DESCRIPTION
The correct canonical use of 204 is just not to send a response,
which should _not_ change the client representation of the data.
205, instead, tells the client to reset its representation. Therefore
205 is far saner for this than 204.