### PR TITLE
Codacy removal

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,2 +1,0 @@
-exclude_paths:
-  - */src/test/**/*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 /**
  * Java build pipeline for the kangaroo-server project.
  */
+@Library('kangaroo-jenkins') _
 
 def gitCommit = ''
 def jdbc_mariadb = "jdbc:mariadb://127.0.0.1:3306/oid?useUnicode=yes"


### PR DESCRIPTION
This tool never really worked for us, this removes the configuration
file and accomodates for the Jenkins library no longer being implicitly
imported.