### PR TITLE
RFC 7009: Token revocation

### DIFF
--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/OAuthAPI.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/OAuthAPI.java
@@ -24,6 +24,7 @@ import net.krotscheck.kangaroo.authz.oauth2.authn.O2AuthDynamicFeature;
 import net.krotscheck.kangaroo.authz.oauth2.exception.RedirectingExceptionMapper;
 import net.krotscheck.kangaroo.authz.oauth2.resource.AuthorizationService;
 import net.krotscheck.kangaroo.authz.oauth2.resource.IntrospectionService;
+import net.krotscheck.kangaroo.authz.oauth2.resource.RevocationService;
 import net.krotscheck.kangaroo.authz.oauth2.resource.TokenService;
 import net.krotscheck.kangaroo.authz.oauth2.resource.authorize.AuthCodeHandler;
 import net.krotscheck.kangaroo.authz.oauth2.resource.authorize.ImplicitHandler;
@@ -100,5 +101,6 @@ public class OAuthAPI extends ResourceConfig {
         register(TokenService.class);
         register(AuthorizationService.class);
         register(IntrospectionService.class);
+        register(RevocationService.class);
     }
 }

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/authn/authn/O2ClientBodyFilter.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/authn/authn/O2ClientBodyFilter.java
@@ -31,6 +31,7 @@ import javax.ws.rs.HttpMethod;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Form;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import java.math.BigInteger;
 import java.util.List;
@@ -103,7 +104,10 @@ public final class O2ClientBodyFilter
         }
 
         // Only form data is permitted.
-        if (!context.getMediaType().equals(APPLICATION_FORM_URLENCODED_TYPE)) {
+        MediaType type = Optional.ofNullable(context.getMediaType())
+                .filter(m -> m.equals(APPLICATION_FORM_URLENCODED_TYPE))
+                .orElse(null);
+        if (type == null) {
             return;
         }
 

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/RevocationService.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/oauth2/resource/RevocationService.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.oauth2.resource;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import net.krotscheck.kangaroo.authz.common.database.entity.Client;
+import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
+import net.krotscheck.kangaroo.authz.oauth2.authn.O2BearerToken;
+import net.krotscheck.kangaroo.authz.oauth2.authn.O2Client;
+import net.krotscheck.kangaroo.authz.oauth2.authn.O2Principal;
+import net.krotscheck.kangaroo.authz.oauth2.exception.RFC6749.AccessDeniedException;
+import net.krotscheck.kangaroo.common.hibernate.transaction.Transactional;
+import net.krotscheck.kangaroo.util.ObjectUtil;
+import org.hibernate.Session;
+
+import javax.annotation.security.PermitAll;
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.SecurityContext;
+import java.math.BigInteger;
+import java.util.Optional;
+
+import static net.krotscheck.kangaroo.authz.common.database.entity.ClientType.ClientCredentials;
+
+/**
+ * Revocation endpoint of the OAuth2 service, complies with RFC-7009.
+ *
+ * @author Michael Krotscheck
+ */
+@Path("/revoke")
+@PermitAll
+@Transactional
+@Api(tags = "OAuth2")
+public final class RevocationService {
+
+    /**
+     * Hibernate session to use.
+     */
+    private final Session session;
+
+    /**
+     * Security Context for this request..
+     */
+    private final SecurityContext securityContext;
+
+    /**
+     * Create a new introspection service.
+     *
+     * @param session         Injected hibernate session.
+     * @param securityContext The security context for the current request.
+     */
+    @Inject
+    public RevocationService(final Session session,
+                             final SecurityContext securityContext) {
+        this.session = session;
+        this.securityContext = securityContext;
+    }
+
+    /**
+     * Attempt to return the claims associated with this token.
+     *
+     * @param tokenId The token ID to introspect.
+     * @return The processed response.
+     */
+    @POST
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @O2Client(permitPublic = false)
+    @O2BearerToken()
+    @ApiOperation(value = "OAuth2 Revocation endpoint.")
+    public Response introspectionRequest(
+            @ApiParam(type = "string")
+            @FormParam("token") final BigInteger tokenId) {
+
+        // Pull the principal, to check the style of authorization we have here.
+        O2Principal principal = ObjectUtil
+                .safeCast(securityContext.getUserPrincipal(), O2Principal.class)
+                .orElseThrow(AccessDeniedException::new);
+
+        Optional<OAuthToken> revokedToken;
+
+        OAuthToken authToken = principal.getOAuthToken();
+        Client client = principal.getContext();
+
+        if (client.getType().equals(ClientCredentials)) {
+            // We're authorized via the client, or via a token belonging to a
+            // client-credentials client. In this case, any token may be
+            // revoked, as long as it exists and belongs to the same
+            // application.
+            revokedToken = Optional.ofNullable(tokenId)
+                    .map(id -> session.get(OAuthToken.class, id))
+                    .filter(t -> t.getClient()
+                            .getApplication()
+                            .equals(client.getApplication()));
+        } else {
+            // We are authorizing via a non-client-credentials token, meaning
+            // it's attached to a user and identity. In this case, any token
+            // belonging to the user may be revoked.
+            revokedToken = Optional.ofNullable(tokenId)
+                    .map(id -> session.get(OAuthToken.class, id))
+                    .filter(t -> t.getIdentity().getUser()
+                            .equals(authToken.getIdentity().getUser()));
+        }
+
+        if (!revokedToken.isPresent()) {
+            throw new NotFoundException();
+        }
+
+        session.delete(revokedToken.get());
+        session.getTransaction().commit();
+
+        return Response.status(Status.RESET_CONTENT).build();
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc7009/TokenRevocationTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc7009/TokenRevocationTest.java
@@ -1,0 +1,916 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.krotscheck.kangaroo.authz.oauth2.rfc7009;
+
+import net.krotscheck.kangaroo.authz.common.authenticator.AuthenticatorType;
+import net.krotscheck.kangaroo.authz.common.database.entity.Client;
+import net.krotscheck.kangaroo.authz.common.database.entity.ClientType;
+import net.krotscheck.kangaroo.authz.common.database.entity.OAuthToken;
+import net.krotscheck.kangaroo.authz.oauth2.OAuthAPI;
+import net.krotscheck.kangaroo.authz.test.ApplicationBuilder;
+import net.krotscheck.kangaroo.authz.test.ApplicationBuilder.ApplicationContext;
+import net.krotscheck.kangaroo.common.hibernate.id.IdUtil;
+import net.krotscheck.kangaroo.common.hibernate.id.MalformedIdException;
+import net.krotscheck.kangaroo.test.jersey.ContainerTest;
+import net.krotscheck.kangaroo.test.jersey.SingletonTestContainerFactory;
+import net.krotscheck.kangaroo.test.rule.TestDataResource;
+import net.krotscheck.kangaroo.test.runner.SingleInstanceTestRunner;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
+import org.hibernate.Session;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.Map;
+
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static net.krotscheck.kangaroo.util.HttpUtil.authHeaderBasic;
+import static net.krotscheck.kangaroo.util.HttpUtil.authHeaderBearer;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * These unit tests handle the token revocation endpoint.
+ */
+@RunWith(SingleInstanceTestRunner.class)
+public class TokenRevocationTest extends ContainerTest {
+
+    /**
+     * The test context for a regular application.
+     */
+    private static ApplicationContext context;
+
+    /**
+     * The test context for a peer application.
+     */
+    private static ApplicationContext otherContext;
+
+    /**
+     * Test data loading for this test.
+     */
+    @ClassRule
+    public static final TestRule TEST_DATA_RULE =
+            new TestDataResource(HIBERNATE_RESOURCE) {
+                /**
+                 * Initialize the test data.
+                 */
+                @Override
+                protected void loadTestData(final Session session) {
+                    context = ApplicationBuilder
+                            .newApplication(session)
+                            .scope("debug")
+                            .scope("debug1")
+                            .role("test", new String[]{"debug"})
+                            .client(ClientType.ClientCredentials, true)
+                            .authenticator(AuthenticatorType.Test)
+                            .redirect("http://www.example.com/")
+                            .user()
+                            .identity()
+                            .claim("one", "claim")
+                            .claim("two", "claim")
+                            .bearerToken()
+                            .build();
+                    otherContext = ApplicationBuilder
+                            .newApplication(session)
+                            .scope("debug")
+                            .scope("debug1")
+                            .role("test", new String[]{"debug"})
+                            .client(ClientType.AuthorizationGrant, true)
+                            .authenticator(AuthenticatorType.Test)
+                            .redirect("http://www.example.com/")
+                            .user()
+                            .identity()
+                            .claim("red", "claim")
+                            .claim("blue", "claim")
+                            .build();
+                }
+            };
+    /**
+     * Test container factory.
+     */
+    private SingletonTestContainerFactory testContainerFactory;
+
+    /**
+     * The current running test application.
+     */
+    private ResourceConfig testApplication;
+
+    /**
+     * This method overrides the underlying default test container provider,
+     * with one that provides a singleton instance. This allows us to
+     * circumvent the often expensive initialization routines that come from
+     * bootstrapping our services.
+     *
+     * @return an instance of {@link TestContainerFactory} class.
+     * @throws TestContainerException if the initialization of
+     *                                {@link TestContainerFactory} instance
+     *                                is not successful.
+     */
+    protected TestContainerFactory getTestContainerFactory()
+            throws TestContainerException {
+        if (this.testContainerFactory == null) {
+            this.testContainerFactory =
+                    new SingletonTestContainerFactory(
+                            super.getTestContainerFactory(),
+                            this.getClass());
+        }
+        return testContainerFactory;
+    }
+
+    /**
+     * Create the application under test.
+     *
+     * @return A configured api servlet.
+     */
+    @Override
+    protected ResourceConfig createApplication() {
+        if (testApplication == null) {
+            testApplication = new OAuthAPI();
+        }
+        return testApplication;
+    }
+
+    /**
+     * Convert a map into an HTML form payload.
+     *
+     * @param values The values to map.
+     * @return The payload.
+     */
+    private Entity buildEntity(final Map<String, String> values) {
+        Form f = new Form();
+        values.forEach(f::param);
+        return Entity.entity(f, MediaType.APPLICATION_FORM_URLENCODED_TYPE);
+    }
+
+    /**
+     * Assert that the revocation response matches the expected response
+     * body, and that the revoked token no longer exists in the database.
+     *
+     * @param r            The response.
+     * @param revokedToken The revoked token.
+     */
+    private void assertValidRevocation(final Response r,
+                                       final OAuthToken revokedToken) {
+        assertEquals(205, r.getStatus());
+//        assertFalse(r.hasEntity());
+
+        Session s = getSession();
+        s.evict(revokedToken);
+        s.beginTransaction();
+        OAuthToken existingToken = s.get(OAuthToken.class,
+                revokedToken.getId());
+        s.getTransaction().commit();
+        assertNull(existingToken);
+    }
+
+    /**
+     * Assert that a bearer can revoke itself.
+     */
+    @Test
+    public void testRevokeSelf() {
+        ApplicationContext testContext = otherContext.getBuilder()
+                .bearerToken("debug")
+                .build();
+        OAuthToken bearerToken = testContext.getToken();
+        String header = authHeaderBearer(bearerToken.getId());
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(bearerToken.getId()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertValidRevocation(r, bearerToken);
+    }
+
+    /**
+     * Assert that a bearer token can revoke another bearer token if it's
+     * attached to the same user.
+     */
+    @Test
+    public void testRevokeOtherBearerSameUser() {
+        ApplicationContext testContext = otherContext.getBuilder()
+                .bearerToken("debug")
+                .build();
+        OAuthToken bearerToken = testContext.getToken();
+        testContext = otherContext.getBuilder()
+                .bearerToken("debug")
+                .build();
+        OAuthToken revokedToken = testContext.getToken();
+        String header = authHeaderBearer(bearerToken.getId());
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(revokedToken.getId()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertValidRevocation(r, revokedToken);
+    }
+
+    /**
+     * Assert that a bearer token cannot revoke a bearer token that belongs
+     * to a different user.
+     */
+    @Test
+    public void testRevokeOtherBearerDifferentUser() {
+        ApplicationContext testContext = otherContext.getBuilder()
+                .bearerToken("debug")
+                .build();
+        OAuthToken bearerToken = testContext.getToken();
+        testContext = otherContext.getBuilder()
+                .user()
+                .identity()
+                .bearerToken("debug")
+                .build();
+        OAuthToken revokedToken = testContext.getToken();
+        String header = authHeaderBearer(bearerToken.getId());
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(revokedToken.getId()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertErrorResponse(r, new NotFoundException());
+    }
+
+    /**
+     * Assert that a bearer cannot revoke a malformed token.
+     */
+    @Test
+    public void testRevokeMalformed() {
+        ApplicationContext testContext = otherContext.getBuilder()
+                .bearerToken("debug")
+                .build();
+        OAuthToken bearerToken = testContext.getToken();
+        String header = authHeaderBearer(bearerToken.getId());
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", "malformed_token");
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertErrorResponse(r, new MalformedIdException());
+    }
+
+    /**
+     * Assert that a bearer cannot revoke a nonexistent token.
+     */
+    @Test
+    public void testRevokeNonexistent() {
+        ApplicationContext testContext = otherContext.getBuilder()
+                .bearerToken("debug")
+                .build();
+        OAuthToken bearerToken = testContext.getToken();
+        String header = authHeaderBearer(bearerToken.getId());
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(IdUtil.next()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertErrorResponse(r, new NotFoundException());
+    }
+
+    /**
+     * Assert that a bearer token can revoke its own refresh token.
+     */
+    @Test
+    public void testRevokeOwnRefresh() {
+        ApplicationContext testContext = otherContext.getBuilder()
+                .bearerToken("debug")
+                .build();
+        OAuthToken bearerToken = testContext.getToken();
+        testContext = testContext.getBuilder()
+                .refreshToken()
+                .build();
+        OAuthToken refreshToken = testContext.getToken();
+        String header = authHeaderBearer(bearerToken.getId());
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(refreshToken.getId()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertValidRevocation(r, refreshToken);
+    }
+
+    /**
+     * Assert that a bearer token can revoke another refresh token if it's
+     * attached to the same user.
+     */
+    @Test
+    public void testRevokeOtherRefreshSameUser() {
+        ApplicationContext testContext = otherContext.getBuilder()
+                .bearerToken("debug")
+                .build();
+        OAuthToken bearerToken = testContext.getToken();
+        testContext = otherContext.getBuilder()
+                .bearerToken("debug")
+                .refreshToken()
+                .build();
+        OAuthToken revokedToken = testContext.getToken();
+        String header = authHeaderBearer(bearerToken.getId());
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(revokedToken.getId()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertValidRevocation(r, revokedToken);
+    }
+
+    /**
+     * Assert that a bearer token cannot revoke another bearer token if it's
+     * owned by a different user.
+     */
+    @Test
+    public void testRevokeOtherRefreshDifferentUser() {
+        ApplicationContext testContext = otherContext.getBuilder()
+                .bearerToken("debug")
+                .build();
+        OAuthToken bearerToken = testContext.getToken();
+        testContext = otherContext.getBuilder()
+                .user()
+                .identity()
+                .bearerToken("debug")
+                .refreshToken()
+                .build();
+        OAuthToken revokedToken = testContext.getToken();
+        String header = authHeaderBearer(bearerToken.getId());
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(revokedToken.getId()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertErrorResponse(r, new NotFoundException());
+    }
+
+    /**
+     * Assert that a bearer token can revoke another authorization code if it's
+     * attached to the same user.
+     */
+    @Test
+    public void testRevokeOtherAuthorizationCodeSameUser() {
+        ApplicationContext testContext = otherContext.getBuilder()
+                .bearerToken("debug")
+                .build();
+        OAuthToken bearerToken = testContext.getToken();
+        testContext = otherContext.getBuilder()
+                .authToken()
+                .build();
+        OAuthToken revokedToken = testContext.getToken();
+        String header = authHeaderBearer(bearerToken.getId());
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(revokedToken.getId()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertValidRevocation(r, revokedToken);
+    }
+
+    /**
+     * Assert that a bearer token cannot revoke another bearer token if it's
+     * owned by a different user.
+     */
+    @Test
+    public void testRevokeOtherAuthorizationCodeDifferentUser() {
+        ApplicationContext testContext = otherContext.getBuilder()
+                .bearerToken("debug")
+                .build();
+        OAuthToken bearerToken = testContext.getToken();
+        testContext = otherContext.getBuilder()
+                .user()
+                .identity()
+                .authToken()
+                .build();
+        OAuthToken revokedToken = testContext.getToken();
+        String header = authHeaderBearer(bearerToken.getId());
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(revokedToken.getId()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertErrorResponse(r, new NotFoundException());
+    }
+
+    /**
+     * Assert that client credentials can revoke a bearer token issued to the
+     * same client.
+     */
+    @Test
+    public void testRevokeBearerBySameClient() {
+        Client c = context.getClient();
+        String header = authHeaderBasic(c.getId(), c.getClientSecret());
+
+        ApplicationContext testContext = context.getBuilder()
+                .bearerToken("debug")
+                .build();
+        OAuthToken revokedToken = testContext.getToken();
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(revokedToken.getId()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertValidRevocation(r, revokedToken);
+    }
+
+    /**
+     * Assert that client credentials cannot revoke a malformed token.
+     */
+    @Test
+    public void testRevokeMalformedByClient() {
+        Client c = context.getClient();
+        String header = authHeaderBasic(c.getId(), c.getClientSecret());
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", "malformed_token");
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertErrorResponse(r, new MalformedIdException());
+    }
+
+    /**
+     * Assert that client credentials cannot revoke a nonexistent token.
+     */
+    @Test
+    public void testRevokeInvalidByClient() {
+        Client c = context.getClient();
+        String header = authHeaderBasic(c.getId(), c.getClientSecret());
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(IdUtil.next()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertErrorResponse(r, new NotFoundException());
+    }
+
+    /**
+     * Assert that client credentials can revoke a bearer token issued to a
+     * different client in the same application.
+     */
+    @Test
+    public void testRevokeBearerByOtherClient() {
+        Client c = context.getClient();
+        String header = authHeaderBasic(c.getId(), c.getClientSecret());
+
+        ApplicationContext testContext = context.getBuilder()
+                .client(ClientType.Implicit)
+                .bearerToken("debug")
+                .build();
+        OAuthToken revokedToken = testContext.getToken();
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(revokedToken.getId()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertValidRevocation(r, revokedToken);
+    }
+
+    /**
+     * Assert that client credentials can revoke a refresh token issued to the
+     * same client.
+     */
+    @Test
+    public void testRevokeRefreshBySameClient() {
+        Client c = context.getClient();
+        String header = authHeaderBasic(c.getId(), c.getClientSecret());
+
+        ApplicationContext testContext = context.getBuilder()
+                .bearerToken("debug")
+                .refreshToken()
+                .build();
+        OAuthToken revokedToken = testContext.getToken();
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(revokedToken.getId()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertValidRevocation(r, revokedToken);
+    }
+
+    /**
+     * Assert that client credentials can revoke a refresh token issued to a
+     * different client in the same application.
+     */
+    @Test
+    public void testRevokeRefreshByOtherClient() {
+        Client c = context.getClient();
+        String header = authHeaderBasic(c.getId(), c.getClientSecret());
+
+        ApplicationContext testContext = context.getBuilder()
+                .client(ClientType.Implicit)
+                .bearerToken("debug")
+                .refreshToken()
+                .build();
+        OAuthToken revokedToken = testContext.getToken();
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(revokedToken.getId()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertValidRevocation(r, revokedToken);
+    }
+
+    /**
+     * Assert that client credentials can revoke an authorization code issued to
+     * the same client.
+     */
+    @Test
+    public void testRevokeAuthCodeBySameClient() {
+        Client c = context.getClient();
+        String header = authHeaderBasic(c.getId(), c.getClientSecret());
+
+        ApplicationContext testContext = context.getBuilder()
+                .authToken()
+                .build();
+        OAuthToken revokedToken = testContext.getToken();
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(revokedToken.getId()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertValidRevocation(r, revokedToken);
+    }
+
+    /**
+     * Assert that client credentials can revoke an authorization code issued
+     * to a different client in the same application.
+     */
+    @Test
+    public void testRevokeAuthCodeByOtherClient() {
+        Client c = context.getClient();
+        String header = authHeaderBasic(c.getId(), c.getClientSecret());
+
+        ApplicationContext testContext = context.getBuilder()
+                .client(ClientType.Implicit)
+                .authToken()
+                .build();
+        OAuthToken revokedToken = testContext.getToken();
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(revokedToken.getId()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertValidRevocation(r, revokedToken);
+    }
+
+    /**
+     * Assert that a token issued to a client credentials client can revoke a
+     * bearer token issued to the same client.
+     */
+    @Test
+    public void testRevokeBearerBySameClientToken() {
+        Client c = context.getClient();
+        String header = authHeaderBearer(context.getToken().getId());
+
+        ApplicationContext testContext = context.getBuilder()
+                .bearerToken("debug")
+                .build();
+        OAuthToken revokedToken = testContext.getToken();
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(revokedToken.getId()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertValidRevocation(r, revokedToken);
+    }
+
+    /**
+     * Assert that a token issued to a client credentials client cannot revoke
+     * a malformed token.
+     */
+    @Test
+    public void testRevokeMalformedByClientToken() {
+        String header = authHeaderBearer(context.getToken().getId());
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", "malformed_token");
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertErrorResponse(r, new MalformedIdException());
+    }
+
+    /**
+     * Assert that a token issued to a client credentials client cannot revoke
+     * a nonexistent token.
+     */
+    @Test
+    public void testRevokeInvalidByClientToken() {
+        Client c = context.getClient();
+        String header = authHeaderBearer(context.getToken().getId());
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(IdUtil.next()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertErrorResponse(r, new NotFoundException());
+    }
+
+    /**
+     * Assert that a token issued to a client credentials client can revoke
+     * a bearer token issued to a different client in the same application.
+     */
+    @Test
+    public void testRevokeBearerByOtherClientToken() {
+        Client c = context.getClient();
+        String header = authHeaderBearer(context.getToken().getId());
+
+        ApplicationContext testContext = context.getBuilder()
+                .client(ClientType.Implicit)
+                .bearerToken("debug")
+                .build();
+        OAuthToken revokedToken = testContext.getToken();
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(revokedToken.getId()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertValidRevocation(r, revokedToken);
+    }
+
+    /**
+     * Assert that a token issued to a client credentials client can revoke
+     * a refresh token issued to the same client.
+     */
+    @Test
+    public void testRevokeRefreshBySameClientToken() {
+        Client c = context.getClient();
+        String header = authHeaderBearer(context.getToken().getId());
+
+        ApplicationContext testContext = context.getBuilder()
+                .bearerToken("debug")
+                .refreshToken()
+                .build();
+        OAuthToken revokedToken = testContext.getToken();
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(revokedToken.getId()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertValidRevocation(r, revokedToken);
+    }
+
+    /**
+     * Assert that a token issued to a client credentials client can revoke
+     * a refresh token issued to a different client in the same application.
+     */
+    @Test
+    public void testRevokeRefreshByOtherClientToken() {
+        Client c = context.getClient();
+        String header = authHeaderBearer(context.getToken().getId());
+
+        ApplicationContext testContext = context.getBuilder()
+                .client(ClientType.Implicit)
+                .bearerToken("debug")
+                .refreshToken()
+                .build();
+        OAuthToken revokedToken = testContext.getToken();
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(revokedToken.getId()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertValidRevocation(r, revokedToken);
+    }
+
+    /**
+     * Assert that a token issued to a client credentials client can revoke
+     * an authorization code issued to the same client.
+     */
+    @Test
+    public void testRevokeAuthCodeBySameClientToken() {
+        Client c = context.getClient();
+        String header = authHeaderBearer(context.getToken().getId());
+
+        ApplicationContext testContext = context.getBuilder()
+                .authToken()
+                .build();
+        OAuthToken revokedToken = testContext.getToken();
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(revokedToken.getId()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertValidRevocation(r, revokedToken);
+    }
+
+    /**
+     * Assert that a token issued to a client credentials client can revoke
+     * can revoke an authorization code issued to a different client in the
+     * same application.
+     */
+    @Test
+    public void testRevokeAuthCodeByOtherClientToken() {
+        Client c = context.getClient();
+        String header = authHeaderBearer(context.getToken().getId());
+
+        ApplicationContext testContext = context.getBuilder()
+                .client(ClientType.Implicit)
+                .authToken()
+                .build();
+        OAuthToken revokedToken = testContext.getToken();
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(revokedToken.getId()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertValidRevocation(r, revokedToken);
+    }
+
+    /**
+     * Assert that client credentials cannot revoke a refresh token issued to
+     * a different application.
+     */
+    @Test
+    public void testRevokeRefreshByDifferentApplication() {
+        Client c = context.getClient();
+        String header = authHeaderBasic(c.getId(), c.getClientSecret());
+
+        ApplicationContext testContext = otherContext.getBuilder()
+                .bearerToken()
+                .refreshToken()
+                .build();
+        OAuthToken revokedToken = testContext.getToken();
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(revokedToken.getId()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertErrorResponse(r, new NotFoundException());
+    }
+
+    /**
+     * Assert that client credentials cannot revoke a Bearer token issued to
+     * a different application.
+     */
+    @Test
+    public void testRevokeBearerByDifferentApplication() {
+        Client c = context.getClient();
+        String header = authHeaderBasic(c.getId(), c.getClientSecret());
+
+        ApplicationContext testContext = otherContext.getBuilder()
+                .bearerToken()
+                .build();
+        OAuthToken revokedToken = testContext.getToken();
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(revokedToken.getId()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertErrorResponse(r, new NotFoundException());
+    }
+
+    /**
+     * Assert that client credentials cannot revoke a auth code issued to
+     * a different application.
+     */
+    @Test
+    public void testRevokeAuthCodeByDifferentApplication() {
+        Client c = context.getClient();
+        String header = authHeaderBasic(c.getId(), c.getClientSecret());
+
+        ApplicationContext testContext = otherContext.getBuilder()
+                .authToken()
+                .build();
+        OAuthToken revokedToken = testContext.getToken();
+
+        Map<String, String> values = new HashMap<>();
+        values.put("token", IdUtil.toString(revokedToken.getId()));
+
+        Response r = target("/revoke")
+                .request()
+                .header(AUTHORIZATION, header)
+                .post(buildEntity(values));
+
+        assertErrorResponse(r, new NotFoundException());
+    }
+}

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc7009/package-info.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc7009/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2018 Michael Krotscheck
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * This suite of tests enforces rfc7009: token revocation.
+ */
+package net.krotscheck.kangaroo.authz.oauth2.rfc7009;

--- a/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc7662/TokenIntrospectionTest.java
+++ b/kangaroo-server-authz/src/test/java/net/krotscheck/kangaroo/authz/oauth2/rfc7662/TokenIntrospectionTest.java
@@ -33,6 +33,7 @@ import net.krotscheck.kangaroo.common.hibernate.id.MalformedIdException;
 import net.krotscheck.kangaroo.test.jersey.ContainerTest;
 import net.krotscheck.kangaroo.test.jersey.SingletonTestContainerFactory;
 import net.krotscheck.kangaroo.test.rule.TestDataResource;
+import net.krotscheck.kangaroo.test.runner.SingleInstanceTestRunner;
 import net.krotscheck.kangaroo.util.StringUtil;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.spi.TestContainerException;
@@ -41,12 +42,12 @@ import org.hibernate.Session;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Form;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -67,6 +68,7 @@ import static org.junit.Assert.assertNull;
  *
  * @author Michael Krotscheck
  */
+@RunWith(SingleInstanceTestRunner.class)
 public final class TokenIntrospectionTest extends ContainerTest {
 
     /**


### PR DESCRIPTION
This patch permits authorized parties to revoke appropriately scoped
tokens.

Closes #114