### PR TITLE
Go offline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,7 @@ pipeline {
                                     -Dcheckstyle.skip=true \
                                     -Dpmd.skip=true \
                                     -Dcpdskip=true
+                                mvn dependency:go-offline
                             '''
                         },
                         "stat": {


### PR DESCRIPTION
Added go-offline to the jenkinsfile build, to try to sidestep the issue
where multiple parallel nexus downloads interfere with each other and
block the build.