### PR TITLE
Split Integration tests and unit tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,6 +73,7 @@ pipeline {
                                 -Dcheckstyle.skip=true \
                                 -Dpmd.skip=true \
                                 -Dcpdskip=true \
+                                -DskipTests.integration=true \
                                 -pl kangaroo-common \
                                 -Ph2 \
                                 -Dtarget-directory=target-h2
@@ -84,6 +85,7 @@ pipeline {
                                 -Dcheckstyle.skip=true \
                                 -Dpmd.skip=true \
                                 -Dcpdskip=true \
+                                -DskipTests.integration=true \
                                 -pl kangaroo-common \
                                 -Pmariadb \
                                 -Dtarget-directory=target-mariadb \
@@ -111,6 +113,7 @@ pipeline {
                                 -Dcheckstyle.skip=true \
                                 -Dpmd.skip=true \
                                 -Dcpdskip=true \
+                                -DskipTests.integration=true \
                                 -pl kangaroo-server-authz \
                                 -Ph2 \
                                 -Dtarget-directory=target-h2
@@ -122,12 +125,29 @@ pipeline {
                                 -Dcheckstyle.skip=true \
                                 -Dpmd.skip=true \
                                 -Dcpdskip=true \
+                                -DskipTests.integration=true \
                                 -pl kangaroo-server-authz \
                                 -Pmariadb \
                                 -Dtarget-directory=target-mariadb \
                                 -Dhibernate.connection.url=${jdbc_mariadb}
                         """
                         })
+            }
+        }
+
+        /**
+         * Integration tests.
+         */
+        stage('integration') {
+            steps {
+                sh """
+                    mvn integration-test verify \
+                        -Dcheckstyle.skip=true \
+                        -Dpmd.skip=true \
+                        -Dcpdskip=true \
+                        -DskipTests.unit=true \
+                        -Ph2
+                """
             }
         }
     }

--- a/kangaroo-common/pom.xml
+++ b/kangaroo-common/pom.xml
@@ -15,7 +15,9 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
     <artifactId>kangaroo</artifactId>
@@ -104,6 +106,17 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <test.db.changelog>liquibase/db.changelog-commons-master.yaml</test.db.changelog>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+
     </plugins>
   </build>
 

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/IntegrationTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/IntegrationTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation can be used to distinguish unit tests - tests that are
+ * self contained - with integration tests, which require access to external
+ * resources.
+ *
+ * @author Michael Krotscheck
+ */
+@Target({ElementType.TYPE})
+@Retention(value = RetentionPolicy.RUNTIME)
+public @interface IntegrationTest {
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/TestConfig.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/TestConfig.java
@@ -215,12 +215,6 @@ public final class TestConfig {
      * @return A port which should be unique _per test run_.
      */
     public static String getTestingPort() {
-        switch (getDatabase()) {
-            case H2:
-                return "7778";
-            case MARIADB:
-            default:
-                return "7777";
-        }
+        return "7777";
     }
 }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jersey/SimpleSeleniumTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/test/jersey/SimpleSeleniumTest.java
@@ -20,10 +20,12 @@ package net.krotscheck.kangaroo.test.jersey;
 
 import com.google.common.base.Strings;
 import net.krotscheck.kangaroo.common.status.StatusFeature;
+import net.krotscheck.kangaroo.test.IntegrationTest;
 import net.krotscheck.kangaroo.test.rule.SeleniumRule;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.openqa.selenium.WebDriver;
 
 import javax.ws.rs.core.UriBuilder;
@@ -38,7 +40,8 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Michael Krotscheck
  */
-public final class SimpleSeleniumTest extends ContainerTest {
+@Category(IntegrationTest.class)
+public final class SimpleSeleniumTest extends KangarooJerseyTest {
 
     /**
      * The selenium rule.

--- a/kangaroo-server-authz/pom.xml
+++ b/kangaroo-server-authz/pom.xml
@@ -91,6 +91,11 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/FacebookFullAuthFlowTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/FacebookFullAuthFlowTest.java
@@ -21,6 +21,7 @@ package net.krotscheck.kangaroo.authz.common.authenticator;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthTokenType;
 import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
+import net.krotscheck.kangaroo.test.IntegrationTest;
 import net.krotscheck.kangaroo.test.rule.FacebookTestUser;
 import net.krotscheck.kangaroo.test.runner.SingleInstanceTestRunner;
 import net.krotscheck.kangaroo.util.HttpUtil;
@@ -29,6 +30,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
@@ -50,6 +52,7 @@ import static org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElemen
  *
  * @author Michael Krotscheck
  */
+@Category(IntegrationTest.class)
 @RunWith(SingleInstanceTestRunner.class)
 public final class FacebookFullAuthFlowTest
         extends AbstractBrowserLoginTest {

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/GoogleFullAuthFlowTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/common/authenticator/GoogleFullAuthFlowTest.java
@@ -21,6 +21,7 @@ package net.krotscheck.kangaroo.authz.common.authenticator;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.OAuthTokenType;
 import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
+import net.krotscheck.kangaroo.test.IntegrationTest;
 import net.krotscheck.kangaroo.test.TestConfig;
 import net.krotscheck.kangaroo.test.runner.SingleInstanceTestRunner;
 import net.krotscheck.kangaroo.util.HttpUtil;
@@ -28,6 +29,7 @@ import org.apache.commons.lang.RandomStringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
@@ -49,6 +51,7 @@ import static org.openqa.selenium.support.ui.ExpectedConditions.urlContains;
  *
  * @author Michael Krotscheck
  */
+@Category(IntegrationTest.class)
 @RunWith(SingleInstanceTestRunner.class)
 public final class GoogleFullAuthFlowTest
         extends AbstractBrowserLoginTest {

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,9 @@
     <jacoco.version>0.8.0</jacoco.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+    <skipTests.unit>${skipTests}</skipTests.unit>
+    <skipTests.integration>${skipTests}</skipTests.integration>
   </properties>
 
   <build>
@@ -269,7 +272,7 @@
           <version>3.0.0</version>
         </plugin>
 
-        <!-- Surefire reporting -->
+        <!-- Unit Test Runner -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
@@ -282,7 +285,9 @@
             </dependency>
           </dependencies>
           <configuration>
+            <skipTests>${skipTests.unit}</skipTests>
             <argLine>-Xmx1024m</argLine>
+            <excludedGroups>net.krotscheck.kangaroo.test.IntegrationTest</excludedGroups>
 
             <systemPropertyVariables>
               <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
@@ -296,6 +301,40 @@
               <hibernate.root.password>${hibernate.root.password}</hibernate.root.password>
             </systemPropertyVariables>
           </configuration>
+        </plugin>
+
+        <!-- Integration Test Runner -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>2.20.1</version>
+          <executions>
+            <execution>
+              <id>integration-tests</id>
+              <goals>
+                <goal>integration-test</goal>
+                <goal>verify</goal>
+              </goals>
+              <configuration>
+                <skipTests>${skipTests.integration}</skipTests>
+                <includes>
+                  <include>**/*.java</include>
+                </includes>
+                <groups>net.krotscheck.kangaroo.test.IntegrationTest</groups>
+                <systemPropertyVariables>
+                  <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
+                  <java.security.egd>file:/dev/./urandom</java.security.egd>
+                  <sun.net.http.allowRestrictedHeaders>true</sun.net.http.allowRestrictedHeaders>
+                  <hibernate.connection.url>${hibernate.connection.url}</hibernate.connection.url>
+                  <hibernate.connection.username>oid</hibernate.connection.username>
+                  <hibernate.connection.password>oid</hibernate.connection.password>
+                  <hibernate.connection.driver_class>${hibernate.connection.driver_class}</hibernate.connection.driver_class>
+                  <hibernate.dialect>${hibernate.dialect}</hibernate.dialect>
+                  <hibernate.root.password>${hibernate.root.password}</hibernate.root.password>
+                </systemPropertyVariables>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
 
         <!-- Test coverage -->


### PR DESCRIPTION
The goal of this effort is to reduce the # of tests that are run
against live servers. Constraining these will ensure that we don't have
to register multiple remote clients with IdP's, and in general prevent the
management nightmare of many redirects.