### PR TITLE
Fix commandline passing in Authz server

### DIFF
--- a/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/ServerFactory.java
+++ b/kangaroo-common/src/main/java/net/krotscheck/kangaroo/server/ServerFactory.java
@@ -300,7 +300,7 @@ public final class ServerFactory {
         serverConfiguration.setDefaultErrorPageGenerator(
                 new KangarooErrorPageGenerator()
         );
-        serverLambdas.forEach(s -> s.operation(server));
+        serverLambdas.forEach(s -> s.operation(server, config));
 
         return server;
     }
@@ -417,8 +417,9 @@ public final class ServerFactory {
         /**
          * Operation handler.
          *
+         * @param server The server.
          * @param config The server configuration.
          */
-        void operation(HttpServer config);
+        void operation(HttpServer server, Configuration config);
     }
 }

--- a/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/ServerFactoryTest.java
+++ b/kangaroo-common/src/test/java/net/krotscheck/kangaroo/server/ServerFactoryTest.java
@@ -303,7 +303,7 @@ public final class ServerFactoryTest {
     @Test
     public void testConfigureServer() throws Exception {
         ServerFactory f = new ServerFactory()
-                .configureServer(s -> {
+                .configureServer((s, c) -> {
                     s.getServerConfiguration().setSessionTimeoutSeconds(1000);
                 });
 

--- a/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/AuthzServer.java
+++ b/kangaroo-server-authz/src/main/java/net/krotscheck/kangaroo/authz/AuthzServer.java
@@ -20,11 +20,9 @@ package net.krotscheck.kangaroo.authz;
 
 import net.krotscheck.kangaroo.authz.admin.AdminV1API;
 import net.krotscheck.kangaroo.authz.oauth2.OAuthAPI;
-import net.krotscheck.kangaroo.server.ConfigurationBuilder;
 import net.krotscheck.kangaroo.server.ServerFactory;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import org.apache.commons.configuration.Configuration;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.grizzly.http.server.ServerConfiguration;
 import org.slf4j.bridge.SLF4JBridgeHandler;
@@ -86,26 +84,20 @@ public final class AuthzServer {
      */
     public static void main(final String[] args)
             throws IOException, InterruptedException {
-
-        Configuration config = new ConfigurationBuilder()
-                .withCommandlineOptions(CLI_OPTIONS)
-                .addCommandlineArgs(args)
-                .addPropertiesFile("kangaroo.authz.properties")
-                .build();
-
-        Integer sessionMaxAge = config.getInt(
-                AuthzServerConfig.SESSION_MAX_AGE.getKey(),
-                AuthzServerConfig.SESSION_MAX_AGE.getValue());
-
         HttpServer server = new ServerFactory()
                 .withCommandlineOptions(CLI_OPTIONS)
                 .withCommandlineArgs(args)
                 .withPropertiesFile("kangaroo.authz.properties")
                 .withResource("/v1", new AdminV1API())
                 .withResource("/oauth2", new OAuthAPI())
-                .configureServer((s) -> {
-                    ServerConfiguration c = s.getServerConfiguration();
-                    c.setSessionTimeoutSeconds(sessionMaxAge);
+                .configureServer((s, c) -> {
+                    Integer sessionMaxAge = c.getInt(
+                            AuthzServerConfig.SESSION_MAX_AGE.getKey(),
+                            AuthzServerConfig.SESSION_MAX_AGE.getValue());
+
+                    ServerConfiguration serverConf =
+                            s.getServerConfiguration();
+                    serverConf.setSessionTimeoutSeconds(sessionMaxAge);
                 })
                 .build();
 


### PR DESCRIPTION
Because the authz server did its own commandline parsing, without including
the default configuration options, any of the kangaroo defaults would cause
an exception.