### PR TITLE
Replace bad request exceptions with helpful things

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/id/Base16BigIntegerConverterProvider.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/id/Base16BigIntegerConverterProvider.java
@@ -21,7 +21,6 @@ package net.krotscheck.kangaroo.common.hibernate.id;
 import org.glassfish.jersey.internal.inject.Custom;
 
 import javax.inject.Singleton;
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.PathParam;
@@ -70,10 +69,10 @@ public final class Base16BigIntegerConverterProvider
                 return new BigIntConverter<>(NotFoundException::new);
             }
             if (a instanceof QueryParam) {
-                return new BigIntConverter<>(BadRequestException::new);
+                return new BigIntConverter<>(MalformedIdException::new);
             }
             if (a instanceof FormParam) {
-                return new BigIntConverter<>(BadRequestException::new);
+                return new BigIntConverter<>(MalformedIdException::new);
             }
         }
 

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/id/MalformedIdException.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/hibernate/id/MalformedIdException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate.id;
+
+import javax.ws.rs.BadRequestException;
+
+/**
+ * Exception thrown if a field intended to be a Base-16 encoded BigInteger
+ * is malformed or cannot be decoded.
+ *
+ * @author Michael Krotscheck
+ */
+public class MalformedIdException extends BadRequestException {
+
+    /**
+     * The exception message.
+     */
+    static final String MESSAGE = "Invalid resource identifier.";
+
+    /**
+     * Construct a new MalformedIdException with the provided message.
+     */
+    public MalformedIdException() {
+        super(MESSAGE);
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/security/CsrfProtectionFilter.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/security/CsrfProtectionFilter.java
@@ -21,7 +21,6 @@ package net.krotscheck.kangaroo.common.security;
 import com.google.common.collect.Sets;
 
 import javax.annotation.Priority;
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
@@ -63,6 +62,6 @@ public final class CsrfProtectionFilter implements ContainerRequestFilter {
             return;
         }
 
-        throw new BadRequestException();
+        throw new NoCSRFHeaderException();
     }
 }

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/security/NoCSRFHeaderException.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/common/security/NoCSRFHeaderException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.security;
+
+import javax.ws.rs.BadRequestException;
+
+/**
+ * Exception thrown if our Cross-Site-Request-Forgery protections are not in
+ * place.
+ *
+ * @author Michael Krotscheck
+ */
+final class NoCSRFHeaderException extends BadRequestException {
+
+    /**
+     * The exception message.
+     */
+    static final String MESSAGE =
+            "No CSRF Header found, expected any value in X-Requested-With";
+
+    /**
+     * Construct a new BadRequestException with the provided message.
+     */
+    NoCSRFHeaderException() {
+        super(MESSAGE);
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/util/InvalidFieldException.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/util/InvalidFieldException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.util;
+
+import javax.ws.rs.BadRequestException;
+
+/**
+ * Exception thrown if a field intended to be a Base-16 encoded BigInteger
+ * is malformed or cannot be decoded.
+ *
+ * @author Michael Krotscheck
+ */
+public class InvalidFieldException extends BadRequestException {
+
+    /**
+     * The exception message.
+     */
+    private static final String MESSAGE = "Invalid field: %s";
+
+    /**
+     * Construct a new InvalidFieldException with the provided message.
+     *
+     * @param field The name of the field.
+     */
+    public InvalidFieldException(final String field) {
+        super(String.format(MESSAGE, field));
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/util/InvalidHostException.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/util/InvalidHostException.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.util;
+
+import javax.ws.rs.BadRequestException;
+
+/**
+ * The Request Utility was unable to reduce the incoming HTTP request into a
+ * valid protocol, host, and port. This usually indicates a severe
+ * misconfiguration problem.
+ *
+ * @author Michael Krotscheck
+ */
+class InvalidHostException extends BadRequestException {
+
+    /**
+     * The exception message.
+     */
+    static final String MESSAGE =
+            "Unable to extract request protocol, host, or port.";
+
+    /**
+     * Construct a new BadRequestException with the provided message.
+     *
+     * @param e The cause of this exception.
+     */
+    InvalidHostException(final Throwable e) {
+        super(MESSAGE, e);
+    }
+}

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/util/ParamUtil.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/util/ParamUtil.java
@@ -17,7 +17,6 @@
 
 package net.krotscheck.kangaroo.util;
 
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.MultivaluedMap;
 import java.util.List;
 
@@ -49,10 +48,10 @@ public final class ParamUtil {
                                 final String key) {
         List<String> listValues = values.get(key);
         if (listValues == null) {
-            throw new BadRequestException("Invalid Field: " + key);
+            throw new InvalidFieldException(key);
         }
         if (listValues.size() != 1) {
-            throw new BadRequestException("Invalid Field: " + key);
+            throw new InvalidFieldException(key);
         }
         return listValues.get(0);
     }

--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/util/RequestUtil.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/util/RequestUtil.java
@@ -24,7 +24,6 @@ import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.MultivaluedMap;
 import java.net.URI;
@@ -154,7 +153,7 @@ public final class RequestUtil {
             return builder.build();
         } catch (URISyntaxException | NumberFormatException
                 | NullPointerException e) {
-            throw new BadRequestException(e);
+            throw new InvalidHostException(e);
         }
     }
 
@@ -200,13 +199,13 @@ public final class RequestUtil {
      *
      * @param request The request from which to extract the X-Forwarded-Host.
      * @return True if this is an OWASP-evaluated cross-origin request.
-     * @throws BadRequestException Thrown if the source or target cannot be
-     *                             determined from the provided headers.
+     * @throws InvalidHostException Thrown if the source or target cannot be
+     *                              determined from the provided headers.
      * @see <a href="https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#Verifying_Same_Origin_with_Standard_Headers">https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet#Verifying_Same_Origin_with_Standard_Headers</a>
      */
     public static Boolean isCrossOriginRequest(
             final ContainerRequestContext request)
-            throws BadRequestException {
+            throws InvalidHostException {
 
         URI origin = getOrigin(request);
         URI referer = getReferer(request);

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/id/Base16BigIntegerConverterProviderTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/id/Base16BigIntegerConverterProviderTest.java
@@ -20,7 +20,6 @@ package net.krotscheck.kangaroo.common.hibernate.id;
 
 import org.junit.Test;
 
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.NotFoundException;
@@ -214,7 +213,7 @@ public final class Base16BigIntegerConverterProviderTest {
     /**
      * Fail a conversion using a form annotation.
      */
-    @Test(expected = BadRequestException.class)
+    @Test(expected = MalformedIdException.class)
     public void testFailConvertForm() {
         Annotation[] annotations = new Annotation[]{formAnnotation};
 
@@ -227,7 +226,7 @@ public final class Base16BigIntegerConverterProviderTest {
     /**
      * Fail a conversion using a query annotation.
      */
-    @Test(expected = BadRequestException.class)
+    @Test(expected = MalformedIdException.class)
     public void testFailConvertQuery() {
         Annotation[] annotations = new Annotation[]{queryAnnotation};
 

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/id/MalformedIdExceptionTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/hibernate/id/MalformedIdExceptionTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.hibernate.id;
+
+import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder;
+import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder.ErrorResponse;
+import org.junit.Test;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.core.Response.Status;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the MalformedIdException.
+ *
+ * @author Michael Krotscheck
+ */
+public final class MalformedIdExceptionTest {
+
+    /**
+     * Test the type.
+     */
+    @Test
+    public void testExtendsBadRequest() {
+        MalformedIdException e = new MalformedIdException();
+        assertTrue(e instanceof BadRequestException);
+    }
+
+    /**
+     * Test the message.
+     */
+    @Test
+    public void testCustomMessage() {
+        MalformedIdException e = new MalformedIdException();
+        assertEquals(e.getMessage(), MalformedIdException.MESSAGE);
+    }
+
+    /**
+     * Test serialization.
+     */
+    @Test
+    public void testSerialization() {
+        ErrorResponse e = ErrorResponseBuilder
+                .from(new MalformedIdException())
+                .buildEntity();
+
+        assertEquals(MalformedIdException.MESSAGE, e.getErrorDescription());
+        assertEquals(Status.BAD_REQUEST, e.getHttpStatus());
+        assertEquals("bad_request", e.getError());
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/security/CsrfProtectionFilterTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/security/CsrfProtectionFilterTest.java
@@ -66,7 +66,7 @@ public final class CsrfProtectionFilterTest {
     /**
      * Assert that the filter will fail the request if no header is included.
      */
-    @Test(expected = BadRequestException.class)
+    @Test(expected = NoCSRFHeaderException.class)
     public void assertFailsWithoutHeader() {
         CsrfProtectionFilter filter = new CsrfProtectionFilter();
         doReturn("POST").when(mockContext).getMethod();

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/security/NoCSRFHeaderExceptionTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/common/security/NoCSRFHeaderExceptionTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.common.security;
+
+import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder;
+import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder.ErrorResponse;
+import org.junit.Test;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.core.Response.Status;
+
+import static org.junit.Assert.*;
+
+public class NoCSRFHeaderExceptionTest {
+
+    /**
+     * Test the type.
+     */
+    @Test
+    public void testExtendsBadRequest() {
+        NoCSRFHeaderException e = new NoCSRFHeaderException();
+        assertTrue(e instanceof BadRequestException);
+    }
+
+    /**
+     * Test the message.
+     */
+    @Test
+    public void testCustomMessage() {
+        NoCSRFHeaderException e = new NoCSRFHeaderException();
+        assertEquals(e.getMessage(), NoCSRFHeaderException.MESSAGE);
+    }
+
+    /**
+     * Test serialization.
+     */
+    @Test
+    public void testSerialization() {
+        ErrorResponse e = ErrorResponseBuilder
+                .from(new NoCSRFHeaderException())
+                .buildEntity();
+
+        assertEquals(NoCSRFHeaderException.MESSAGE, e.getErrorDescription());
+        assertEquals(Status.BAD_REQUEST, e.getHttpStatus());
+        assertEquals("bad_request", e.getError());
+    }
+
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/util/InvalidHostExceptionTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/util/InvalidHostExceptionTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.util;
+
+import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder;
+import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder.ErrorResponse;
+import org.junit.Test;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.core.Response.Status;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the invalid host exception.
+ *
+ * @author Michael Krotscheck
+ */
+public class InvalidHostExceptionTest {
+
+    /**
+     * Test the type.
+     */
+    @Test
+    public void testExtendsBadRequest() {
+        InvalidHostException e = new InvalidHostException(null);
+        assertTrue(e instanceof BadRequestException);
+    }
+
+    /**
+     * Test the message.
+     */
+    @Test
+    public void testCustomMessage() {
+        InvalidHostException e = new InvalidHostException(null);
+        assertEquals(e.getMessage(), InvalidHostException.MESSAGE);
+    }
+
+    /**
+     * Test serialization.
+     */
+    @Test
+    public void testSerialization() {
+        ErrorResponse e = ErrorResponseBuilder
+                .from(new InvalidHostException(null))
+                .buildEntity();
+
+        assertEquals(InvalidHostException.MESSAGE, e.getErrorDescription());
+        assertEquals(Status.BAD_REQUEST, e.getHttpStatus());
+        assertEquals("bad_request", e.getError());
+    }
+}

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/util/ParamUtilTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/util/ParamUtilTest.java
@@ -19,7 +19,6 @@ package net.krotscheck.kangaroo.util;
 
 import org.junit.Test;
 
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import java.lang.reflect.Constructor;
@@ -65,7 +64,7 @@ public final class ParamUtilTest {
     /**
      * Assert that testOne throws an exception if no value exists to retrieve.
      */
-    @Test(expected = BadRequestException.class)
+    @Test(expected = InvalidFieldException.class)
     public void testGetOneNoValue() {
         MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
         ParamUtil.getOne(params, "does_not_exist");
@@ -74,7 +73,7 @@ public final class ParamUtilTest {
     /**
      * Assert that testOne throws an exception if more than one value exists.
      */
-    @Test(expected = BadRequestException.class)
+    @Test(expected = InvalidFieldException.class)
     public void testGetOneMultiResult() {
         MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
         params.add("foo", "one");

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/util/RequestUtilTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/util/RequestUtilTest.java
@@ -22,7 +22,6 @@ import com.google.common.net.HttpHeaders;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
@@ -201,7 +200,7 @@ public final class RequestUtilTest {
      *
      * @throws Exception Should not be thrown.
      */
-    @Test(expected = BadRequestException.class)
+    @Test(expected = InvalidHostException.class)
     public void testGetHostInvalid() throws Exception {
         MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
         headers.add(HttpHeaders.HOST, "host.example.com:string");
@@ -217,7 +216,7 @@ public final class RequestUtilTest {
      *
      * @throws Exception Should not be thrown.
      */
-    @Test(expected = BadRequestException.class)
+    @Test(expected = InvalidHostException.class)
     public void testGetHostEmpty() throws Exception {
         MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
         headers.add(HttpHeaders.HOST, "");
@@ -478,7 +477,7 @@ public final class RequestUtilTest {
      *
      * @throws Exception Should not be thrown.
      */
-    @Test(expected = BadRequestException.class)
+    @Test(expected = InvalidHostException.class)
     public void testCrossOriginWithOriginAndInvalidForward() throws Exception {
         MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
         headers.add(HttpHeaders.ORIGIN, "http://example.com:8080");
@@ -583,7 +582,7 @@ public final class RequestUtilTest {
      *
      * @throws Exception Should not be thrown.
      */
-    @Test(expected = BadRequestException.class)
+    @Test(expected = InvalidHostException.class)
     public void testCrossOriginWithReferrerAndInvalidForward()
             throws Exception {
         MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
@@ -604,7 +603,7 @@ public final class RequestUtilTest {
      *
      * @throws Exception Should not be thrown.
      */
-    @Test(expected = BadRequestException.class)
+    @Test(expected = InvalidHostException.class)
     public void testCrossOriginNoOriginOrReferrer() throws Exception {
         MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
         headers.add(HttpHeaders.X_FORWARDED_PROTO, "http");
@@ -623,7 +622,7 @@ public final class RequestUtilTest {
      *
      * @throws Exception Should not be thrown.
      */
-    @Test(expected = BadRequestException.class)
+    @Test(expected = InvalidHostException.class)
     public void testCrossOriginNoHostOrForward() throws Exception {
         MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
         headers.add(HttpHeaders.ORIGIN, "http://example.com:8080");

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/exception/EntityRequiredException.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/exception/EntityRequiredException.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.admin.v1.exception;
+
+import javax.ws.rs.BadRequestException;
+
+/**
+ * This exception is thrown when an external reference - such as a linked
+ * record of some kind, is invalid. THis could occur either if the reference
+ * is malformed, does not exist, or we attempted to link to a resource that
+ * we do not have the access rights for.
+ *
+ * @author Michael Krotscheck
+ */
+public final class EntityRequiredException extends BadRequestException {
+
+    /**
+     * The exception message.
+     */
+    static final String MESSAGE =
+            "An entity is required to complete this operation.";
+
+    /**
+     * Construct a new BadRequestException with the provided message.
+     */
+    public EntityRequiredException() {
+        super(MESSAGE);
+    }
+
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/exception/InvalidEntityPropertyException.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/exception/InvalidEntityPropertyException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.admin.v1.exception;
+
+import javax.ws.rs.BadRequestException;
+
+/**
+ * This exception is a catchall exception for requests that are malformed on a
+ * per-property basis. While we can't give details on each property directly,
+ * we can at least point the engineer at where to look.
+ *
+ * @author Michael Krotscheck
+ */
+public final class InvalidEntityPropertyException extends BadRequestException {
+
+    /**
+     * The exception message.
+     */
+    static final String MESSAGE = "The property '%s' is invalid.";
+
+    /**
+     * Construct a new exception with the provided property name, indicating
+     * that the value is required or invalid.
+     *
+     * @param propertyName The name of the property.
+     */
+    public InvalidEntityPropertyException(final String propertyName) {
+        super(String.format(MESSAGE, propertyName));
+    }
+
+}

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/exception/package-info.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/exception/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Exceptions for the authorization API.
+ */
+package net.krotscheck.kangaroo.authz.admin.v1.exception;

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractService.java
@@ -18,6 +18,7 @@
 
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
+import net.krotscheck.kangaroo.authz.admin.v1.exception.EntityRequiredException;
 import net.krotscheck.kangaroo.authz.admin.v1.servlet.Config;
 import net.krotscheck.kangaroo.authz.admin.v1.servlet.ServletConfigFactory;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
@@ -27,6 +28,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.User;
 import net.krotscheck.kangaroo.authz.oauth2.exception.RFC6749.InvalidScopeException;
 import net.krotscheck.kangaroo.common.hibernate.entity.AbstractEntity;
 import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
+import net.krotscheck.kangaroo.common.hibernate.id.MalformedIdException;
 import net.krotscheck.kangaroo.common.response.ListResponseBuilder;
 import org.apache.commons.configuration.Configuration;
 import org.glassfish.jersey.internal.inject.InjectionManager;
@@ -297,31 +299,6 @@ public abstract class AbstractService {
     }
 
     /**
-     * This method tests whether a particular subresource entity may be
-     * accessed. It defers most of its logic to assertCanAccess, except that
-     * it will rethrow NotFoundExceptions as BadRequestExceptions in the
-     * case where a user does not have permissions to see the parent resource.
-     *
-     * @param entity              The entity to check.
-     * @param requiredParentScope The scope required to access the parent
-     *                            entity.
-     */
-    protected final void assertCanAccessSubresource(
-            final AbstractAuthzEntity entity,
-            final String requiredParentScope) {
-        // No null entities permitted.
-        if (entity == null) {
-            throw new NotFoundException();
-        }
-
-        try {
-            assertCanAccess(entity, requiredParentScope);
-        } catch (NotFoundException e) {
-            throw new BadRequestException();
-        }
-    }
-
-    /**
      * Determine the appropriate owner on which we should be filtering.
      *
      * @param ownerId The passed-in owner id, could be null.
@@ -473,7 +450,7 @@ public abstract class AbstractService {
         // Attempt to resolve...
         K entity = getSession().get(requestedType, entityId);
         if (entity == null) {
-            throw new BadRequestException();
+            throw new MalformedIdException();
         }
         return entity;
     }
@@ -491,7 +468,7 @@ public abstract class AbstractService {
             final K entity) {
         K resolved = resolveEntityInput(requestedType, entity);
         if (resolved == null) {
-            throw new BadRequestException();
+            throw new EntityRequiredException();
         }
         return resolved;
     }

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ApplicationService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ApplicationService.java
@@ -24,6 +24,8 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
 import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.admin.v1.auth.ScopesAllowed;
+import net.krotscheck.kangaroo.authz.admin.v1.exception.EntityRequiredException;
+import net.krotscheck.kangaroo.authz.admin.v1.exception.InvalidEntityPropertyException;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.Role;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
@@ -72,16 +74,16 @@ import java.util.Objects;
 @ScopesAllowed({Scope.APPLICATION, Scope.APPLICATION_ADMIN})
 @Transactional
 @Api(tags = "Application",
-        authorizations = {
-                @Authorization(value = "Kangaroo", scopes = {
-                        @AuthorizationScope(
-                                scope = Scope.APPLICATION,
-                                description = "Modify one application."),
-                        @AuthorizationScope(
-                                scope = Scope.APPLICATION_ADMIN,
-                                description = "Modify all applications.")
-                })
-        })
+     authorizations = {
+             @Authorization(value = "Kangaroo", scopes = {
+                     @AuthorizationScope(
+                             scope = Scope.APPLICATION,
+                             description = "Modify one application."),
+                     @AuthorizationScope(
+                             scope = Scope.APPLICATION_ADMIN,
+                             description = "Modify all applications.")
+             })
+     })
 public final class ApplicationService extends AbstractService {
 
     /**
@@ -221,10 +223,10 @@ public final class ApplicationService extends AbstractService {
     public Response createResource(final Application application) {
         // Validate that the ID is empty.
         if (application == null) {
-            throw new BadRequestException();
+            throw new EntityRequiredException();
         }
         if (application.getId() != null) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("id");
         }
 
         // Only admins can change the owner.
@@ -281,12 +283,12 @@ public final class ApplicationService extends AbstractService {
 
         // Make sure the body ID's match
         if (!currentApp.equals(application)) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("id");
         }
 
         // Make sure we're not trying to change data we're not allowed.
         if (!currentApp.getOwner().equals(application.getOwner())) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("owner");
         }
 
         // Did the role change?

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AuthenticatorService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AuthenticatorService.java
@@ -25,6 +25,8 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
 import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.admin.v1.auth.ScopesAllowed;
+import net.krotscheck.kangaroo.authz.admin.v1.exception.EntityRequiredException;
+import net.krotscheck.kangaroo.authz.admin.v1.exception.InvalidEntityPropertyException;
 import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorType;
 import net.krotscheck.kangaroo.authz.common.authenticator.IAuthenticator;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
@@ -271,21 +273,21 @@ public final class AuthenticatorService extends AbstractService {
 
         // Input value checks.
         if (authenticator == null) {
-            throw new BadRequestException();
+            throw new EntityRequiredException();
         }
         if (authenticator.getId() != null) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("id");
         }
         if (authenticator.getClient() == null) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("client");
         }
         if (authenticator.getType() == null) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("type");
         }
         Client parent = getSession().get(Client.class,
                 authenticator.getClient().getId());
         if (parent == null) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("client");
         }
 
         // Assert that we can create an authenticator in this application.
@@ -341,17 +343,17 @@ public final class AuthenticatorService extends AbstractService {
 
         // Make sure the body ID's match
         if (!current.equals(authenticator)) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("id");
         }
 
         // Make sure we're not trying to change the parent entity.
         if (!current.getClient().equals(authenticator.getClient())) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("client");
         }
 
         // Make sure the type isn't void.
         if (authenticator.getType() == null) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("type");
         }
 
         // Assert that the configuration values are correct for this

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientReferrerService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientReferrerService.java
@@ -24,6 +24,8 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
 import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.admin.v1.auth.ScopesAllowed;
+import net.krotscheck.kangaroo.authz.admin.v1.exception.EntityRequiredException;
+import net.krotscheck.kangaroo.authz.admin.v1.exception.InvalidEntityPropertyException;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractClientUri;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientReferrer;
@@ -39,7 +41,6 @@ import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 
 import javax.inject.Inject;
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -199,17 +200,17 @@ public final class ClientReferrerService extends AbstractService {
 
         // Make sure we're allowed to access the client.
         Client client = s.get(Client.class, clientId);
-        assertCanAccessSubresource(client, getAdminScope());
+        assertCanAccess(client, getAdminScope());
 
         // Input value checks.
         if (referrer == null) {
-            throw new BadRequestException();
+            throw new EntityRequiredException();
         }
         if (referrer.getId() != null) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("id");
         }
         if (referrer.getUri() == null) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("uri");
         }
 
         // Check for duplicates
@@ -269,11 +270,11 @@ public final class ClientReferrerService extends AbstractService {
 
         // Make sure the body ID's match
         if (!currentReferrer.equals(referrer)) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("id");
         }
-        // Make sure we're not trying to null the redirect.
+        // Make sure we're not trying to null the referrer.
         if (referrer.getUri() == null) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("uri");
         }
 
         // Make sure we're not creating a duplicate.

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientService.java
@@ -24,6 +24,8 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
 import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.admin.v1.auth.ScopesAllowed;
+import net.krotscheck.kangaroo.authz.admin.v1.exception.EntityRequiredException;
+import net.krotscheck.kangaroo.authz.admin.v1.exception.InvalidEntityPropertyException;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
@@ -267,13 +269,13 @@ public final class ClientService extends AbstractService {
 
         // Input value checks.
         if (client == null) {
-            throw new BadRequestException();
+            throw new EntityRequiredException();
         }
         if (client.getId() != null) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("id");
         }
         if (client.getApplication() == null) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("application");
         }
 
         // Assert that we can create a scope in this application.
@@ -324,7 +326,7 @@ public final class ClientService extends AbstractService {
 
         // Make sure the body ID's match
         if (!current.equals(client)) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("id");
         }
 
         // Additional special case: We cannot modify the client we're
@@ -337,7 +339,7 @@ public final class ClientService extends AbstractService {
 
         // Make sure we're not trying to change the parent entity.
         if (!current.getApplication().equals(client.getApplication())) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("application");
         }
 
         // Transfer all the values we're allowed to edit.

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleScopeService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleScopeService.java
@@ -24,6 +24,7 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
 import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.admin.v1.auth.ScopesAllowed;
+import net.krotscheck.kangaroo.authz.admin.v1.exception.InvalidEntityPropertyException;
 import net.krotscheck.kangaroo.authz.common.database.entity.ApplicationScope;
 import net.krotscheck.kangaroo.authz.common.database.entity.Role;
 import net.krotscheck.kangaroo.authz.oauth2.exception.RFC6749.InvalidScopeException;
@@ -32,7 +33,6 @@ import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.process.internal.RequestScope;
 import org.hibernate.Session;
 
-import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.ForbiddenException;
@@ -54,18 +54,18 @@ import java.math.BigInteger;
 @ScopesAllowed({Scope.ROLE, Scope.ROLE_ADMIN})
 @Transactional
 @Api(tags = "Role",
-        authorizations = {
-                @Authorization(value = "Kangaroo", scopes = {
-                        @AuthorizationScope(
-                                scope = Scope.ROLE,
-                                description = "Modify scopes in one"
-                                        + " application."),
-                        @AuthorizationScope(
-                                scope = Scope.ROLE_ADMIN,
-                                description = "Modify scopes in all"
-                                        + " applications.")
-                })
-        })
+     authorizations = {
+             @Authorization(value = "Kangaroo", scopes = {
+                     @AuthorizationScope(
+                             scope = Scope.ROLE,
+                             description = "Modify scopes in one"
+                                     + " application."),
+                     @AuthorizationScope(
+                             scope = Scope.ROLE_ADMIN,
+                             description = "Modify scopes in all"
+                                     + " applications.")
+             })
+     })
 public final class RoleScopeService extends AbstractService {
 
     /**
@@ -113,7 +113,7 @@ public final class RoleScopeService extends AbstractService {
 
         // If the parent application doesn't match, error.
         if (!role.getApplication().equals(scope.getApplication())) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("application");
         }
 
         // If the role is already linked to this scope, error.

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleService.java
@@ -24,6 +24,8 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
 import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.admin.v1.auth.ScopesAllowed;
+import net.krotscheck.kangaroo.authz.admin.v1.exception.EntityRequiredException;
+import net.krotscheck.kangaroo.authz.admin.v1.exception.InvalidEntityPropertyException;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.Role;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
@@ -258,13 +260,13 @@ public final class RoleService extends AbstractService {
 
         // Input value checks.
         if (role == null) {
-            throw new BadRequestException();
+            throw new EntityRequiredException();
         }
         if (role.getId() != null) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("id");
         }
         if (role.getApplication() == null) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("application");
         }
 
         // Assert that we can create a scope in this application.
@@ -315,7 +317,7 @@ public final class RoleService extends AbstractService {
 
         // Make sure the body ID's match
         if (!current.equals(role)) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("id");
         }
 
         // You cannot modify a role from the admin application.
@@ -325,7 +327,7 @@ public final class RoleService extends AbstractService {
 
         // Make sure we're not trying to change the parent entity.
         if (!current.getApplication().equals(role.getApplication())) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("application");
         }
 
         // Transfer all the values we're allowed to edit.

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ScopeService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ScopeService.java
@@ -24,6 +24,8 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
 import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.admin.v1.auth.ScopesAllowed;
+import net.krotscheck.kangaroo.authz.admin.v1.exception.EntityRequiredException;
+import net.krotscheck.kangaroo.authz.admin.v1.exception.InvalidEntityPropertyException;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.ApplicationScope;
 import net.krotscheck.kangaroo.authz.common.database.entity.Role;
@@ -275,13 +277,13 @@ public final class ScopeService extends AbstractService {
 
         // Input value checks.
         if (scope == null) {
-            throw new BadRequestException();
+            throw new EntityRequiredException();
         }
         if (scope.getId() != null) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("id");
         }
         if (scope.getApplication() == null) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("application");
         }
 
         // Assert that we can create a scope in this application.
@@ -340,12 +342,12 @@ public final class ScopeService extends AbstractService {
 
         // Make sure the body ID's match
         if (!currentScope.equals(scope)) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("id");
         }
 
         // Make sure we're not trying to change data we're not allowed.
         if (!currentScope.getApplication().equals(scope.getApplication())) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("application");
         }
 
         // Transfer all the values we're allowed to edit.

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserService.java
@@ -24,6 +24,8 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
 import net.krotscheck.kangaroo.authz.admin.Scope;
 import net.krotscheck.kangaroo.authz.admin.v1.auth.ScopesAllowed;
+import net.krotscheck.kangaroo.authz.admin.v1.exception.EntityRequiredException;
+import net.krotscheck.kangaroo.authz.admin.v1.exception.InvalidEntityPropertyException;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.Role;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
@@ -70,18 +72,18 @@ import java.net.URI;
 @ScopesAllowed({Scope.USER, Scope.USER_ADMIN})
 @Transactional
 @Api(tags = "User",
-        authorizations = {
-                @Authorization(value = "Kangaroo", scopes = {
-                        @AuthorizationScope(
-                                scope = Scope.USER,
-                                description = "Modify users in one"
-                                        + " application."),
-                        @AuthorizationScope(
-                                scope = Scope.USER_ADMIN,
-                                description = "Modify users in all"
-                                        + " applications.")
-                })
-        })
+     authorizations = {
+             @Authorization(value = "Kangaroo", scopes = {
+                     @AuthorizationScope(
+                             scope = Scope.USER,
+                             description = "Modify users in one"
+                                     + " application."),
+                     @AuthorizationScope(
+                             scope = Scope.USER_ADMIN,
+                             description = "Modify users in all"
+                                     + " applications.")
+             })
+     })
 public final class UserService extends AbstractService {
 
     /**
@@ -287,13 +289,13 @@ public final class UserService extends AbstractService {
 
         // Input value checks.
         if (user == null) {
-            throw new BadRequestException();
+            throw new EntityRequiredException();
         }
         if (user.getId() != null) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("id");
         }
         if (user.getApplication() == null) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("application");
         }
 
         // Assert that we can create a scope in this application.
@@ -344,12 +346,12 @@ public final class UserService extends AbstractService {
 
         // Make sure the body ID's match
         if (!currentUser.equals(user)) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("id");
         }
 
         // Make sure we're not trying to change data we're not allowed.
         if (!currentUser.getApplication().equals(user.getApplication())) {
-            throw new BadRequestException();
+            throw new InvalidEntityPropertyException("application");
         }
 
         // Transfer all the values we're allowed to edit.

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/exception/EntityRequiredExceptionTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/exception/EntityRequiredExceptionTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.admin.v1.exception;
+
+import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder;
+import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder.ErrorResponse;
+import org.junit.Test;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.core.Response.Status;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the EntityRequired exception.
+ *
+ * @author Michael Krotscheck
+ */
+public final class EntityRequiredExceptionTest {
+
+    /**
+     * Test the type.
+     */
+    @Test
+    public void testExtendsBadRequest() {
+        EntityRequiredException e = new EntityRequiredException();
+        assertTrue(e instanceof BadRequestException);
+    }
+
+    /**
+     * Test the message.
+     */
+    @Test
+    public void testCustomMessage() {
+        EntityRequiredException e = new EntityRequiredException();
+        assertEquals(e.getMessage(), EntityRequiredException.MESSAGE);
+    }
+
+    /**
+     * Test serialization.
+     */
+    @Test
+    public void testSerialization() {
+        ErrorResponse e = ErrorResponseBuilder
+                .from(new EntityRequiredException())
+                .buildEntity();
+
+        assertEquals(EntityRequiredException.MESSAGE, e.getErrorDescription());
+        assertEquals(Status.BAD_REQUEST, e.getHttpStatus());
+        assertEquals("bad_request", e.getError());
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/exception/InvalidEntityPropertyExceptionTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/exception/InvalidEntityPropertyExceptionTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.admin.v1.exception;
+
+import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder;
+import net.krotscheck.kangaroo.common.exception.ErrorResponseBuilder.ErrorResponse;
+import org.junit.Test;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.core.Response.Status;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for invalid entity properties.
+ *
+ * @author Michael Krotscheck
+ */
+public final class InvalidEntityPropertyExceptionTest {
+
+    /**
+     * Test the type.
+     */
+    @Test
+    public void testExtendsBadRequest() {
+        InvalidEntityPropertyException e =
+                new InvalidEntityPropertyException("foo");
+        assertTrue(e instanceof BadRequestException);
+    }
+
+    /**
+     * Test the message.
+     */
+    @Test
+    public void testCustomMessage() {
+        InvalidEntityPropertyException e =
+                new InvalidEntityPropertyException("foo");
+        String expected =
+                String.format(InvalidEntityPropertyException.MESSAGE, "foo");
+        assertEquals(e.getMessage(), expected);
+    }
+
+    /**
+     * Test serialization.
+     */
+    @Test
+    public void testSerialization() {
+        ErrorResponse e = ErrorResponseBuilder
+                .from(new InvalidEntityPropertyException("foo"))
+                .buildEntity();
+        String expected =
+                String.format(InvalidEntityPropertyException.MESSAGE, "foo");
+
+        assertEquals(expected, e.getErrorDescription());
+        assertEquals(Status.BAD_REQUEST, e.getHttpStatus());
+        assertEquals("bad_request", e.getError());
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/exception/package-info.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/exception/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Unit tests for our exceptions.
+ */
+package net.krotscheck.kangaroo.authz.admin.v1.exception;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceBrowseTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceBrowseTest.java
@@ -29,6 +29,7 @@ import net.krotscheck.kangaroo.authz.oauth2.exception.RFC6749.InvalidScopeExcept
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
 import net.krotscheck.kangaroo.common.hibernate.entity.AbstractEntity;
 import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
+import net.krotscheck.kangaroo.common.hibernate.id.MalformedIdException;
 import net.krotscheck.kangaroo.common.response.ApiParam;
 import net.krotscheck.kangaroo.test.jersey.SingletonTestContainerFactory;
 import net.krotscheck.kangaroo.test.runner.ParameterizedSingleInstanceTestRunner.ParameterizedSingleInstanceTestRunnerFactory;
@@ -44,6 +45,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import java.nio.charset.MalformedInputException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -479,7 +481,7 @@ public abstract class AbstractServiceBrowseTest<T extends AbstractAuthzEntity>
                         HttpUtil.authHeaderBearer(adminAppToken.getId()))
                 .get();
 
-        assertErrorResponse(response, Status.BAD_REQUEST);
+        assertErrorResponse(response, new MalformedIdException());
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AbstractServiceSearchTest.java
@@ -28,6 +28,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.UserIdentity;
 import net.krotscheck.kangaroo.authz.oauth2.exception.RFC6749.InvalidScopeException;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
 import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
+import net.krotscheck.kangaroo.common.hibernate.id.MalformedIdException;
 import net.krotscheck.kangaroo.test.jersey.SingletonTestContainerFactory;
 import net.krotscheck.kangaroo.test.runner.ParameterizedSingleInstanceTestRunner.ParameterizedSingleInstanceTestRunnerFactory;
 import org.apache.lucene.search.Query;
@@ -573,7 +574,7 @@ public abstract class AbstractServiceSearchTest<T extends AbstractAuthzEntity>
         params.put("owner", "malformed");
 
         Response r = search(params, getAdminToken());
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        assertErrorResponse(r, new MalformedIdException());
     }
 
     /**
@@ -588,7 +589,6 @@ public abstract class AbstractServiceSearchTest<T extends AbstractAuthzEntity>
         if (isLimitedByClientCredentials()) {
             assertErrorResponse(r, new InvalidScopeException());
         } else {
-
             assertListResponse(r, 0, 0, 10, 0);
         }
     }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ApplicationServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ApplicationServiceCRUDTest.java
@@ -19,6 +19,7 @@
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
 import net.krotscheck.kangaroo.authz.admin.Scope;
+import net.krotscheck.kangaroo.authz.admin.v1.exception.InvalidEntityPropertyException;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
@@ -239,7 +240,8 @@ public final class ApplicationServiceCRUDTest
         // Issue the request.
         Response r = postEntity(newApp, getAdminToken());
 
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        assertErrorResponse(r,
+                new InvalidEntityPropertyException("id"));
     }
 
     /**
@@ -639,7 +641,8 @@ public final class ApplicationServiceCRUDTest
         Response r = putEntity(newApp, getAdminToken());
 
         if (shouldSucceed()) {
-            assertErrorResponse(r, Status.BAD_REQUEST);
+            assertErrorResponse(r,
+                    new InvalidEntityPropertyException("owner"));
         } else {
             assertErrorResponse(r, Status.NOT_FOUND);
         }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AuthenticatorServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AuthenticatorServiceCRUDTest.java
@@ -19,6 +19,7 @@
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
 import net.krotscheck.kangaroo.authz.admin.Scope;
+import net.krotscheck.kangaroo.authz.admin.v1.exception.InvalidEntityPropertyException;
 import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorType;
 import net.krotscheck.kangaroo.authz.common.authenticator.exception.MisconfiguredAuthenticatorException;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
@@ -250,7 +251,8 @@ public final class AuthenticatorServiceCRUDTest
         testEntity.setClient(null);
 
         Response r = postEntity(testEntity, getAdminToken());
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        assertErrorResponse(r,
+                new InvalidEntityPropertyException("client"));
     }
 
     /**
@@ -267,7 +269,8 @@ public final class AuthenticatorServiceCRUDTest
 
         // Issue the request.
         Response r = postEntity(testEntity, getAdminToken());
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        assertErrorResponse(r,
+                new InvalidEntityPropertyException("client"));
     }
 
     /**
@@ -282,7 +285,8 @@ public final class AuthenticatorServiceCRUDTest
 
         // Issue the request.
         Response r = postEntity(testEntity, getAdminToken());
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        assertErrorResponse(r,
+                new InvalidEntityPropertyException("type"));
     }
 
     /**
@@ -372,7 +376,8 @@ public final class AuthenticatorServiceCRUDTest
         // Issue the request.
         Response r = putEntity(authenticator, getAdminToken());
         if (isAccessible(entity, getAdminToken())) {
-            assertErrorResponse(r, Status.BAD_REQUEST);
+            assertErrorResponse(r,
+                    new InvalidEntityPropertyException("client"));
         } else {
             assertErrorResponse(r, Status.NOT_FOUND);
         }
@@ -391,7 +396,8 @@ public final class AuthenticatorServiceCRUDTest
         // Issue the request.
         Response r = putEntity(entity, getAdminToken());
         if (isAccessible(entity, getAdminToken())) {
-            assertErrorResponse(r, Status.BAD_REQUEST);
+            assertErrorResponse(r,
+                    new InvalidEntityPropertyException("type"));
         } else {
             assertErrorResponse(r, Status.NOT_FOUND);
         }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AuthenticatorServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/AuthenticatorServiceSearchTest.java
@@ -28,6 +28,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
 import net.krotscheck.kangaroo.authz.oauth2.exception.RFC6749.InvalidScopeException;
 import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
+import net.krotscheck.kangaroo.common.hibernate.id.MalformedIdException;
 import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -266,7 +267,7 @@ public final class AuthenticatorServiceSearchTest
         if (isLimitedByClientCredentials()) {
             assertErrorResponse(r, new InvalidScopeException());
         } else {
-            assertErrorResponse(r, Status.BAD_REQUEST);
+            assertErrorResponse(r, new MalformedIdException());
         }
     }
 
@@ -280,7 +281,7 @@ public final class AuthenticatorServiceSearchTest
         params.put("client", "malformed");
 
         Response r = search(params, getAdminToken());
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        assertErrorResponse(r, new MalformedIdException());
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientRedirectServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientRedirectServiceCRUDTest.java
@@ -19,6 +19,7 @@
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
 import net.krotscheck.kangaroo.authz.admin.Scope;
+import net.krotscheck.kangaroo.authz.admin.v1.exception.InvalidEntityPropertyException;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;
@@ -32,6 +33,7 @@ import org.hibernate.Session;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -305,7 +307,12 @@ public final class ClientRedirectServiceCRUDTest
 
         // Issue the request.
         Response r = postEntity(testEntity, getAdminToken());
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        if (isAccessible(testEntity.getClient(), getAdminToken())) {
+            assertErrorResponse(r,
+                    new InvalidEntityPropertyException("uri"));
+        } else {
+            assertErrorResponse(r, new NotFoundException());
+        }
     }
 
     /**
@@ -327,6 +334,8 @@ public final class ClientRedirectServiceCRUDTest
         Response r = postEntity(testEntity, getAdminToken());
         if (shouldSucceed()) {
             assertErrorResponse(r, Status.CONFLICT);
+        } else if (isSubresource()) {
+            assertErrorResponse(r, new NotFoundException());
         } else {
             assertErrorResponse(r, Status.BAD_REQUEST);
         }
@@ -378,7 +387,8 @@ public final class ClientRedirectServiceCRUDTest
         // Issue the request.
         Response r = putEntity(duplicateRedirect, getAdminToken());
         if (shouldSucceed()) {
-            assertErrorResponse(r, Status.BAD_REQUEST);
+            assertErrorResponse(r,
+                    new InvalidEntityPropertyException("uri"));
         } else {
             assertErrorResponse(r, Status.NOT_FOUND);
         }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientServiceCRUDTest.java
@@ -19,6 +19,7 @@
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
 import net.krotscheck.kangaroo.authz.admin.Scope;
+import net.krotscheck.kangaroo.authz.admin.v1.exception.InvalidEntityPropertyException;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.Client;
@@ -233,7 +234,9 @@ public final class ClientServiceCRUDTest
         testEntity.setApplication(null);
 
         Response r = postEntity(testEntity, getAdminToken());
-        assertErrorResponse(r, new BadRequestException());
+        assertErrorResponse(r,
+                new InvalidEntityPropertyException(
+                        "application"));
     }
 
     /**
@@ -367,7 +370,8 @@ public final class ClientServiceCRUDTest
         // Issue the request.
         Response r = putEntity(client, getAdminToken());
         if (isAccessible(entity, getAdminToken())) {
-            assertErrorResponse(r, new BadRequestException());
+            assertErrorResponse(r,
+                    new InvalidEntityPropertyException("application"));
         } else {
             assertErrorResponse(r, Status.NOT_FOUND);
         }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ClientServiceSearchTest.java
@@ -27,6 +27,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
 import net.krotscheck.kangaroo.authz.oauth2.exception.RFC6749.InvalidScopeException;
 import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
+import net.krotscheck.kangaroo.common.hibernate.id.MalformedIdException;
 import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.hibernate.Session;
 import org.junit.Test;
@@ -261,7 +262,7 @@ public final class ClientServiceSearchTest
         if (isLimitedByClientCredentials()) {
             assertErrorResponse(r, new InvalidScopeException());
         } else {
-            assertErrorResponse(r, Status.BAD_REQUEST);
+            assertErrorResponse(r, new MalformedIdException());
         }
     }
 
@@ -275,7 +276,7 @@ public final class ClientServiceSearchTest
         params.put("application", "malformed");
 
         Response r = search(params, getAdminToken());
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        assertErrorResponse(r, new MalformedIdException());
     }
 }
 

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/OAuthTokenServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/OAuthTokenServiceSearchTest.java
@@ -29,6 +29,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.User;
 import net.krotscheck.kangaroo.authz.common.database.entity.UserIdentity;
 import net.krotscheck.kangaroo.authz.oauth2.exception.RFC6749.InvalidScopeException;
 import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
+import net.krotscheck.kangaroo.common.hibernate.id.MalformedIdException;
 import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -264,7 +265,7 @@ public final class OAuthTokenServiceSearchTest
         if (isLimitedByClientCredentials()) {
             assertErrorResponse(r, new InvalidScopeException());
         } else {
-            assertErrorResponse(r, Status.BAD_REQUEST);
+            assertErrorResponse(r, new MalformedIdException());
         }
     }
 
@@ -278,7 +279,7 @@ public final class OAuthTokenServiceSearchTest
         params.put("user", "malformed");
 
         Response r = search(params, getAdminToken());
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        assertErrorResponse(r, new MalformedIdException());
     }
 
     /**
@@ -344,7 +345,7 @@ public final class OAuthTokenServiceSearchTest
         if (isLimitedByClientCredentials()) {
             assertErrorResponse(r, new InvalidScopeException());
         } else {
-            assertErrorResponse(r, Status.BAD_REQUEST);
+            assertErrorResponse(r, new MalformedIdException());
         }
     }
 
@@ -358,7 +359,7 @@ public final class OAuthTokenServiceSearchTest
         params.put("identity", "malformed");
 
         Response r = search(params, getAdminToken());
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        assertErrorResponse(r, new MalformedIdException());
     }
 
     /**
@@ -420,7 +421,7 @@ public final class OAuthTokenServiceSearchTest
         if (isLimitedByClientCredentials()) {
             assertErrorResponse(r, new InvalidScopeException());
         } else {
-            assertErrorResponse(r, Status.BAD_REQUEST);
+            assertErrorResponse(r, new MalformedIdException());
         }
     }
 
@@ -434,7 +435,7 @@ public final class OAuthTokenServiceSearchTest
         params.put("client", "malformed");
 
         Response r = search(params, getAdminToken());
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        assertErrorResponse(r, new MalformedIdException());
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleServiceCRUDTest.java
@@ -19,6 +19,7 @@
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
 import net.krotscheck.kangaroo.authz.admin.Scope;
+import net.krotscheck.kangaroo.authz.admin.v1.exception.InvalidEntityPropertyException;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.ApplicationScope;
@@ -264,7 +265,8 @@ public final class RoleServiceCRUDTest
         testEntity.setApplication(null);
 
         Response r = postEntity(testEntity, getAdminToken());
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        assertErrorResponse(r,
+                new InvalidEntityPropertyException("application"));
     }
 
     /**
@@ -368,7 +370,8 @@ public final class RoleServiceCRUDTest
         // Issue the request.
         Response r = putEntity(testEntity, getAdminToken());
         if (isAccessible(entity, getAdminToken())) {
-            assertErrorResponse(r, Status.BAD_REQUEST);
+            assertErrorResponse(r,
+                    new InvalidEntityPropertyException("application"));
         } else {
             assertErrorResponse(r, Status.NOT_FOUND);
         }
@@ -646,7 +649,8 @@ public final class RoleServiceCRUDTest
 
         if (isAccessible(role, testContext.getToken())) {
             // Bad request because OMG really?
-            assertErrorResponse(r, Status.BAD_REQUEST);
+            assertErrorResponse(r,
+                    new InvalidEntityPropertyException("application"));
         } else {
             // Bad request because we can't tell you about it.
             assertErrorResponse(r, Status.NOT_FOUND);

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/RoleServiceSearchTest.java
@@ -27,6 +27,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.Role;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
 import net.krotscheck.kangaroo.authz.oauth2.exception.RFC6749.InvalidScopeException;
 import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
+import net.krotscheck.kangaroo.common.hibernate.id.MalformedIdException;
 import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -255,7 +256,7 @@ public final class RoleServiceSearchTest
         if (isLimitedByClientCredentials()) {
             assertErrorResponse(r, new InvalidScopeException());
         } else {
-            assertErrorResponse(r, Status.BAD_REQUEST);
+            assertErrorResponse(r, new MalformedIdException());
         }
     }
 
@@ -269,6 +270,6 @@ public final class RoleServiceSearchTest
         params.put("application", "malformed");
 
         Response r = search(params, getAdminToken());
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        assertErrorResponse(r, new MalformedIdException());
     }
 }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ScopeServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/ScopeServiceSearchTest.java
@@ -27,6 +27,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
 import net.krotscheck.kangaroo.authz.oauth2.exception.RFC6749.InvalidScopeException;
 import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
+import net.krotscheck.kangaroo.common.hibernate.id.MalformedIdException;
 import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -219,7 +220,7 @@ public final class ScopeServiceSearchTest
         if (isLimitedByClientCredentials()) {
             assertErrorResponse(r, new InvalidScopeException());
         } else {
-            assertErrorResponse(r, Status.BAD_REQUEST);
+            assertErrorResponse(r, new MalformedIdException());
         }
     }
 

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserIdentityServiceBrowseTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserIdentityServiceBrowseTest.java
@@ -29,6 +29,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.User;
 import net.krotscheck.kangaroo.authz.common.database.entity.UserIdentity;
 import net.krotscheck.kangaroo.authz.oauth2.exception.RFC6749.InvalidScopeException;
 import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
+import net.krotscheck.kangaroo.common.hibernate.id.MalformedIdException;
 import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.hibernate.Criteria;
 import org.junit.Test;
@@ -268,7 +269,7 @@ public final class UserIdentityServiceBrowseTest
         if (isLimitedByClientCredentials()) {
             assertErrorResponse(r, new InvalidScopeException());
         } else {
-            assertErrorResponse(r, Status.BAD_REQUEST);
+            assertErrorResponse(r, new MalformedIdException());
         }
     }
 
@@ -281,7 +282,7 @@ public final class UserIdentityServiceBrowseTest
         params.put("user", "malformed");
         Response r = browse(params, getAdminToken());
 
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        assertErrorResponse(r, new MalformedIdException());
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserIdentityServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserIdentityServiceCRUDTest.java
@@ -19,6 +19,7 @@
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
 import net.krotscheck.kangaroo.authz.admin.Scope;
+import net.krotscheck.kangaroo.authz.admin.v1.exception.InvalidEntityPropertyException;
 import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorType;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Authenticator;
@@ -347,8 +348,7 @@ public final class UserIdentityServiceCRUDTest
 
         // Issue the request.
         Response r = postEntity(testEntity, getAdminToken());
-
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        assertErrorResponse(r, new InvalidEntityPropertyException("type"));
     }
 
     /**
@@ -364,7 +364,8 @@ public final class UserIdentityServiceCRUDTest
         // Issue the request.
         Response r = postEntity(testEntity, getAdminToken());
 
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        assertErrorResponse(r,
+                new InvalidEntityPropertyException("type"));
     }
 
     /**
@@ -382,7 +383,8 @@ public final class UserIdentityServiceCRUDTest
         // Issue the request.
         Response r = postEntity(testEntity, getAdminToken());
 
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        assertErrorResponse(r,
+                new InvalidEntityPropertyException("user"));
     }
 
     /**
@@ -398,7 +400,8 @@ public final class UserIdentityServiceCRUDTest
         // Issue the request.
         Response r = postEntity(testEntity, getAdminToken());
 
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        assertErrorResponse(r,
+                new InvalidEntityPropertyException("user"));
     }
 
     /**
@@ -414,7 +417,8 @@ public final class UserIdentityServiceCRUDTest
         // Issue the request.
         Response r = postEntity(testEntity, getAdminToken());
 
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        assertErrorResponse(r,
+                new InvalidEntityPropertyException("remoteId"));
     }
 
     /**
@@ -430,7 +434,8 @@ public final class UserIdentityServiceCRUDTest
         // Issue the request.
         Response r = postEntity(testEntity, getAdminToken());
 
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        assertErrorResponse(r,
+                new InvalidEntityPropertyException("password"));
     }
 
     /**
@@ -484,7 +489,8 @@ public final class UserIdentityServiceCRUDTest
         Response r = putEntity(testEntity, getAdminToken());
 
         if (isAccessible(testEntity, getAdminToken())) {
-            assertErrorResponse(r, Status.BAD_REQUEST);
+            assertErrorResponse(r,
+                    new InvalidEntityPropertyException("type"));
         } else {
             assertErrorResponse(r, Status.NOT_FOUND);
         }
@@ -513,7 +519,8 @@ public final class UserIdentityServiceCRUDTest
         Response r = putEntity(testEntity, getAdminToken());
 
         if (isAccessible(originalEntity, getAdminToken())) {
-            assertErrorResponse(r, Status.BAD_REQUEST);
+            assertErrorResponse(r,
+                    new InvalidEntityPropertyException("user"));
         } else {
             assertErrorResponse(r, Status.NOT_FOUND);
         }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserIdentityServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserIdentityServiceSearchTest.java
@@ -28,6 +28,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.User;
 import net.krotscheck.kangaroo.authz.common.database.entity.UserIdentity;
 import net.krotscheck.kangaroo.authz.oauth2.exception.RFC6749.InvalidScopeException;
 import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
+import net.krotscheck.kangaroo.common.hibernate.id.MalformedIdException;
 import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
@@ -262,7 +263,7 @@ public final class UserIdentityServiceSearchTest
         if (isLimitedByClientCredentials()) {
             assertErrorResponse(r, new InvalidScopeException());
         } else {
-            assertErrorResponse(r, Status.BAD_REQUEST);
+            assertErrorResponse(r, new MalformedIdException());
         }
     }
 
@@ -276,7 +277,7 @@ public final class UserIdentityServiceSearchTest
         params.put("user", "malformed");
 
         Response r = search(params, getAdminToken());
-        assertErrorResponse(r, new BadRequestException());
+        assertErrorResponse(r, new MalformedIdException());
     }
 
     /**

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserServiceBrowseTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserServiceBrowseTest.java
@@ -27,6 +27,7 @@ import net.krotscheck.kangaroo.authz.common.database.entity.Role;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
 import net.krotscheck.kangaroo.authz.oauth2.exception.RFC6749.InvalidScopeException;
 import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
+import net.krotscheck.kangaroo.common.hibernate.id.MalformedIdException;
 import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.hibernate.Criteria;
 import org.junit.Test;
@@ -263,7 +264,7 @@ public final class UserServiceBrowseTest
         if (isLimitedByClientCredentials()) {
             assertErrorResponse(r, new InvalidScopeException());
         } else {
-            assertErrorResponse(r, Status.BAD_REQUEST);
+            assertErrorResponse(r, new MalformedIdException());
         }
     }
 
@@ -321,7 +322,7 @@ public final class UserServiceBrowseTest
         if (isLimitedByClientCredentials()) {
             assertErrorResponse(r, new InvalidScopeException());
         } else {
-            assertErrorResponse(r, Status.BAD_REQUEST);
+            assertErrorResponse(r, new MalformedIdException());
         }
     }
 }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserServiceCRUDTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserServiceCRUDTest.java
@@ -19,6 +19,7 @@
 package net.krotscheck.kangaroo.authz.admin.v1.resource;
 
 import net.krotscheck.kangaroo.authz.admin.Scope;
+import net.krotscheck.kangaroo.authz.admin.v1.exception.InvalidEntityPropertyException;
 import net.krotscheck.kangaroo.authz.common.database.entity.AbstractAuthzEntity;
 import net.krotscheck.kangaroo.authz.common.database.entity.Application;
 import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
@@ -224,7 +225,8 @@ public final class UserServiceCRUDTest
         testEntity.setApplication(null);
 
         Response r = postEntity(testEntity, getAdminToken());
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        assertErrorResponse(r,
+                new InvalidEntityPropertyException("application"));
     }
 
     /**
@@ -268,7 +270,8 @@ public final class UserServiceCRUDTest
         // Issue the request.
         Response r = putEntity(user, getAdminToken());
         if (isAccessible(entity, getAdminToken())) {
-            assertErrorResponse(r, Status.BAD_REQUEST);
+            assertErrorResponse(r,
+                    new InvalidEntityPropertyException("application"));
         } else {
             assertErrorResponse(r, Status.NOT_FOUND);
         }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserServiceSearchTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/admin/v1/resource/UserServiceSearchTest.java
@@ -27,10 +27,12 @@ import net.krotscheck.kangaroo.authz.common.database.entity.Role;
 import net.krotscheck.kangaroo.authz.common.database.entity.User;
 import net.krotscheck.kangaroo.authz.oauth2.exception.RFC6749.InvalidScopeException;
 import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
+import net.krotscheck.kangaroo.common.hibernate.id.MalformedIdException;
 import net.krotscheck.kangaroo.common.response.ListResponseEntity;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -229,7 +231,7 @@ public final class UserServiceSearchTest
         if (isLimitedByClientCredentials()) {
             assertErrorResponse(r, new InvalidScopeException());
         } else if (!isAccessible(a, token)) {
-            assertErrorResponse(r, Status.BAD_REQUEST);
+            assertErrorResponse(r, new BadRequestException());
         } else {
             assertTrue(expectedTotal > 0);
 
@@ -255,7 +257,7 @@ public final class UserServiceSearchTest
         if (isLimitedByClientCredentials()) {
             assertErrorResponse(r, new InvalidScopeException());
         } else {
-            assertErrorResponse(r, Status.BAD_REQUEST);
+            assertErrorResponse(r, new MalformedIdException());
         }
     }
 
@@ -269,7 +271,7 @@ public final class UserServiceSearchTest
         params.put("application", "malformed");
 
         Response r = search(params, getAdminToken());
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        assertErrorResponse(r, new MalformedIdException());
     }
 
     /**
@@ -338,7 +340,7 @@ public final class UserServiceSearchTest
         if (isLimitedByClientCredentials()) {
             assertErrorResponse(r, new InvalidScopeException());
         } else {
-            assertErrorResponse(r, Status.BAD_REQUEST);
+            assertErrorResponse(r, new MalformedIdException());
         }
     }
 
@@ -352,6 +354,6 @@ public final class UserServiceSearchTest
         params.put("role", "malformed");
 
         Response r = search(params, getAdminToken());
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        assertErrorResponse(r, new MalformedIdException());
     }
 }

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc7662/TokenIntrospectionTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc7662/TokenIntrospectionTest.java
@@ -29,6 +29,7 @@ import net.krotscheck.kangaroo.authz.oauth2.resource.IntrospectionResponseEntity
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder;
 import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
 import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
+import net.krotscheck.kangaroo.common.hibernate.id.MalformedIdException;
 import net.krotscheck.kangaroo.test.jersey.ContainerTest;
 import net.krotscheck.kangaroo.test.jersey.SingletonTestContainerFactory;
 import net.krotscheck.kangaroo.test.rule.TestDataResource;
@@ -522,7 +523,7 @@ public final class TokenIntrospectionTest extends ContainerTest {
                 .header(AUTHORIZATION, contextAuthHeader)
                 .post(buildEntity(values));
 
-        assertErrorResponse(r, Status.BAD_REQUEST);
+        assertErrorResponse(r, new MalformedIdException());
     }
 
     /**


### PR DESCRIPTION
This patch attempts to improve 'developer' runtime documentation
by returning 400 bad requests that have helpful error messages.

Closes #429